### PR TITLE
Manage Antigravity PATH with zsh snippet

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -23,6 +23,11 @@ tests/**
 .chezmoiscripts/60-install-ai-cli-tools.sh
 {{ end }}
 
+{{ if not (and (eq .chezmoi.os "darwin") (or (default false (get . "enableAiCliTools")) (default false (get . "enableDevelopmentWorkspace")))) }}
+# Antigravity PATH snippet is opt-in for macOS AI/development profiles.
+.config/zsh/path.d/antigravity.zsh
+{{ end }}
+
 {{ if ne .chezmoi.os "darwin" }}
 # macOS Terminal Profile entries are not part of the VPS Shell Profile.
 .chezmoiscripts/00-bootstrap-homebrew.sh

--- a/dot_config/zsh/path.d/antigravity.zsh.tmpl
+++ b/dot_config/zsh/path.d/antigravity.zsh.tmpl
@@ -1,0 +1,12 @@
+# Antigravity paths.
+typeset -U path PATH
+
+if [[ -d "$HOME/.antigravity/antigravity/bin" ]]; then
+  path=("$HOME/.antigravity/antigravity/bin" $path)
+fi
+
+if [[ -d "$HOME/.antigravity-ide/antigravity-ide/bin" ]]; then
+  path=("$HOME/.antigravity-ide/antigravity-ide/bin" $path)
+fi
+
+export PATH

--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -1,8 +1,18 @@
 export XDG_CONFIG_HOME="$HOME/.config"
 
+typeset -U path PATH
+
 # User-local binaries.
 if [[ -d "$HOME/.local/bin" ]]; then
-  typeset -U path PATH
   path=("$HOME/.local/bin" $path)
-  export PATH
 fi
+
+# Managed PATH snippets.
+if [[ -d "$HOME/.config/zsh/path.d" ]]; then
+  for path_snippet in "$HOME"/.config/zsh/path.d/*.zsh(N); do
+    source "$path_snippet"
+  done
+  unset path_snippet
+fi
+
+export PATH

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -89,6 +89,10 @@ ubuntu_data='{"chezmoi":{"os":"linux","osRelease":{"id":"ubuntu","versionID":"24
 ubuntu_managed="$(managed_source_paths "$ubuntu_data")"
 macos_data='{"chezmoi":{"os":"darwin"},"enableEditorStack":false,"enableAiCliTools":false,"enableDevelopmentWorkspace":false}'
 macos_managed="$(managed_source_paths "$macos_data")"
+macos_ai_cli_tools_data='{"chezmoi":{"os":"darwin"},"enableEditorStack":false,"enableAiCliTools":true,"enableDevelopmentWorkspace":false}'
+macos_ai_cli_tools_managed="$(managed_source_paths "$macos_ai_cli_tools_data")"
+macos_development_workspace_data='{"chezmoi":{"os":"darwin"},"enableEditorStack":false,"enableAiCliTools":false,"enableDevelopmentWorkspace":true}'
+macos_development_workspace_managed="$(managed_source_paths "$macos_development_workspace_data")"
 editor_stack_data='{"chezmoi":{"os":"linux","osRelease":{"id":"ubuntu","versionID":"24.04"}},"enableEditorStack":true,"enableAiCliTools":false,"enableDevelopmentWorkspace":false}'
 editor_stack_managed="$(managed_source_paths "$editor_stack_data")"
 ai_cli_tools_data='{"chezmoi":{"os":"linux","osRelease":{"id":"ubuntu","versionID":"24.04"}},"enableEditorStack":false,"enableAiCliTools":true,"enableDevelopmentWorkspace":false}'
@@ -138,6 +142,26 @@ assert_managed_paths_exclude_prefix \
   "$macos_managed" \
   "dot_config/nvim" \
   "macOS ignores Optional Editor Stack entries by default"
+
+assert_managed_paths_exclude_prefix \
+  "$macos_managed" \
+  "dot_config/zsh/path.d/antigravity.zsh.tmpl" \
+  "macOS default ignores Antigravity PATH snippet"
+
+assert_managed_paths_exclude_prefix \
+  "$ai_cli_tools_managed" \
+  "dot_config/zsh/path.d/antigravity.zsh.tmpl" \
+  "Linux enableAiCliTools ignores Antigravity PATH snippet"
+
+assert_managed_paths_include_prefix \
+  "$macos_ai_cli_tools_managed" \
+  "dot_config/zsh/path.d/antigravity.zsh.tmpl" \
+  "macOS enableAiCliTools includes Antigravity PATH snippet"
+
+assert_managed_paths_include_prefix \
+  "$macos_development_workspace_managed" \
+  "dot_config/zsh/path.d/antigravity.zsh.tmpl" \
+  "macOS enableDevelopmentWorkspace includes Antigravity PATH snippet"
 
 assert_managed_paths_include_prefix \
   "$editor_stack_managed" \

--- a/tests/zshenv_local_bin_test.sh
+++ b/tests/zshenv_local_bin_test.sh
@@ -31,11 +31,13 @@ render_zshenv() {
     >"$tmp_dir/home/.zshenv"
 }
 
-lookup_chezmoi() {
+lookup_command() {
+  command_name="$1"
+
   env -i \
     HOME="$tmp_dir/home" \
     PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
-    zsh -c 'command -v chezmoi' \
+    zsh -c 'command -v "$1"' zsh "$command_name" \
     >"$tmp_dir/lookup.out" \
     2>"$tmp_dir/lookup.err"
 }
@@ -46,11 +48,43 @@ assert_lookup_success() {
 
   render_zshenv "$data"
 
-  if ! lookup_chezmoi; then
+  if ! lookup_command chezmoi; then
     fail "$message; expected ~/.local/bin/chezmoi in PATH"
   fi
 
   expected="$tmp_dir/home/.local/bin/chezmoi"
+  actual="$(cat "$tmp_dir/lookup.out")"
+
+  if [ "$actual" != "$expected" ]; then
+    fail "$message; expected '$expected', got '$actual'"
+  fi
+
+  pass "$message"
+}
+
+assert_path_snippet_lookup_success() {
+  data="$1"
+  message="$2"
+
+  render_zshenv "$data"
+
+  mkdir -p "$tmp_dir/home/.config/zsh/path.d"
+  mkdir -p "$tmp_dir/home/.snippet/bin"
+
+  cat >"$tmp_dir/home/.config/zsh/path.d/custom.zsh" <<'STUB'
+typeset -U path PATH
+path=("$HOME/.snippet/bin" $path)
+export PATH
+STUB
+
+  : >"$tmp_dir/home/.snippet/bin/snippet-tool"
+  chmod +x "$tmp_dir/home/.snippet/bin/snippet-tool"
+
+  if ! lookup_command snippet-tool; then
+    fail "$message; expected path.d snippet directory in PATH"
+  fi
+
+  expected="$tmp_dir/home/.snippet/bin/snippet-tool"
   actual="$(cat "$tmp_dir/lookup.out")"
 
   if [ "$actual" != "$expected" ]; then
@@ -78,3 +112,7 @@ assert_lookup_success \
 assert_lookup_success \
   '{"chezmoi":{"os":"darwin"}}' \
   "macOS zshenv exposes user-local binaries by default"
+
+assert_path_snippet_lookup_success \
+  '{"chezmoi":{"os":"darwin"}}' \
+  "macOS zshenv loads user PATH snippets"


### PR DESCRIPTION
## Summary

- Load managed zsh PATH snippets from `~/.config/zsh/path.d` in `.zshenv`.
- Add a macOS optional AI/development-profile Antigravity PATH snippet.
- Cover snippet loading and chezmoiignore profile behavior with shell tests.

## Why

Antigravity's macOS installer added PATH exports directly to `~/.zshrc`, which caused chezmoi source drift. Moving those entries into a managed snippet keeps `.zshrc` clean while preserving Antigravity availability on development machines.

## Impact

macOS machines with `enableAiCliTools` or `enableDevelopmentWorkspace` manage `~/.config/zsh/path.d/antigravity.zsh`. Missing Antigravity directories are ignored, and default/non-macOS profiles do not manage the snippet.

## Validation

- `sh tests/zshenv_local_bin_test.sh`
- `sh tests/chezmoiignore_test.sh`
- `sh tests/readme_optional_stack_profiles_test.sh && zsh tests/zshrc_zoxide_test.zsh`
- `chezmoi diff -- ~/.zshrc ~/.zshenv ~/.config/zsh`