### PR TITLE
Gate development Zellij workspace surfaces

### DIFF
--- a/dot_config/zellij/layouts/dev.kdl
+++ b/dot_config/zellij/layouts/dev.kdl
@@ -9,7 +9,9 @@ layout {
                 pane name="CODEX" command="codex" start_suspended=true {
                     args "--yolo"
                 }
-                pane name="GEMINI" command="gemini" start_suspended=true
+                pane name="GEMINI" command="gemini" start_suspended=true {
+                    args "--yolo"
+                }
             }
         }
     }

--- a/dot_config/zellij/layouts/dev.kdl
+++ b/dot_config/zellij/layouts/dev.kdl
@@ -3,7 +3,7 @@ layout {
         pane split_direction="vertical" {
             pane size="64%" name="EDITOR" command="nvim"
             pane size="36%" stacked=true {
-                pane name="CLAUDE" focus=true command="claude" {
+                pane name="CLAUDE" focus=true command="claude" start_suspended=true {
                     args "--dangerously-skip-permissions"
                 }
                 pane name="CODEX" command="codex" start_suspended=true {

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -193,3 +193,11 @@ for pane in CLAUDE CODEX GEMINI; do
 done
 
 pass "enableDevelopmentWorkspace starts assistant panes suspended"
+
+if ! printf '%s\n' "$development_workspace_zellij_layout" |
+  grep -A2 'pane name="GEMINI" command="gemini"' |
+  grep -F 'args "--yolo"' >/dev/null; then
+  fail "enableDevelopmentWorkspace passes yolo mode to the Gemini pane"
+fi
+
+pass "enableDevelopmentWorkspace passes yolo mode to the Gemini pane"

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -2,6 +2,12 @@
 set -eu
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT INT TERM
 
 fail() {
   printf '%s\n' "not ok - $1" >&2
@@ -28,6 +34,17 @@ render_template() {
   chezmoi execute-template \
     --override-data "$data" \
     --file "$repo_root/$file"
+}
+
+render_managed_file() {
+  data="$1"
+  destination="$2"
+
+  chezmoi \
+    --source "$repo_root" \
+    --destination "$tmp_dir/home" \
+    --override-data "$data" \
+    cat "$tmp_dir/home/$destination"
 }
 
 assert_managed_paths_exclude_prefix() {
@@ -104,6 +121,11 @@ assert_managed_paths_exclude_prefix \
   "Ubuntu VPS ignores Optional Editor Stack entries by default"
 
 assert_managed_paths_exclude_prefix \
+  "$ubuntu_managed" \
+  "dot_config/zellij/layouts/dev.kdl" \
+  "Ubuntu VPS ignores Optional Development Workspace layout by default"
+
+assert_managed_paths_exclude_prefix \
   "$macos_managed" \
   "dot_config/nvim" \
   "macOS ignores Optional Editor Stack entries by default"
@@ -160,3 +182,14 @@ done
 
 pass "enableAiCliTools renders Optional AI Tool Stack installer"
 pass "enableDevelopmentWorkspace renders Optional AI Tool Stack installer"
+
+development_workspace_zellij_layout="$(render_managed_file "$development_workspace_data" ".config/zellij/layouts/dev.kdl")"
+
+for pane in CLAUDE CODEX GEMINI; do
+  if ! printf '%s\n' "$development_workspace_zellij_layout" |
+    grep -E "pane name=\"${pane}\" .*start_suspended=true" >/dev/null; then
+    fail "enableDevelopmentWorkspace starts assistant panes suspended"
+  fi
+done
+
+pass "enableDevelopmentWorkspace starts assistant panes suspended"

--- a/tests/zshrc_zoxide_test.zsh
+++ b/tests/zshrc_zoxide_test.zsh
@@ -126,6 +126,23 @@ export CLAUDECODE=1
 export ZOXIDE_TEST_SELECTION="$tmp_dir/selected"
 
 : >"$tmp_dir/chezmoi.toml"
+render_zshrc '{"chezmoi":{"os":"linux","osRelease":{"id":"ubuntu","versionID":"24.04"}}}'
+
+cd "$tmp_dir/start" || fail "could not enter test start directory"
+source "$tmp_dir/home/.zshrc"
+
+if ! alias zj >/dev/null 2>&1; then
+  fail "default shell should expose the general Zellij launcher"
+fi
+
+pass "default shell exposes the general Zellij launcher"
+
+if alias zd >/dev/null 2>&1; then
+  fail "default shell should not expose the Optional Development Workspace launcher"
+fi
+
+pass "default shell does not expose the Optional Development Workspace launcher"
+
 render_zshrc '{"chezmoi":{"os":"linux","osRelease":{"id":"ubuntu","versionID":"24.04"}},"enableAiCliTools":true}'
 
 cd "$tmp_dir/start" || fail "could not enter test start directory"


### PR DESCRIPTION
## Summary

- Keep the default shell surface focused on Core Shell Stack Zellij behavior by explicitly testing that `zj` is present and `zd` is absent by default.
- Add managed-output coverage that the Optional Development Workspace Zellij layout is excluded by default and included only when `enableDevelopmentWorkspace` is active.
- Start all assistant panes in the development Zellij layout suspended, including Claude Code.
- Pass `--yolo` to both Codex and Gemini assistant panes in the development Zellij layout.

Closes #11

## Why

Issue #11 requires development-specific Zellij surfaces to remain behind the Optional Development Workspace preset while keeping baseline Zellij available. The Claude pane was the remaining assistant pane that could start eagerly when the development workspace layout was enabled, and Gemini now matches the Codex pane's yolo-mode startup argument.

## Validation

- `sh tests/bootstrap_ubuntu_test.sh`
- `sh tests/chezmoiignore_test.sh`
- `sh tests/zshenv_local_bin_test.sh`
- `zsh tests/zshrc_zoxide_test.zsh`
- `git diff --check`
