### PR TITLE
record optional stack decisions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,9 +24,17 @@ _Avoid_: optional tools, nice-to-have tools
 The mandatory language/runtime tool set expected to exist in the VPS Shell Profile.
 _Avoid_: project-local runtime, optional runtime
 
+**Optional Editor Stack**:
+The opt-in rich editor configuration that is excluded from every machine profile unless explicitly enabled.
+_Avoid_: core shell editor, mandatory editor config, default LazyVim setup
+
 **Optional AI Tool Stack**:
 The opt-in command-line AI tools that may be installed on selected development machines.
 _Avoid_: core shell tools, mandatory AI tools
+
+**Optional Development Workspace**:
+The opt-in full development preset for machines that need rich editor configuration, AI tools, and an integrated terminal workspace together.
+_Avoid_: core terminal multiplexer config, default dev layout, mandatory workspace
 
 **Bootstrap Package Manager**:
 The operating-system package manager used only to prepare a machine for the shared tool stack.
@@ -42,10 +50,17 @@ _Avoid_: Homebrew replacement, standalone aqua
 - The **VPS Shell Profile** targets exactly one **Supported Ubuntu Release**.
 - The **VPS Shell Profile** includes the **Core Shell Stack**.
 - The **VPS Shell Profile** includes the **Development Runtime Stack**.
-- The **Core Shell Stack** includes Oh My Zsh and modern CLI tools such as fd, ripgrep, zoxide, lazygit, and Neovim.
+- The **Core Shell Stack** includes Oh My Zsh and modern CLI tools such as fd, ripgrep, zoxide, lazygit, and plain Neovim.
 - The **Development Runtime Stack** includes mise-managed Bun, Node.js, Python, and uv.
 - pnpm belongs to the **Development Runtime Stack** through Node.js Corepack, not as a mise-managed tool.
+- Rich Neovim configuration belongs to the **Optional Editor Stack**, not the **Core Shell Stack**, and is opt-in for every machine profile.
 - Gemini CLI, Claude Code, and Codex belong to the **Optional AI Tool Stack**, not the **Core Shell Stack**.
+- Enabling only the **Optional AI Tool Stack** does not imply the **Optional Editor Stack** or **Optional Development Workspace**.
+- Development-specific terminal layouts belong to the **Optional Development Workspace**, not the **Core Shell Stack**.
+- Enabling the **Optional Development Workspace** also enables the **Optional Editor Stack** and **Optional AI Tool Stack**.
+- The **Optional Development Workspace** is a preset that takes precedence over disabled optional stack flags.
+- Zellij and its general launcher alias belong to the **Core Shell Stack**, while development-specific Zellij layouts and aliases belong to the **Optional Development Workspace**.
+- Disabling an optional stack excludes its files from management but does not remove files already present on a machine.
 - Homebrew and APT are **Bootstrap Package Managers**, not the **Modern CLI Provider**.
 - mise with its aqua backend is the **Modern CLI Provider**.
 
@@ -57,3 +72,5 @@ _Avoid_: Homebrew replacement, standalone aqua
 ## Flagged Ambiguities
 
 - "VPS shell experience" means the **VPS Shell Profile**, not a full desktop or GUI environment.
+- "development environment" can mean runtimes, editor configuration, or AI tools; resolved here as **Optional Editor Stack** when discussing opt-in LazyVim-style editor configuration.
+- "dev layout" means the **Optional Development Workspace**, not the baseline Zellij installation.

--- a/docs/adr/0002-use-opt-in-presets-for-rich-development-tools.md
+++ b/docs/adr/0002-use-opt-in-presets-for-rich-development-tools.md
@@ -1,0 +1,9 @@
+# Use opt-in presets for rich development tools
+
+Rich editor configuration, assistant CLI tools, and development-specific terminal layouts are excluded from every machine profile by default so low-memory VPS machines keep a small Core Shell Stack. `enableEditorStack` and `enableAiCliTools` remain independently controllable leaf flags, while `enableDevelopmentWorkspace` is a full development preset that also enables both leaf stacks and the development Zellij layout. Disabling an optional stack only excludes its files from chezmoi management; it does not remove files that already exist on a machine.
+
+## Considered Options
+
+- Keep LazyVim and the development Zellij layout in the default shell profile: rejected because a 2 GB RAM VPS can fail under the startup and plugin load.
+- Use only independent leaf flags: rejected because a user asking for a full development environment should not have to discover and enable every lower-level stack.
+- Let disabled leaf flags override the full workspace preset: rejected because it makes `false` mean both "default off" and "explicitly block this preset."


### PR DESCRIPTION
## What changed

- Added Optional Editor Stack and Optional Development Workspace terms to the domain glossary.
- Clarified that plain Neovim and general Zellij stay in the Core Shell Stack, while rich Neovim config and development-specific Zellij surfaces are opt-in.
- Added an ADR recording the opt-in preset model for rich development tools.

## Why

This records the shared design decisions behind PRD #8 before the implementation slices begin. Low-memory VPS machines should keep a small Core Shell Stack by default, while richer editor, assistant, and workspace tooling should be enabled explicitly.

## Impact

No runtime dotfile behavior changes in this PR. This is a foundation documentation PR for #9, #10, #11, and #12.

Refs #8

## Validation

- `git show --check --format=short HEAD`
- `sh ./tests/chezmoiignore_test.sh`

Note: direct execution of `./tests/chezmoiignore_test.sh` failed because the script is not executable, so it was run with `sh`.