### PR TITLE
expose user-local bin in zshenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ chezmoi diff
 chezmoi apply
 ```
 
+The `export PATH=...` line is only for the current bootstrap shell. After the
+first `chezmoi apply`, managed zsh sessions keep `~/.local/bin` on `PATH` so
+user-local binaries such as `chezmoi` remain available after reconnecting.
+
 On Ubuntu, `chezmoi apply` runs setup scripts for the VPS shell profile:
 
 - APT bootstrap packages: zsh, git, curl, ca-certificates, gpg, unzip, and build-essential
@@ -136,7 +140,6 @@ do not commit workstation-specific values.
 | Key | Default | Purpose |
 | --- | --- | --- |
 | `enableAiCliTools` | `false` | Installs Gemini CLI, Claude Code, and Codex with npm through the mise-managed Node.js runtime. |
-| `enableHermesAgentPath` | `false` | Adds `~/.local/bin` to `PATH` for Hermes Agent on machines that need it. |
 | `gitAllowedSigners` | `[]` | Adds workstation-specific SSH signing identities to `~/.ssh/allowed_signers`. |
 
 Example:
@@ -144,7 +147,6 @@ Example:
 ```toml
 [data]
 enableAiCliTools = true
-enableHermesAgentPath = true
 
 gitAllowedSigners = [
   "name@company.com ssh-ed25519 AAAA_COMPANY_PUBLIC_KEY company",

--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -1,10 +1,8 @@
 export XDG_CONFIG_HOME="$HOME/.config"
 
-{{- if (default false (get . "enableHermesAgentPath")) }}
-# Local opt-in: add Hermes Agent user binaries.
+# User-local binaries.
 if [[ -d "$HOME/.local/bin" ]]; then
   typeset -U path PATH
   path=("$HOME/.local/bin" $path)
   export PATH
 fi
-{{- end }}

--- a/tests/zshenv_local_bin_test.sh
+++ b/tests/zshenv_local_bin_test.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT INT TERM
+
+fail() {
+  printf '%s\n' "not ok - $1" >&2
+  exit 1
+}
+
+pass() {
+  printf '%s\n' "ok - $1"
+}
+
+render_zshenv() {
+  data="$1"
+
+  "$chezmoi_bin" \
+    --config "$tmp_dir/chezmoi.toml" \
+    --destination "$tmp_dir/home" \
+    --source "$repo_root" \
+    execute-template \
+    --override-data "$data" \
+    --file "$repo_root/dot_zshenv.tmpl" \
+    >"$tmp_dir/home/.zshenv"
+}
+
+lookup_chezmoi() {
+  env -i \
+    HOME="$tmp_dir/home" \
+    PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+    zsh -c 'command -v chezmoi' \
+    >"$tmp_dir/lookup.out" \
+    2>"$tmp_dir/lookup.err"
+}
+
+assert_lookup_success() {
+  data="$1"
+  message="$2"
+
+  render_zshenv "$data"
+
+  if ! lookup_chezmoi; then
+    fail "$message; expected ~/.local/bin/chezmoi in PATH"
+  fi
+
+  expected="$tmp_dir/home/.local/bin/chezmoi"
+  actual="$(cat "$tmp_dir/lookup.out")"
+
+  if [ "$actual" != "$expected" ]; then
+    fail "$message; expected '$expected', got '$actual'"
+  fi
+
+  pass "$message"
+}
+
+chezmoi_bin="$(command -v chezmoi)" || fail "chezmoi is required to render templates"
+
+mkdir -p "$tmp_dir/home/.local/bin"
+: >"$tmp_dir/chezmoi.toml"
+
+cat >"$tmp_dir/home/.local/bin/chezmoi" <<'STUB'
+#!/bin/sh
+exit 0
+STUB
+chmod +x "$tmp_dir/home/.local/bin/chezmoi"
+
+assert_lookup_success \
+  '{"chezmoi":{"os":"linux","osRelease":{"id":"ubuntu","versionID":"24.04"}}}' \
+  "Ubuntu zshenv exposes user-local chezmoi after reconnect"
+
+assert_lookup_success \
+  '{"chezmoi":{"os":"darwin"}}' \
+  "macOS zshenv exposes user-local binaries by default"


### PR DESCRIPTION
## Summary

- Add `~/.local/bin` to zsh `PATH` whenever the directory exists, regardless of OS.
- Remove the now-obsolete `enableHermesAgentPath` README option.
- Document that the Ubuntu bootstrap `export PATH=...` line is only for the current shell and that managed zsh sessions persist the path afterward.
- Add coverage that verifies both Ubuntu and macOS zshenv renderings can find a user-local `chezmoi` binary.

## Why

The Ubuntu guide installs `chezmoi` into `~/.local/bin`, but the previous zshenv template only exposed that directory when `enableHermesAgentPath` was set. After reconnecting into a managed zsh session, `chezmoi` could disappear from `PATH`.

Using `~/.local/bin` consistently across OSes also avoids the same class of issue on macOS for user-local tools.

## Impact

Managed zsh sessions now expose user-local binaries consistently. Existing Homebrew and mise paths still load through their existing startup files.

## Validation

- `sh tests/zshenv_local_bin_test.sh`
- `sh tests/bootstrap_ubuntu_test.sh`
- `sh tests/chezmoiignore_test.sh`
- `zsh tests/zshrc_zoxide_test.zsh`