### PR TITLE
fix zoxide zi interactive jump

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -77,9 +77,9 @@ if command -v fzf &>/dev/null; then
 fi
 
 if command -v zoxide &>/dev/null; then
+  unalias zi 2>/dev/null
   eval "$(zoxide init zsh)"
 fi
-alias zi="zoxide query -i"
 
 # ============================================
 # Tool launcher

--- a/tests/zshrc_zoxide_test.zsh
+++ b/tests/zshrc_zoxide_test.zsh
@@ -1,0 +1,163 @@
+#!/usr/bin/env zsh
+
+set -u
+
+repo_root="${0:A:h:h}"
+tmp_dir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT INT TERM
+
+fail() {
+  print -u2 -- "not ok - $1"
+  exit 1
+}
+
+pass() {
+  print -- "ok - $1"
+}
+
+assert_pwd() {
+  local expected_dir="$1"
+  local message="$2"
+  local actual_pwd expected_pwd
+
+  actual_pwd="$(pwd -P)"
+  expected_pwd="$(cd "$expected_dir" && pwd -P)"
+
+  if [[ "$actual_pwd" != "$expected_pwd" ]]; then
+    fail "$message; expected $expected_pwd, got $actual_pwd"
+  fi
+}
+
+mkdir -p \
+  "$tmp_dir/bin" \
+  "$tmp_dir/home" \
+  "$tmp_dir/home/.local/share/zinit/zinit.git" \
+  "$tmp_dir/start" \
+  "$tmp_dir/selected" \
+  "$tmp_dir/recent" \
+  "$tmp_dir/git-project/.git" \
+  "$tmp_dir/plain"
+
+cat >"$tmp_dir/home/.local/share/zinit/zinit.git/zinit.zsh" <<'STUB'
+function zinit() {
+  :
+}
+
+alias zi=zinit
+STUB
+
+cat >"$tmp_dir/bin/fzf" <<'STUB'
+#!/bin/sh
+if [ "${1:-}" = "--zsh" ]; then
+  printf '%s\n' '# fzf zsh integration stub'
+  exit 0
+fi
+
+if [ -n "${FZF_TEST_SELECTION:-}" ]; then
+  cat >/dev/null
+  printf '%s\n' "$FZF_TEST_SELECTION"
+  exit 0
+fi
+
+exit 130
+STUB
+
+cat >"$tmp_dir/bin/zoxide" <<'STUB'
+#!/bin/sh
+if [ "${1:-}" = "init" ] && [ "${2:-}" = "zsh" ]; then
+  cat <<'INIT'
+function z() {
+  builtin cd -- "$1"
+}
+
+function zi() {
+  local dir
+  dir="$(zoxide query -i "$@")" || return
+  [[ -n "$dir" ]] || return
+  builtin cd -- "$dir"
+}
+INIT
+  exit 0
+fi
+
+if [ "${1:-}" = "query" ] && [ "${2:-}" = "-i" ]; then
+  if [ -n "${ZOXIDE_TEST_SELECTION:-}" ]; then
+    printf '%s\n' "$ZOXIDE_TEST_SELECTION"
+    exit 0
+  fi
+
+  exit 1
+fi
+
+if [ "${1:-}" = "query" ] && [ "${2:-}" = "-l" ]; then
+  if [ -n "${ZOXIDE_TEST_LIST:-}" ]; then
+    printf '%s\n' "$ZOXIDE_TEST_LIST"
+  fi
+
+  exit 0
+fi
+
+exit 64
+STUB
+
+chmod +x "$tmp_dir/bin/fzf" "$tmp_dir/bin/zoxide"
+
+export HOME="$tmp_dir/home"
+export PATH="$tmp_dir/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+export CLAUDECODE=1
+export ZOXIDE_TEST_SELECTION="$tmp_dir/selected"
+
+cd "$tmp_dir/start" || fail "could not enter test start directory"
+source "$repo_root/dot_zshrc"
+
+if alias zi >/dev/null 2>&1; then
+  fail "dot_zshrc should not define a zi alias over zoxide's function"
+fi
+
+zi_kind="$(whence -w zi)"
+if [[ "$zi_kind" != "zi: function" ]]; then
+  fail "zi should resolve to zoxide's generated function, got '$zi_kind'"
+fi
+
+pass "zi remains zoxide's generated function"
+
+if ! whence -w zinit >/dev/null 2>&1; then
+  fail "zinit should remain available after resolving the zi shortcut conflict"
+fi
+
+pass "zinit remains available by its full command name"
+
+if ! eval "zi" >"$tmp_dir/zi.out" 2>&1; then
+  fail "zi should complete successfully"
+fi
+
+assert_pwd "$tmp_dir/selected" "zi should change directory to the selected path"
+pass "zi changes directory to the selected zoxide path"
+
+cd "$tmp_dir/start" || fail "could not reset to test start directory"
+export ZOXIDE_TEST_SELECTION=""
+eval "zi" >"$tmp_dir/zi-cancel.out" 2>&1
+assert_pwd "$tmp_dir/start" "cancelled zi should leave the current directory unchanged"
+pass "cancelled zi keeps the current directory"
+
+z "$tmp_dir/selected"
+assert_pwd "$tmp_dir/selected" "z should still change directory"
+pass "z continues to change directory"
+
+cd "$tmp_dir/start" || fail "could not reset to test start directory"
+export FZF_TEST_SELECTION="$tmp_dir/recent"
+export ZOXIDE_TEST_LIST="$tmp_dir/recent"$'\n'"$tmp_dir/plain"
+zr
+assert_pwd "$tmp_dir/recent" "zr should still jump to the selected recent directory"
+pass "zr continues to change directory"
+
+cd "$tmp_dir/start" || fail "could not reset to test start directory"
+export FZF_TEST_SELECTION="$tmp_dir/git-project"
+export ZOXIDE_TEST_LIST="$tmp_dir/git-project"$'\n'"$tmp_dir/plain"
+zg
+assert_pwd "$tmp_dir/git-project" "zg should still jump to the selected git directory"
+pass "zg continues to change directory"


### PR DESCRIPTION
## What changed

- Remove the `zi="zoxide query -i"` alias override from `dot_zshrc`.
- Clear any existing `zi` alias before running `zoxide init zsh`, so zoxide's generated `zi()` function can handle interactive jumps.
- Add a zsh regression test that stubs zinit, fzf, and zoxide to verify the shell behavior through the public command interface.

## Why

`zoxide init zsh` generates a `zi()` function that runs interactive selection and changes the current shell directory. The previous alias bypassed that function and only printed the selected path. Removing the alias exposed another conflict: zinit can define `alias zi=zinit`, which still shadows zoxide's generated function in zsh. The fix removes only the `zi` shortcut alias immediately before zoxide initialization while keeping the `zinit` command available by its full name.

## Impact

Users can run `zi`, select a directory, and have the current shell move there. Cancelling the interactive selection leaves the current directory unchanged. Existing `z`, `zr`, and `zg` zoxide-related commands remain covered by the regression test.

## Validation

- `zsh tests/zshrc_zoxide_test.zsh`
- `zsh -n dot_zshrc`
- `zsh -n tests/zshrc_zoxide_test.zsh`

Closes #3