### PR TITLE
configure right command input toggle

### DIFF
--- a/dot_config/private_karabiner/private_karabiner.json
+++ b/dot_config/private_karabiner/private_karabiner.json
@@ -43,10 +43,55 @@
                                 "type": "basic"
                             }
                         ]
+                    },
+                    {
+                        "description": "Right Command: Korean/English input shortcut when pressed alone",
+                        "manipulators": [
+                            {
+                                "from": {
+                                    "key_code": "right_command",
+                                    "modifiers": { "optional": ["any"] }
+                                },
+                                "to": [
+                                    {
+                                        "key_code": "right_command",
+                                        "lazy": true
+                                    }
+                                ],
+                                "to_if_alone": [
+                                    {
+                                        "key_code": "spacebar",
+                                        "modifiers": ["left_control"]
+                                    }
+                                ],
+                                "to_if_held_down": [{ "key_code": "right_command" }],
+                                "parameters": {
+                                    "basic.to_if_held_down_threshold_milliseconds": 100
+                                },
+                                "type": "basic"
+                            }
+                        ]
                     }
                 ]
             },
             "devices": [
+                {
+                    "identifiers": {
+                        "is_keyboard": true,
+                        "is_pointing_device": true,
+                        "product_id": 20565,
+                        "vendor_id": 12815
+                    },
+                    "ignore": false
+                },
+                {
+                    "identifiers": {
+                        "is_keyboard": true,
+                        "product_id": 20565,
+                        "vendor_id": 12815
+                    },
+                    "ignore": false
+                },
                 {
                     "identifiers": {
                         "is_keyboard": true,

--- a/tests/karabiner_config_test.sh
+++ b/tests/karabiner_config_test.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+karabiner_config="$repo_root/dot_config/private_karabiner/private_karabiner.json"
+
+fail() {
+  printf '%s\n' "not ok - $1" >&2
+  exit 1
+}
+
+pass() {
+  printf '%s\n' "ok - $1"
+}
+
+assert_json_value() {
+  filter="$1"
+  expected="$2"
+  message="$3"
+
+  actual="$(jq -r "$filter // empty" "$karabiner_config")"
+  if [ "$actual" != "$expected" ]; then
+    fail "$message; expected '$expected', got '${actual:-<missing>}'"
+  fi
+
+  pass "$message"
+}
+
+command -v jq >/dev/null || fail "jq is required to test Karabiner config"
+
+jq empty "$karabiner_config" || fail "Karabiner config should be valid JSON"
+pass "Karabiner config is valid JSON"
+
+rule='.profiles[0].complex_modifications.rules[2]'
+manipulator="$rule.manipulators[0]"
+
+assert_json_value \
+  "$rule.description" \
+  "Right Command: Korean/English input shortcut when pressed alone" \
+  "Karabiner documents the right Command Hangul toggle rule"
+
+assert_json_value \
+  "$manipulator.from.key_code" \
+  "right_command" \
+  "right Command is the source key"
+
+assert_json_value \
+  "$manipulator.to[0].key_code" \
+  "right_command" \
+  "right Command keeps modifier behavior in key chords"
+
+assert_json_value \
+  "$manipulator.to[0].lazy" \
+  "true" \
+  "right Command modifier output is lazy until a chord is used"
+
+assert_json_value \
+  "$manipulator.to_if_alone[0].key_code" \
+  "spacebar" \
+  "right Command alone sends the macOS input source shortcut key"
+
+assert_json_value \
+  "$manipulator.to_if_alone[0].modifiers[0]" \
+  "left_control" \
+  "right Command alone sends control-space for input source switching"
+
+assert_json_value \
+  "$manipulator.to_if_held_down[0].key_code" \
+  "right_command" \
+  "right Command can still be held as a modifier"
+
+rdr_devices="$(jq '
+  [
+    .profiles[0].devices[]
+    | select(
+      .identifiers.vendor_id == 12815
+      and .identifiers.product_id == 20565
+      and .ignore == false
+    )
+  ]
+  | length
+' "$karabiner_config")"
+
+if [ "$rdr_devices" -lt 2 ]; then
+  fail "RDR IX PRO keyboard interfaces should be enabled for Karabiner modifications"
+fi
+
+pass "RDR IX PRO keyboard interfaces are enabled for Karabiner modifications"


### PR DESCRIPTION
## Summary

- Map right Command to the macOS input-source shortcut when pressed alone.
- Preserve right Command as a modifier for key chords.
- Enable the currently connected RDR IX PRO keyboard interfaces for Karabiner modifications.
- Add a shell regression test for the Karabiner JSON shape.

## Root Cause

The original `lang1` output did not switch the active macOS Korean/English input source reliably. Karabiner EventViewer confirmed the physical key arrives as `right_command`, so the fix sends the configured macOS input-source shortcut (`control + space`) instead.

## Validation

- `sh tests/karabiner_config_test.sh`
- `karabiner_cli --lint-complex-modifications dot_config/private_karabiner/private_karabiner.json`
- `sh tests/chezmoiignore_test.sh`
- `sh tests/readme_optional_stack_profiles_test.sh`
- `sh tests/bootstrap_ubuntu_test.sh`
- `sh tests/zshenv_local_bin_test.sh`
- `zsh tests/zshrc_zoxide_test.zsh`

Also manually confirmed that right Command now toggles Korean/English input on macOS.