### PR TITLE
Capitalize git user name

### DIFF
--- a/private_dot_gitconfig.tmpl
+++ b/private_dot_gitconfig.tmpl
@@ -1,5 +1,5 @@
 [user]
-	name = minu
+	name = Minu
 	email = juty9026@gmail.com
 	signingkey = ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINz8oDp6v7P4IXYUzIsNuH3TvCogpPexpMYNB4JTxysJ
 [gpg]


### PR DESCRIPTION
## What changed

Updated the managed Git user name in `private_dot_gitconfig.tmpl` from `minu` to `Minu`.

## Why

The dotfiles should render the preferred capitalized Git author name across managed machines.

## Impact

After `chezmoi apply`, `~/.gitconfig` renders `[user] name = Minu` while keeping the existing email, signing key, and GitHub credential helper unchanged.

## Validation

- `chezmoi execute-template < private_dot_gitconfig.tmpl | sed -n '1,4p'`
- `bash tests/karabiner_config_test.sh`
- `bash tests/chezmoiignore_test.sh`
- `zsh tests/zshrc_zoxide_test.zsh`
- `bash tests/bootstrap_ubuntu_test.sh`
- `bash tests/zshenv_local_bin_test.sh`
- `bash tests/ghostty_config_test.sh`
- `bash tests/readme_optional_stack_profiles_test.sh`