### PR TITLE
add discord hammerspoon launcher

### DIFF
--- a/dot_hammerspoon/init.lua
+++ b/dot_hammerspoon/init.lua
@@ -19,6 +19,7 @@ local helpToastStyle = {
 local appBindings = {
   { key = "t", label = "cmux", bundleID = "com.cmuxterm.app" },
   { key = "s", label = "Slack", bundleID = "com.tinyspeck.slackmacgap" },
+  { key = "d", label = "Discord", bundleID = "com.hnc.Discord" },
   { key = "n", label = "Notion", bundleID = "notion.id" },
   { key = "a", label = "ChatGPT Atlas", bundleID = "com.openai.atlas" },
   { key = "b", label = "Google Chrome", bundleID = "com.google.Chrome" },


### PR DESCRIPTION
## Summary

Adds Discord to the Hammerspoon app launcher bindings.

## Why

The launcher already provides Hyper-key shortcuts for frequently used macOS apps. Discord was installed locally but missing from the launcher list.

## Impact

`Hyper+D` and the F18 leader flow followed by `d` now launch or focus Discord. The generated Hammerspoon help toast will include Discord automatically because it is built from `appBindings`.

## Validation

- Confirmed `/Applications/Discord.app` bundle ID is `com.hnc.Discord`.
- Ran `nvim --headless -u NONE -c "lua local f, err = loadfile('/Users/minu/.local/share/chezmoi/dot_hammerspoon/init.lua'); assert(f, err)" -c qa`.
- Ran `git diff --check -- dot_hammerspoon/init.lua`.
- Ran `chezmoi diff ~/.hammerspoon/init.lua` after applying the change locally.