### PR TITLE
ignore macOS files on VPS

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -5,3 +5,19 @@ CONTEXT.md
 docs/**
 .github/**
 tests/**
+
+{{ if ne .chezmoi.os "darwin" }}
+# macOS Terminal Profile entries are not part of the VPS Shell Profile.
+.chezmoiscripts/00-bootstrap-homebrew.sh
+.chezmoiscripts/40-remove-legacy-npm-ai-tools.sh
+.chezmoiscripts/50-open-karabiner-if-needed.sh
+.config/cmux
+.config/cmux/**
+.config/ghostty
+.config/ghostty/**
+.config/karabiner
+.config/karabiner/**
+.hammerspoon
+.hammerspoon/**
+.zprofile
+{{ end }}

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -12,6 +12,15 @@ pass() {
   printf '%s\n' "ok - $1"
 }
 
+managed_source_paths() {
+  data="$1"
+  chezmoi \
+    --source "$repo_root" \
+    --override-data "$data" \
+    managed \
+    --path-style source-relative
+}
+
 managed_tests="$(
   chezmoi \
     --source "$repo_root" \
@@ -25,3 +34,25 @@ if [ -n "$managed_tests" ]; then
 fi
 
 pass "development tests are ignored by chezmoi"
+
+ubuntu_data='{"chezmoi":{"os":"linux","osRelease":{"id":"ubuntu","versionID":"24.04"}}}'
+ubuntu_managed="$(managed_source_paths "$ubuntu_data")"
+
+macos_only_entries="
+.chezmoiscripts/run_onchange_after_40-remove-legacy-npm-ai-tools.sh.tmpl
+.chezmoiscripts/run_onchange_after_50-open-karabiner-if-needed.sh.tmpl
+.chezmoiscripts/run_onchange_before_00-bootstrap-homebrew.sh.tmpl
+dot_config/cmux
+dot_config/ghostty
+dot_config/private_karabiner
+dot_hammerspoon
+dot_zprofile
+"
+
+for entry in $macos_only_entries; do
+  if printf '%s\n' "$ubuntu_managed" | grep -Fx "$entry" >/dev/null; then
+    fail "Ubuntu VPS should not manage macOS-only entry: $entry"
+  fi
+done
+
+pass "Ubuntu VPS ignores macOS-only entries"


### PR DESCRIPTION
## Summary

- Ignore macOS-only generated targets when rendering the VPS Shell Profile on non-Darwin hosts.
- Add a regression test that verifies Ubuntu 24.04 does not manage macOS-only source entries.

## Why

The Ubuntu VPS profile was already guarded at the script level, but `chezmoi managed` still included macOS GUI configuration targets such as Ghostty, cmux, Karabiner, Hammerspoon, and `.zprofile`. This keeps the VPS profile focused on headless shell state.

## Validation

- `sh tests/bootstrap_ubuntu_test.sh`
- `sh tests/chezmoiignore_test.sh`
- `sh tests/zshenv_local_bin_test.sh`
- `zsh tests/zshrc_zoxide_test.zsh`