### PR TITLE
Fix Ghostty SSH integration

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -40,7 +40,7 @@ macos-option-as-alt = true
 
 # Shell Integration
 shell-integration = zsh
-shell-integration-features = cursor,sudo,title
+shell-integration-features = cursor,sudo,title,ssh-env,ssh-terminfo
 
 # Keybindings
 keybind = cmd+d=new_split:right

--- a/tests/ghostty_config_test.sh
+++ b/tests/ghostty_config_test.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+ghostty_config="$repo_root/dot_config/ghostty/config"
+
+fail() {
+  printf '%s\n' "not ok - $1" >&2
+  exit 1
+}
+
+pass() {
+  printf '%s\n' "ok - $1"
+}
+
+features_line="$(
+  sed -n 's/^shell-integration-features[[:space:]]*=[[:space:]]*//p' "$ghostty_config" |
+    tail -n 1
+)"
+
+if [ -z "$features_line" ]; then
+  fail "Ghostty shell integration features should be configured"
+fi
+
+case ",$features_line," in
+  *,ssh-env,*) pass "Ghostty SSH sessions fall back to a compatible TERM when needed" ;;
+  *) fail "Ghostty shell integration should enable ssh-env" ;;
+esac
+
+case ",$features_line," in
+  *,ssh-terminfo,*) pass "Ghostty SSH sessions install xterm-ghostty terminfo when possible" ;;
+  *) fail "Ghostty shell integration should enable ssh-terminfo" ;;
+esac


### PR DESCRIPTION
## What changed

- Enabled Ghostty SSH shell-integration features `ssh-env` and `ssh-terminfo`.
- Added a regression test that keeps those SSH integration features present in the Ghostty config.

## Why

Ghostty sessions over SSH could render zsh history autosuggestions incorrectly when the remote side did not have compatible TERM or terminfo handling. The typed command still executed correctly, but the prompt could appear to duplicate history text while typing.

## Impact

SSH sessions from Ghostty should now fall back to a compatible terminal environment when needed and install `xterm-ghostty` terminfo when possible, reducing visual corruption in the VPS Shell Profile experience without changing the remote zsh configuration.

## Validation

- `sh tests/ghostty_config_test.sh`
- `for test in tests/*.sh; do sh "$test"; done`
- `zsh tests/zshrc_zoxide_test.zsh`