### PR TITLE
Fix chezmoi mise tool install

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,7 @@
 # Homebrew bootstrap and macOS-only dependencies.
 
 brew "mise"
+brew "btop"
 
 cask "ghostty"
 cask "cmux"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ the initial terminal environment:
 - Ghostty, cmux, Hammerspoon, and font casks
 - mise
 - CLI tools such as ripgrep, neovim, zellij, lazygit, and starship via mise
+- btop via Homebrew, because its mise-managed release assets do not support macOS arm64
 - Oh My Zsh, zinit, and SCM Breeze
 - Bun, Python, uv/uvx, and Node.js via `~/.config/mise/config.toml`
 - pnpm through Node.js Corepack

--- a/docs/adr/0001-use-mise-for-modern-cli-tools.md
+++ b/docs/adr/0001-use-mise-for-modern-cli-tools.md
@@ -10,6 +10,6 @@ The macOS Terminal Profile and VPS Shell Profile should share one Core Shell Sta
 
 ## Consequences
 
-- Homebrew remains responsible for macOS bootstrap, GUI apps, casks, and fonts.
+- Homebrew remains responsible for macOS bootstrap, GUI apps, casks, fonts, and macOS fallbacks for tools whose mise-managed release assets do not support macOS.
 - APT remains responsible for Ubuntu bootstrap packages and installing mise itself.
 - CLI upgrades move from `brew upgrade` to `mise upgrade`.

--- a/dot_config/mise/config.toml.tmpl
+++ b/dot_config/mise/config.toml.tmpl
@@ -4,12 +4,13 @@ node = "24"
 python = "3.13"
 uv = "latest"
 "aqua:ajeetdsouza/zoxide" = "latest"
+{{ if eq .chezmoi.os "linux" -}}
 "aqua:aristocratos/btop" = "latest"
+{{ end -}}
 "aqua:bootandy/dust" = "latest"
 "aqua:BurntSushi/ripgrep" = "latest"
 "aqua:cli/cli" = "latest"
 "aqua:dandavison/delta" = "latest"
-"aqua:denisidoro/navi" = "latest"
 "aqua:fastfetch-cli/fastfetch" = "latest"
 "aqua:jesseduffield/lazygit" = "latest"
 "aqua:junegunn/fzf" = "latest"
@@ -20,6 +21,9 @@ uv = "latest"
 "aqua:sharkdp/fd" = "latest"
 "aqua:starship/starship" = "latest"
 "aqua:zellij-org/zellij" = "latest"
+
+[settings.github]
+credential_command = "gh auth token 2>/dev/null || true"
 
 [settings.node]
 corepack = true

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -70,7 +70,7 @@ alias zj="zellij"
 alias zd="zellij --layout dev"
 
 # ============================================
-# fzf + zoxide + navi
+# fzf + zoxide
 # ============================================
 if command -v fzf &>/dev/null; then
   source <(fzf --zsh)
@@ -80,10 +80,6 @@ if command -v zoxide &>/dev/null; then
   eval "$(zoxide init zsh)"
 fi
 alias zi="zoxide query -i"
-
-if command -v navi &>/dev/null; then
-  eval "$(navi widget zsh)"
-fi
 
 # ============================================
 # Tool launcher


### PR DESCRIPTION
## Summary

- Convert the managed mise config to a chezmoi template so platform-specific tools can be selected safely.
- Keep `btop` managed by mise/aqua on Linux, and add a macOS Homebrew fallback because upstream `btop` releases do not provide macOS arm64 assets for mise/aqua.
- Remove the unused `navi` shell widget and omit `navi` from the shared managed tool stack.
- Configure mise to read the existing GitHub CLI token via `credential_command` so aqua/GitHub resolution avoids unauthenticated API rate limits.

## Why

`chezmoi update` itself was able to run, but the follow-up `mise install` path could fail or stall the tool setup. The first root cause was unauthenticated GitHub API access from mise/aqua hitting rate limits. After that was fixed, `btop` and `navi` exposed platform issues on macOS arm64: their upstream release assets are not installable through the current mise/aqua path. `navi` was only an optional zsh widget and had no tracked cheatsheets, so it was removed instead of adding another installer path.

## Impact

macOS keeps `btop` available through the bootstrap package manager while the rest of the modern CLI stack remains mise-managed. Ubuntu keeps `btop` in mise/aqua. `navi` is no longer part of the managed profile.

## Validation

- `chezmoi execute-template --file dot_config/mise/config.toml.tmpl | rg -n 'btop|navi' || true`
- `chezmoi execute-template --override-data '{"chezmoi":{"os":"linux"}}' --file dot_config/mise/config.toml.tmpl | rg -n 'btop|navi' || true`
- `rg -n '\bnavi\b' Brewfile dot_zshrc dot_config/mise/config.toml.tmpl README.md docs/adr/0001-use-mise-for-modern-cli-tools.md ~/.zshrc ~/.config/mise/config.toml || true`
- `brew bundle check --file=Brewfile --no-upgrade --verbose`
- `mise install --dry-run -C "$HOME"`
- `chezmoi apply --dry-run --verbose --exclude=scripts`