### PR TITLE
honor development workspace for AI tools

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -12,6 +12,12 @@ tests/**
 .config/nvim/**
 {{ end }}
 
+{{ if not (default false (get . "enableDevelopmentWorkspace")) }}
+# Optional Development Workspace entries are opt-in for every machine profile.
+.config/zellij/layouts
+.config/zellij/layouts/**
+{{ end }}
+
 {{ if ne .chezmoi.os "darwin" }}
 # macOS Terminal Profile entries are not part of the VPS Shell Profile.
 .chezmoiscripts/00-bootstrap-homebrew.sh

--- a/.chezmoiscripts/run_after_60-install-ai-cli-tools.sh.tmpl
+++ b/.chezmoiscripts/run_after_60-install-ai-cli-tools.sh.tmpl
@@ -1,4 +1,4 @@
-{{- if and (or (eq .chezmoi.os "darwin") (eq .chezmoi.os "linux")) (default false (get . "enableAiCliTools")) -}}
+{{- if and (or (eq .chezmoi.os "darwin") (eq .chezmoi.os "linux")) (or (default false (get . "enableAiCliTools")) (default false (get . "enableDevelopmentWorkspace"))) -}}
 #!/bin/sh
 set -eu
 

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -67,7 +67,9 @@ alias c="clear"
 alias ..="cd .."
 alias ...="cd ../.."
 alias zj="zellij"
+{{ if (default false (get . "enableDevelopmentWorkspace")) -}}
 alias zd="zellij --layout dev"
+{{ end -}}
 
 # ============================================
 # fzf + zoxide

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -74,7 +74,9 @@ macos_data='{"chezmoi":{"os":"darwin"}}'
 macos_managed="$(managed_source_paths "$macos_data")"
 editor_stack_data='{"chezmoi":{"os":"linux","osRelease":{"id":"ubuntu","versionID":"24.04"}},"enableEditorStack":true}'
 editor_stack_managed="$(managed_source_paths "$editor_stack_data")"
-development_workspace_data='{"chezmoi":{"os":"linux","osRelease":{"id":"ubuntu","versionID":"24.04"}},"enableEditorStack":false,"enableDevelopmentWorkspace":true}'
+ai_cli_tools_data='{"chezmoi":{"os":"linux","osRelease":{"id":"ubuntu","versionID":"24.04"}},"enableAiCliTools":true}'
+ai_cli_tools_managed="$(managed_source_paths "$ai_cli_tools_data")"
+development_workspace_data='{"chezmoi":{"os":"linux","osRelease":{"id":"ubuntu","versionID":"24.04"}},"enableEditorStack":false,"enableAiCliTools":false,"enableDevelopmentWorkspace":true}'
 development_workspace_managed="$(managed_source_paths "$development_workspace_data")"
 
 macos_only_entries="
@@ -116,6 +118,21 @@ assert_managed_paths_include_prefix \
   "dot_config/nvim" \
   "enableDevelopmentWorkspace includes Optional Editor Stack entries"
 
+assert_managed_paths_exclude_prefix \
+  "$ai_cli_tools_managed" \
+  "dot_config/nvim" \
+  "enableAiCliTools alone ignores Optional Editor Stack entries"
+
+assert_managed_paths_exclude_prefix \
+  "$ai_cli_tools_managed" \
+  "dot_config/zellij/layouts/dev.kdl" \
+  "enableAiCliTools alone ignores Optional Development Workspace layout"
+
+assert_managed_paths_include_prefix \
+  "$development_workspace_managed" \
+  "dot_config/zellij/layouts/dev.kdl" \
+  "enableDevelopmentWorkspace includes Optional Development Workspace layout"
+
 ubuntu_mise_config="$(render_template "$ubuntu_data" "dot_config/mise/config.toml.tmpl")"
 
 if ! printf '%s\n' "$ubuntu_mise_config" | grep -F '"aqua:neovim/neovim" = "latest"' >/dev/null; then
@@ -123,3 +140,23 @@ if ! printf '%s\n' "$ubuntu_mise_config" | grep -F '"aqua:neovim/neovim" = "late
 fi
 
 pass "Ubuntu VPS keeps plain Neovim in the Core Shell Stack"
+
+ai_cli_tools_installer="$(render_template "$ai_cli_tools_data" ".chezmoiscripts/run_after_60-install-ai-cli-tools.sh.tmpl")"
+development_workspace_ai_installer="$(render_template "$development_workspace_data" ".chezmoiscripts/run_after_60-install-ai-cli-tools.sh.tmpl")"
+
+for package in \
+  "@anthropic-ai/claude-code" \
+  "@google/gemini-cli" \
+  "@openai/codex"
+do
+  if ! printf '%s\n' "$ai_cli_tools_installer" | grep -F "$package" >/dev/null; then
+    fail "enableAiCliTools renders Optional AI Tool Stack installer"
+  fi
+
+  if ! printf '%s\n' "$development_workspace_ai_installer" | grep -F "$package" >/dev/null; then
+    fail "enableDevelopmentWorkspace renders Optional AI Tool Stack installer"
+  fi
+done
+
+pass "enableAiCliTools renders Optional AI Tool Stack installer"
+pass "enableDevelopmentWorkspace renders Optional AI Tool Stack installer"

--- a/tests/zshrc_zoxide_test.zsh
+++ b/tests/zshrc_zoxide_test.zsh
@@ -19,6 +19,18 @@ pass() {
   print -- "ok - $1"
 }
 
+render_zshrc() {
+  local data="$1"
+
+  "$chezmoi_bin" \
+    --config "$tmp_dir/chezmoi.toml" \
+    --destination "$tmp_dir/home" \
+    --source "$repo_root" \
+    --override-data "$data" \
+    cat "$tmp_dir/home/.zshrc" \
+    >"$tmp_dir/home/.zshrc"
+}
+
 assert_pwd() {
   local expected_dir="$1"
   local message="$2"
@@ -106,16 +118,33 @@ STUB
 
 chmod +x "$tmp_dir/bin/fzf" "$tmp_dir/bin/zoxide"
 
+chezmoi_bin="$(command -v chezmoi)" || fail "chezmoi is required to render templates"
+
 export HOME="$tmp_dir/home"
 export PATH="$tmp_dir/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 export CLAUDECODE=1
 export ZOXIDE_TEST_SELECTION="$tmp_dir/selected"
 
+: >"$tmp_dir/chezmoi.toml"
+render_zshrc '{"chezmoi":{"os":"linux","osRelease":{"id":"ubuntu","versionID":"24.04"}},"enableAiCliTools":true}'
+
 cd "$tmp_dir/start" || fail "could not enter test start directory"
-source "$repo_root/dot_zshrc"
+source "$tmp_dir/home/.zshrc"
+
+if ! alias zj >/dev/null 2>&1; then
+  fail "zj should remain the general Zellij launcher"
+fi
+
+pass "zj remains the general Zellij launcher"
+
+if alias zd >/dev/null 2>&1; then
+  fail "enableAiCliTools alone should not expose the Optional Development Workspace launcher"
+fi
+
+pass "enableAiCliTools alone does not expose the Optional Development Workspace launcher"
 
 if alias zi >/dev/null 2>&1; then
-  fail "dot_zshrc should not define a zi alias over zoxide's function"
+  fail ".zshrc should not define a zi alias over zoxide's function"
 fi
 
 zi_kind="$(whence -w zi)"
@@ -161,3 +190,12 @@ export ZOXIDE_TEST_LIST="$tmp_dir/git-project"$'\n'"$tmp_dir/plain"
 zg
 assert_pwd "$tmp_dir/git-project" "zg should still jump to the selected git directory"
 pass "zg continues to change directory"
+
+render_zshrc '{"chezmoi":{"os":"linux","osRelease":{"id":"ubuntu","versionID":"24.04"}},"enableDevelopmentWorkspace":true}'
+source "$tmp_dir/home/.zshrc"
+
+if ! alias zd >/dev/null 2>&1; then
+  fail "enableDevelopmentWorkspace should expose the Optional Development Workspace launcher"
+fi
+
+pass "enableDevelopmentWorkspace exposes the Optional Development Workspace launcher"


### PR DESCRIPTION
## Summary

Closes #10.

- Render the Optional AI Tool Stack installer when `enableDevelopmentWorkspace` is enabled, even if `enableAiCliTools` is false or omitted.
- Keep rich Neovim config and development Zellij workspace surfaces out of AI-only machines.
- Template `.zshrc` so the general `zj` launcher remains core while the development `zd` launcher is workspace-only.

## Root Cause

The AI installer script only checked the `enableAiCliTools` leaf flag, so the full Optional Development Workspace preset did not imply AI CLI installation. Separately, the development Zellij layout and launcher were exposed as core shell surfaces instead of being gated by the workspace preset.

## Impact

Full development workspace machines now get Claude Code, Gemini CLI, and Codex installation through the preset. AI-only machines keep assistant CLI installation without inheriting rich editor configuration or development workspace surfaces.

## Validation

- `sh tests/chezmoiignore_test.sh`
- `sh tests/bootstrap_ubuntu_test.sh`
- `sh tests/zshenv_local_bin_test.sh`
- `zsh tests/zshrc_zoxide_test.zsh`