### PR TITLE
gate optional editor stack

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -6,6 +6,12 @@ docs/**
 .github/**
 tests/**
 
+{{ if not (or (default false (get . "enableEditorStack")) (default false (get . "enableDevelopmentWorkspace"))) }}
+# Optional Editor Stack entries are opt-in for every machine profile.
+.config/nvim
+.config/nvim/**
+{{ end }}
+
 {{ if ne .chezmoi.os "darwin" }}
 # macOS Terminal Profile entries are not part of the VPS Shell Profile.
 .chezmoiscripts/00-bootstrap-homebrew.sh

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -21,6 +21,39 @@ managed_source_paths() {
     --path-style source-relative
 }
 
+render_template() {
+  data="$1"
+  file="$2"
+
+  chezmoi execute-template \
+    --override-data "$data" \
+    --file "$repo_root/$file"
+}
+
+assert_managed_paths_exclude_prefix() {
+  managed_paths="$1"
+  prefix="$2"
+  message="$3"
+
+  if printf '%s\n' "$managed_paths" | grep -E "^${prefix}(/|$)" >/dev/null; then
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
+assert_managed_paths_include_prefix() {
+  managed_paths="$1"
+  prefix="$2"
+  message="$3"
+
+  if ! printf '%s\n' "$managed_paths" | grep -E "^${prefix}(/|$)" >/dev/null; then
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
 managed_tests="$(
   chezmoi \
     --source "$repo_root" \
@@ -37,6 +70,12 @@ pass "development tests are ignored by chezmoi"
 
 ubuntu_data='{"chezmoi":{"os":"linux","osRelease":{"id":"ubuntu","versionID":"24.04"}}}'
 ubuntu_managed="$(managed_source_paths "$ubuntu_data")"
+macos_data='{"chezmoi":{"os":"darwin"}}'
+macos_managed="$(managed_source_paths "$macos_data")"
+editor_stack_data='{"chezmoi":{"os":"linux","osRelease":{"id":"ubuntu","versionID":"24.04"}},"enableEditorStack":true}'
+editor_stack_managed="$(managed_source_paths "$editor_stack_data")"
+development_workspace_data='{"chezmoi":{"os":"linux","osRelease":{"id":"ubuntu","versionID":"24.04"}},"enableEditorStack":false,"enableDevelopmentWorkspace":true}'
+development_workspace_managed="$(managed_source_paths "$development_workspace_data")"
 
 macos_only_entries="
 .chezmoiscripts/run_onchange_after_40-remove-legacy-npm-ai-tools.sh.tmpl
@@ -56,3 +95,31 @@ for entry in $macos_only_entries; do
 done
 
 pass "Ubuntu VPS ignores macOS-only entries"
+
+assert_managed_paths_exclude_prefix \
+  "$ubuntu_managed" \
+  "dot_config/nvim" \
+  "Ubuntu VPS ignores Optional Editor Stack entries by default"
+
+assert_managed_paths_exclude_prefix \
+  "$macos_managed" \
+  "dot_config/nvim" \
+  "macOS ignores Optional Editor Stack entries by default"
+
+assert_managed_paths_include_prefix \
+  "$editor_stack_managed" \
+  "dot_config/nvim" \
+  "enableEditorStack includes Optional Editor Stack entries"
+
+assert_managed_paths_include_prefix \
+  "$development_workspace_managed" \
+  "dot_config/nvim" \
+  "enableDevelopmentWorkspace includes Optional Editor Stack entries"
+
+ubuntu_mise_config="$(render_template "$ubuntu_data" "dot_config/mise/config.toml.tmpl")"
+
+if ! printf '%s\n' "$ubuntu_mise_config" | grep -F '"aqua:neovim/neovim" = "latest"' >/dev/null; then
+  fail "Ubuntu VPS keeps plain Neovim in the Core Shell Stack"
+fi
+
+pass "Ubuntu VPS keeps plain Neovim in the Core Shell Stack"


### PR DESCRIPTION
## What changed

- Excludes rich Neovim configuration from managed output unless `enableEditorStack` or `enableDevelopmentWorkspace` is enabled.
- Adds managed-output coverage for default Ubuntu VPS, default macOS, editor-only, and full workspace profiles.
- Verifies plain Neovim remains part of the Core Shell Stack through the mise tool configuration.

## Why

A low-memory VPS should keep plain Neovim available without receiving the LazyVim-style Optional Editor Stack by default. This implements the Optional Editor Stack slice from PRD #8.

## Impact

Default macOS and Ubuntu profiles no longer manage `~/.config/nvim`. Existing files on machines are not removed; chezmoi simply stops managing them unless the editor stack or full workspace preset is enabled.

Closes #9
Refs #8

## Validation

- `git show --check --format=short HEAD`
- `for test_file in tests/*.sh; do sh "$test_file"; done`
- `zsh tests/zshrc_zoxide_test.zsh`