### PR TITLE
update ghostty scrollback limit

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -33,7 +33,7 @@ copy-on-select = true
 clipboard-paste-protection = false
 
 # Scrollback
-scrollback-limit = 1000000
+scrollback-limit = 50000000
 
 # macOS
 macos-option-as-alt = true


### PR DESCRIPTION
## What changed

Updated the Ghostty chezmoi source config so `scrollback-limit` is `50000000` instead of `1000000`.

## Why

The live Ghostty config had already been updated, but the chezmoi source still needed to match so future `chezmoi apply` runs keep the larger scrollback limit.

## Impact

Ghostty will retain a larger scrollback history when this dotfiles source is applied.

## Validation

- `chezmoi diff ~/.config/ghostty/config`
- `chezmoi apply --dry-run --verbose ~/.config/ghostty/config`