### PR TITLE
ubuntu vps readonly setup and zsh shell

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -4,3 +4,4 @@ AGENTS.md
 CONTEXT.md
 docs/**
 .github/**
+tests/**

--- a/.chezmoiscripts/run_onchange_before_00-bootstrap-ubuntu.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_00-bootstrap-ubuntu.sh.tmpl
@@ -49,4 +49,15 @@ printf '%s\n' "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.asc] https:
 
 $sudo_cmd apt-get update -y
 $sudo_cmd apt-get install -y mise
+
+target_user="$(id -un)"
+zsh_path="$(command -v zsh)"
+current_shell="$(getent passwd "$target_user" | cut -d: -f7)"
+
+if [ "$current_shell" != "$zsh_path" ]; then
+  echo "Setting login shell for $target_user to $zsh_path"
+  if ! $sudo_cmd chsh -s "$zsh_path" "$target_user"; then
+    echo "Could not change the login shell automatically. Run this manually after setup: chsh -s \"$zsh_path\"" >&2
+  fi
+fi
 {{- end }}

--- a/.chezmoiscripts/run_onchange_before_00-bootstrap-ubuntu.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_00-bootstrap-ubuntu.sh.tmpl
@@ -51,7 +51,7 @@ $sudo_cmd apt-get update -y
 $sudo_cmd apt-get install -y mise
 
 target_user="$(id -un)"
-zsh_path="$(command -v zsh)"
+zsh_path="/usr/bin/zsh"
 current_shell="$(getent passwd "$target_user" | cut -d: -f7)"
 
 if [ "$current_shell" != "$zsh_path" ]; then

--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ chezmoi cd
 
 ### Ubuntu 24.04 VPS
 
-Ubuntu support targets 24.04 LTS only. Install chezmoi, initialize this repo,
-review the diff, then apply it.
+Ubuntu support targets 24.04 LTS only. The VPS profile is read-only by
+default, so no GitHub authentication is required for the initial setup. Install
+chezmoi, initialize this public repo over HTTPS, review the diff, then apply it.
 
 ```sh
 sudo apt update
@@ -51,7 +52,7 @@ sudo apt install -y ca-certificates curl git
 sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "$HOME/.local/bin"
 export PATH="$HOME/.local/bin:$PATH"
 
-chezmoi init git@github.com:juty9026/dotfiles.git
+chezmoi init https://github.com/juty9026/dotfiles.git
 chezmoi diff
 chezmoi apply
 ```
@@ -65,12 +66,14 @@ On Ubuntu, `chezmoi apply` runs setup scripts for the VPS shell profile:
 - CLI tools such as ripgrep, neovim, zellij, lazygit, and starship via mise
 - Bun, Python, uv/uvx, and Node.js via mise
 - pnpm through Node.js Corepack
+- Login shell switch to zsh
 
+Only configure GitHub authentication on a VPS if write access is needed later.
 If the first mise install hits GitHub API rate limits while resolving aqua
 tools, export a temporary `GITHUB_TOKEN` and rerun `chezmoi apply`.
 
-If zsh is not already the login shell, switch it after the first apply and
-reconnect.
+If the login shell could not be changed automatically, switch it after the
+first apply and reconnect.
 
 ```sh
 chsh -s "$(command -v zsh)"

--- a/tests/bootstrap_ubuntu_test.sh
+++ b/tests/bootstrap_ubuntu_test.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT INT TERM
+
+fail() {
+  printf '%s\n' "not ok - $1" >&2
+  exit 1
+}
+
+pass() {
+  printf '%s\n' "ok - $1"
+}
+
+write_stub() {
+  path="$1"
+  shift
+  {
+    printf '%s\n' '#!/bin/sh'
+    printf '%s\n' "$@"
+  } >"$path"
+  chmod +x "$path"
+}
+
+mkdir -p "$tmp_dir/bin" "$tmp_dir/home"
+
+rendered="$tmp_dir/bootstrap-ubuntu.sh"
+chezmoi execute-template \
+  --override-data '{"chezmoi":{"os":"linux","osRelease":{"id":"ubuntu","versionID":"24.04"}}}' \
+  --file "$repo_root/.chezmoiscripts/run_onchange_before_00-bootstrap-ubuntu.sh.tmpl" \
+  >"$rendered"
+
+sh -n "$rendered" || fail "rendered Ubuntu bootstrap script should be valid sh"
+pass "rendered Ubuntu bootstrap script is valid sh"
+
+write_stub "$tmp_dir/bin/id" \
+  'case "$1" in' \
+  '  -u) printf "%s\n" 1000 ;;' \
+  '  -un) printf "%s\n" testuser ;;' \
+  '  *) exit 64 ;;' \
+  'esac'
+
+write_stub "$tmp_dir/bin/sudo" \
+  'exec "$@"'
+
+write_stub "$tmp_dir/bin/apt-get" \
+  'exit 0'
+
+write_stub "$tmp_dir/bin/install" \
+  'exit 0'
+
+write_stub "$tmp_dir/bin/curl" \
+  'printf "%s\n" mise-key'
+
+write_stub "$tmp_dir/bin/tee" \
+  'cat >/dev/null' \
+  'exit 0'
+
+write_stub "$tmp_dir/bin/getent" \
+  'if [ "$1" = passwd ] && [ "$2" = testuser ]; then' \
+  '  printf "%s\n" "testuser:x:1000:1000::/home/testuser:/bin/bash"' \
+  '  exit 0' \
+  'fi' \
+  'exit 2'
+
+write_stub "$tmp_dir/bin/zsh" \
+  'exit 0'
+
+write_stub "$tmp_dir/bin/chsh" \
+  'printf "%s\n" "$*" >"$CHSH_TEST_LOG"'
+
+export PATH="$tmp_dir/bin:/usr/bin:/bin"
+export HOME="$tmp_dir/home"
+export CHSH_TEST_LOG="$tmp_dir/chsh.log"
+
+sh "$rendered" >"$tmp_dir/bootstrap.out" 2>"$tmp_dir/bootstrap.err"
+
+expected="-s $tmp_dir/bin/zsh testuser"
+actual="$(cat "$CHSH_TEST_LOG" 2>/dev/null || true)"
+
+if [ "$actual" != "$expected" ]; then
+  fail "Ubuntu bootstrap should set the login shell to zsh; expected '$expected', got '${actual:-<no chsh call>}'"
+fi
+
+pass "Ubuntu bootstrap sets the login shell to zsh"

--- a/tests/bootstrap_ubuntu_test.sh
+++ b/tests/bootstrap_ubuntu_test.sh
@@ -70,7 +70,8 @@ write_stub "$tmp_dir/bin/getent" \
   'exit 2'
 
 write_stub "$tmp_dir/bin/zsh" \
-  'exit 0'
+  'printf "%s\n" "PATH zsh should not be used for login shell changes" >&2' \
+  'exit 1'
 
 write_stub "$tmp_dir/bin/chsh" \
   'printf "%s\n" "$*" >"$CHSH_TEST_LOG"'
@@ -81,7 +82,7 @@ export CHSH_TEST_LOG="$tmp_dir/chsh.log"
 
 sh "$rendered" >"$tmp_dir/bootstrap.out" 2>"$tmp_dir/bootstrap.err"
 
-expected="-s $tmp_dir/bin/zsh testuser"
+expected="-s /usr/bin/zsh testuser"
 actual="$(cat "$CHSH_TEST_LOG" 2>/dev/null || true)"
 
 if [ "$actual" != "$expected" ]; then

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+
+fail() {
+  printf '%s\n' "not ok - $1" >&2
+  exit 1
+}
+
+pass() {
+  printf '%s\n' "ok - $1"
+}
+
+managed_tests="$(
+  chezmoi \
+    --source "$repo_root" \
+    managed \
+    --path-style source-relative |
+    grep '^tests/' || true
+)"
+
+if [ -n "$managed_tests" ]; then
+  fail "development tests should not be managed by chezmoi: $managed_tests"
+fi
+
+pass "development tests are ignored by chezmoi"


### PR DESCRIPTION
## Summary

- Use the public HTTPS dotfiles URL for Ubuntu VPS bootstrap instructions so fresh read-only machines do not need GitHub authentication.
- Have the Ubuntu bootstrap script switch the login shell to zsh after installing the VPS shell profile dependencies.
- Add a shell test that renders the Ubuntu bootstrap template and verifies the zsh login-shell change path with stubbed system commands.

## Impact

Clean Ubuntu 24.04 VPS setup can proceed without SSH keys or GitHub tokens, and the first apply now attempts to leave the account on zsh automatically. If `chsh` cannot run in the target environment, setup continues and prints the manual fallback command.

## Validation

- `sh tests/bootstrap_ubuntu_test.sh`
- `zsh tests/zshrc_zoxide_test.zsh`
- `git diff --check HEAD~1 HEAD`