### PR TITLE
Add lazygit PR merge workflow

### DIFF
--- a/docs/superpowers/plans/2026-05-24-lazygit-pr-merge-workflow.md
+++ b/docs/superpowers/plans/2026-05-24-lazygit-pr-merge-workflow.md
@@ -1,0 +1,309 @@
+# Lazygit PR Merge Workflow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a lazygit custom command that merges the selected branch's GitHub PR, with a squash path that opens an editable PR-title/description commit-message template.
+
+**Architecture:** Keep lazygit responsible only for the menu and selected branch handoff, and put merge behavior in a focused POSIX shell helper. Test the helper by stubbing `gh` and `$EDITOR`, and test the managed lazygit config by rendering it with chezmoi.
+
+**Tech Stack:** chezmoi source layout, lazygit `customCommands`, GitHub CLI `gh pr merge`, POSIX shell tests.
+
+---
+
+### Task 1: Lazygit PR Merge Custom Command And Helper
+
+**Files:**
+- Modify: `dot_config/lazygit/config.yml`
+- Create: `dot_config/lazygit/scripts/executable_merge-pr`
+- Create: `tests/lazygit_pr_merge_test.sh`
+
+- [ ] **Step 1: Write the failing helper/config test**
+
+Create `tests/lazygit_pr_merge_test.sh` with a shell test that:
+
+```sh
+#!/bin/sh
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT INT TERM
+
+fail() {
+  printf '%s\n' "not ok - $1" >&2
+  exit 1
+}
+
+pass() {
+  printf '%s\n' "ok - $1"
+}
+
+write_stub() {
+  path="$1"
+  shift
+  {
+    printf '%s\n' '#!/bin/sh'
+    printf '%s\n' "$@"
+  } >"$path"
+  chmod +x "$path"
+}
+
+assert_contains() {
+  haystack="$1"
+  needle="$2"
+  message="$3"
+
+  if ! printf '%s\n' "$haystack" | grep -F "$needle" >/dev/null; then
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
+mkdir -p "$tmp_dir/bin" "$tmp_dir/home" "$tmp_dir/editors"
+
+rendered_config="$(
+  chezmoi \
+    --source "$repo_root" \
+    --destination "$tmp_dir/home" \
+    cat "$tmp_dir/home/.config/lazygit/config.yml"
+)"
+
+assert_contains "$rendered_config" "description: Merge GitHub PR" "lazygit config exposes the PR merge command"
+assert_contains "$rendered_config" "title: Merge pull request" "lazygit config prompts for merge strategy"
+assert_contains "$rendered_config" "Merge commit" "lazygit config offers merge commit strategy"
+assert_contains "$rendered_config" "Squash" "lazygit config offers squash strategy"
+assert_contains "$rendered_config" "merge-pr" "lazygit config delegates PR merge behavior to helper"
+
+helper="$repo_root/dot_config/lazygit/scripts/executable_merge-pr"
+
+write_stub "$tmp_dir/bin/gh" \
+  'printf "%s\n" "$*" >>"$GH_CALL_LOG"' \
+  'if [ "$1" = "pr" ] && [ "$2" = "view" ]; then' \
+  '  printf "%s\n" "Implement lazygit PR merge"' \
+  '  printf "%s\n" "This PR adds a merge menu."' \
+  '  exit 0' \
+  'fi' \
+  'if [ "$1" = "pr" ] && [ "$2" = "merge" ]; then' \
+  '  i=1' \
+  '  for arg in "$@"; do' \
+  '    if [ "$arg" = "--body-file" ]; then' \
+  '      eval "body_file=\\${$((i + 1))}"' \
+  '      cat "$body_file" >"$GH_BODY_CAPTURE"' \
+  '    fi' \
+  '    i=$((i + 1))' \
+  '  done' \
+  '  exit 0' \
+  'fi' \
+  'exit 64'
+
+write_stub "$tmp_dir/editors/append-editor" \
+  'printf "%s\n" "Edited body line." >>"$1"'
+
+export PATH="$tmp_dir/bin:/usr/bin:/bin"
+export GH_CALL_LOG="$tmp_dir/gh-calls.log"
+export GH_BODY_CAPTURE="$tmp_dir/body.txt"
+export EDITOR="$tmp_dir/editors/append-editor"
+
+sh "$helper" feature/pr-menu merge
+
+if ! grep -F "pr merge feature/pr-menu --merge" "$GH_CALL_LOG" >/dev/null; then
+  fail "merge strategy should call gh pr merge with --merge"
+fi
+
+pass "merge strategy calls gh pr merge with --merge"
+
+: >"$GH_CALL_LOG"
+sh "$helper" feature/pr-menu squash
+
+if ! grep -F "pr view feature/pr-menu --json title,body --jq .title, .body" "$GH_CALL_LOG" >/dev/null; then
+  fail "squash strategy should read PR title and body"
+fi
+
+pass "squash strategy reads PR title and body"
+
+if ! grep -F "pr merge feature/pr-menu --squash --subject Implement lazygit PR merge --body-file" "$GH_CALL_LOG" >/dev/null; then
+  fail "squash strategy should pass edited title as subject"
+fi
+
+pass "squash strategy passes edited title as subject"
+
+if ! grep -F "This PR adds a merge menu." "$GH_BODY_CAPTURE" >/dev/null; then
+  fail "squash strategy should pass PR description as body"
+fi
+
+if ! grep -F "Edited body line." "$GH_BODY_CAPTURE" >/dev/null; then
+  fail "squash strategy should include editor changes in body"
+fi
+
+pass "squash strategy passes edited description as body"
+
+write_stub "$tmp_dir/editors/remove-title-editor" \
+  'sed "/^Title:/d" "$1" >"$1.tmp"' \
+  'mv "$1.tmp" "$1"'
+
+export EDITOR="$tmp_dir/editors/remove-title-editor"
+
+if sh "$helper" feature/pr-menu squash >"$tmp_dir/missing-title.out" 2>"$tmp_dir/missing-title.err"; then
+  fail "squash strategy should reject an edited message without a title"
+fi
+
+if ! grep -F "missing a Title" "$tmp_dir/missing-title.err" >/dev/null; then
+  fail "squash strategy should explain missing title errors"
+fi
+
+pass "squash strategy rejects missing title"
+```
+
+- [ ] **Step 2: Run the new test to verify it fails**
+
+Run:
+
+```bash
+sh tests/lazygit_pr_merge_test.sh
+```
+
+Expected: FAIL because `dot_config/lazygit/scripts/executable_merge-pr` does not exist and the lazygit config has no merge custom command.
+
+- [ ] **Step 3: Implement the lazygit custom command**
+
+Update `dot_config/lazygit/config.yml` so it keeps the existing pager settings and adds:
+
+```yaml
+customCommands:
+  - key: "X"
+    context: "localBranches"
+    description: "Merge GitHub PR"
+    prompts:
+      - type: "menu"
+        title: "Merge pull request"
+        key: "MergeStrategy"
+        options:
+          - name: "Merge commit"
+            description: "Create a merge commit"
+            value: "merge"
+          - name: "Squash"
+            description: "Squash commits into one commit"
+            value: "squash"
+      - type: "confirm"
+        title: "Merge PR?"
+        body: "Merge the GitHub PR for the selected branch?"
+    command: "~/.config/lazygit/scripts/merge-pr {{.SelectedLocalBranch.Name | quote}} {{.Form.MergeStrategy | quote}}"
+    output: "terminal"
+    loadingText: "Merging PR..."
+```
+
+- [ ] **Step 4: Implement the helper**
+
+Create `dot_config/lazygit/scripts/executable_merge-pr` as a POSIX shell script with this behavior:
+
+```sh
+#!/bin/sh
+set -eu
+
+fail() {
+  printf '%s\n' "merge-pr: $1" >&2
+  exit 1
+}
+
+branch="${1:-}"
+strategy="${2:-}"
+
+[ -n "$branch" ] || fail "branch is required"
+[ -n "$strategy" ] || fail "merge strategy is required"
+
+editor="${EDITOR:-vi}"
+
+case "$strategy" in
+  merge)
+    exec gh pr merge "$branch" --merge
+    ;;
+  squash)
+    ;;
+  *)
+    fail "unknown merge strategy: $strategy"
+    ;;
+esac
+
+message_file="$(mktemp "${TMPDIR:-/tmp}/merge-pr-message.XXXXXX")"
+body_file="$(mktemp "${TMPDIR:-/tmp}/merge-pr-body.XXXXXX")"
+
+cleanup() {
+  rm -f "$message_file" "$body_file"
+}
+trap cleanup EXIT INT TERM
+
+pr_data="$(gh pr view "$branch" --json title,body --jq '.title, .body')"
+pr_title="$(printf '%s\n' "$pr_data" | sed -n '1p')"
+pr_body="$(printf '%s\n' "$pr_data" | sed '1d')"
+
+{
+  printf '%s\n' '---'
+  printf 'Title: %s\n' "$pr_title"
+  printf '%s\n' '---'
+  printf '\n'
+  printf '%s\n' "$pr_body"
+} >"$message_file"
+
+"$editor" "$message_file"
+
+title="$(
+  sed -n 's/^Title:[[:space:]]*//p' "$message_file" |
+    sed -n '1p'
+)"
+
+[ -n "$title" ] || fail "edited squash message is missing a Title"
+
+awk '
+  BEGIN { frontmatter = 0; body = 0 }
+  /^---$/ {
+    frontmatter++
+    if (frontmatter == 2) {
+      body = 1
+      next
+    }
+  }
+  body {
+    print
+  }
+' "$message_file" |
+  sed '1{/^$/d;}' >"$body_file"
+
+exec gh pr merge "$branch" --squash --subject "$title" --body-file "$body_file"
+```
+
+- [ ] **Step 5: Run the new test to verify it passes**
+
+Run:
+
+```bash
+sh tests/lazygit_pr_merge_test.sh
+```
+
+Expected: PASS for config rendering, merge strategy, squash strategy, body parsing, and missing-title rejection.
+
+- [ ] **Step 6: Run the full local shell test suite**
+
+Run:
+
+```bash
+for test_file in tests/*.sh; do sh "$test_file"; done
+for test_file in tests/*.zsh; do zsh "$test_file"; done
+```
+
+Expected: all tests print `ok - ...` lines and the command exits 0.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```bash
+git add dot_config/lazygit/config.yml dot_config/lazygit/scripts/executable_merge-pr tests/lazygit_pr_merge_test.sh docs/superpowers/plans/2026-05-24-lazygit-pr-merge-workflow.md
+git commit -m "feat: add lazygit PR merge workflow"
+```
+
+Expected: one commit containing the lazygit command, helper, tests, and implementation plan.

--- a/docs/superpowers/plans/2026-05-24-lazygit-pr-merge-workflow.md
+++ b/docs/superpowers/plans/2026-05-24-lazygit-pr-merge-workflow.md
@@ -73,7 +73,7 @@ rendered_config="$(
     cat "$tmp_dir/home/.config/lazygit/config.yml"
 )"
 
-assert_contains "$rendered_config" "description: Merge GitHub PR" "lazygit config exposes the PR merge command"
+assert_contains "$rendered_config" "description: Merge GitHub PR..." "lazygit config exposes the PR merge command as a follow-up flow"
 assert_contains "$rendered_config" "title: Merge pull request" "lazygit config prompts for merge strategy"
 assert_contains "$rendered_config" "Merge commit" "lazygit config offers merge commit strategy"
 assert_contains "$rendered_config" "Squash" "lazygit config offers squash strategy"
@@ -177,7 +177,7 @@ Update `dot_config/lazygit/config.yml` so it keeps the existing pager settings a
 customCommands:
   - key: "X"
     context: "localBranches"
-    description: "Merge GitHub PR"
+    description: "Merge GitHub PR..."
     prompts:
       - type: "menu"
         title: "Merge pull request"

--- a/dot_config/lazygit/config.yml
+++ b/dot_config/lazygit/config.yml
@@ -2,3 +2,25 @@ git:
   pagers:
     - pager: delta --dark --paging=never
     - pager: delta --dark --paging=never --side-by-side
+
+customCommands:
+  - key: X
+    context: localBranches
+    description: Merge GitHub PR
+    prompts:
+      - type: menu
+        title: Merge pull request
+        key: MergeStrategy
+        options:
+          - name: Merge commit
+            description: Create a merge commit
+            value: merge
+          - name: Squash
+            description: Squash commits into one commit
+            value: squash
+      - type: confirm
+        title: Merge PR?
+        body: Merge the GitHub PR for the selected branch?
+    command: ~/.config/lazygit/scripts/merge-pr {{.SelectedLocalBranch.Name | quote}} {{.Form.MergeStrategy | quote}}
+    output: terminal
+    loadingText: Merging PR...

--- a/dot_config/lazygit/config.yml
+++ b/dot_config/lazygit/config.yml
@@ -6,7 +6,7 @@ git:
 customCommands:
   - key: X
     context: localBranches
-    description: Merge GitHub PR
+    description: Merge GitHub PR...
     prompts:
       - type: menu
         title: Merge pull request

--- a/dot_config/lazygit/scripts/executable_merge-pr
+++ b/dot_config/lazygit/scripts/executable_merge-pr
@@ -1,0 +1,98 @@
+#!/bin/sh
+set -eu
+
+temp_dir=""
+
+cleanup() {
+  if [ -n "$temp_dir" ] && [ -d "$temp_dir" ]; then
+    rm -rf "$temp_dir"
+  fi
+}
+
+fail() {
+  printf '%s\n' "merge-pr: $1" >&2
+  exit 1
+}
+
+branch="${1:-}"
+strategy="${2:-}"
+
+[ -n "$branch" ] || fail "branch is required"
+[ -n "$strategy" ] || fail "merge strategy is required"
+
+case "$strategy" in
+  merge)
+    exec gh pr merge "$branch" --merge --delete-branch
+    ;;
+  squash)
+    ;;
+  *)
+    fail "unsupported merge strategy: $strategy"
+    ;;
+esac
+
+trap cleanup EXIT HUP INT TERM
+
+temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/merge-pr.XXXXXX")"
+message_file="$temp_dir/message"
+body_file="$temp_dir/body"
+
+pr_message="$(gh pr view "$branch" --json title,body --jq '.title, .body')"
+pr_title="$(printf '%s\n' "$pr_message" | sed -n '1p')"
+pr_body="$(printf '%s\n' "$pr_message" | sed '1d')"
+
+{
+  printf '%s\n' '---'
+  printf 'Title: %s\n' "$pr_title"
+  printf '%s\n' '---'
+  printf '%s\n' ''
+  printf '%s\n' "$pr_body"
+} >"$message_file"
+
+"${EDITOR:-vi}" "$message_file"
+
+title="$(
+  awk '
+    NR == 1 && $0 == "---" {
+      in_header = 1
+      next
+    }
+    in_header && $0 == "---" {
+      exit
+    }
+    in_header && index($0, "Title:") == 1 {
+      value = substr($0, 7)
+      sub(/^[[:space:]]*/, "", value)
+      sub(/[[:space:]]*$/, "", value)
+      print value
+      exit
+    }
+  ' "$message_file"
+)"
+
+[ -n "$title" ] || fail "edited message is missing a Title"
+
+awk '
+  $0 == "---" && delimiter_count < 2 {
+    delimiter_count++
+    if (delimiter_count == 2) {
+      in_body = 1
+    }
+    next
+  }
+  in_body {
+    if (!checked_leading_blank) {
+      checked_leading_blank = 1
+      if ($0 == "") {
+        next
+      }
+    }
+    print
+  }
+' "$message_file" >"$body_file"
+
+status=0
+gh pr merge "$branch" --squash --delete-branch --subject "$title" --body-file "$body_file" || status=$?
+cleanup
+trap - EXIT HUP INT TERM
+exit "$status"

--- a/dot_config/lazygit/scripts/executable_merge-pr
+++ b/dot_config/lazygit/scripts/executable_merge-pr
@@ -9,6 +9,13 @@ cleanup() {
   fi
 }
 
+signal_exit() {
+  status="$1"
+  trap - EXIT HUP INT TERM
+  cleanup
+  exit "$status"
+}
+
 fail() {
   printf '%s\n' "merge-pr: $1" >&2
   exit 1
@@ -22,7 +29,7 @@ strategy="${2:-}"
 
 case "$strategy" in
   merge)
-    exec gh pr merge "$branch" --merge --delete-branch
+    exec gh pr merge "$branch" --merge
     ;;
   squash)
     ;;
@@ -31,7 +38,10 @@ case "$strategy" in
     ;;
 esac
 
-trap cleanup EXIT HUP INT TERM
+trap cleanup EXIT
+trap 'signal_exit 129' HUP
+trap 'signal_exit 130' INT
+trap 'signal_exit 143' TERM
 
 temp_dir="$(mktemp -d "${TMPDIR:-/tmp}/merge-pr.XXXXXX")"
 message_file="$temp_dir/message"
@@ -49,7 +59,13 @@ pr_body="$(printf '%s\n' "$pr_message" | sed '1d')"
   printf '%s\n' "$pr_body"
 } >"$message_file"
 
-"${EDITOR:-vi}" "$message_file"
+if ! (
+  set -f
+  editor_command=${EDITOR:-vi}
+  sh -c '"$@"' sh $editor_command "$message_file"
+); then
+  fail "editor exited unsuccessfully"
+fi
 
 title="$(
   awk '
@@ -92,7 +108,7 @@ awk '
 ' "$message_file" >"$body_file"
 
 status=0
-gh pr merge "$branch" --squash --delete-branch --subject "$title" --body-file "$body_file" || status=$?
+gh pr merge "$branch" --squash --subject "$title" --body-file "$body_file" || status=$?
 cleanup
 trap - EXIT HUP INT TERM
 exit "$status"

--- a/tests/lazygit_pr_merge_test.sh
+++ b/tests/lazygit_pr_merge_test.sh
@@ -165,6 +165,9 @@ write_stub "$tmp_dir/bin/gh" \
   '  exit 0' \
   'fi' \
   'if [ "$1" = "pr" ] && [ "$2" = "merge" ]; then' \
+  '  if [ "${GH_MERGE_EXIT:-0}" != "0" ]; then' \
+  '    exit "$GH_MERGE_EXIT"' \
+  '  fi' \
   '  body_file=""' \
   '  while [ "$#" -gt 0 ]; do' \
   '    if [ "$1" = "--body-file" ]; then' \
@@ -206,6 +209,7 @@ export GH_BODY_CAPTURE="$tmp_dir/body.txt"
 export GH_BODY_FILE_PATH="$tmp_dir/body-file-path.txt"
 export GH_PR_TITLE='Implement lazygit PR merge; keep $HOME safe'
 export GH_PR_BODY="This PR adds a merge menu."
+export GH_MERGE_EXIT=0
 export TMPDIR="$tmp_dir/tmp"
 
 reset_gh_calls
@@ -273,6 +277,25 @@ assert_tmp_empty "squash strategy should not leave temporary files or directorie
 pass "squash strategy rejects missing title"
 
 reset_gh_calls
+export EDITOR="$tmp_dir/editors/append-editor"
+export GH_MERGE_EXIT=45
+
+if sh "$helper" feature/pr-menu squash >"$tmp_dir/merge-failure.out" 2>"$tmp_dir/merge-failure.err"; then
+  fail "squash strategy should fail when gh merge exits non-zero"
+else
+  merge_failure_status="$?"
+fi
+
+if [ "$merge_failure_status" != "45" ]; then
+  fail "squash strategy should preserve gh merge failure status"
+fi
+
+assert_call_count 2 "merge failure should happen after view and merge calls"
+assert_tmp_empty "squash strategy should not leave temporary files or directories after gh merge failure"
+pass "squash strategy preserves gh merge failures"
+
+reset_gh_calls
+export GH_MERGE_EXIT=0
 export EDITOR="$tmp_dir/editors/failing-editor"
 
 if sh "$helper" feature/pr-menu squash >"$tmp_dir/editor-failure.out" 2>"$tmp_dir/editor-failure.err"; then

--- a/tests/lazygit_pr_merge_test.sh
+++ b/tests/lazygit_pr_merge_test.sh
@@ -40,7 +40,90 @@ assert_contains() {
   pass "$message"
 }
 
-mkdir -p "$tmp_dir/bin" "$tmp_dir/home" "$tmp_dir/editors" "$tmp_dir/tmp"
+assert_no_arg() {
+  call_file="$1"
+  unexpected="$2"
+  message="$3"
+
+  while IFS= read -r arg; do
+    if [ "$arg" = "$unexpected" ]; then
+      fail "$message"
+    fi
+  done <"$call_file"
+
+  pass "$message"
+}
+
+assert_arg_at() {
+  call_file="$1"
+  position="$2"
+  expected="$3"
+  message="$4"
+  actual="$(sed -n "${position}p" "$call_file")"
+
+  if [ "$actual" != "$expected" ]; then
+    fail "$message: expected arg $position to be '$expected', got '$actual'"
+  fi
+
+  pass "$message"
+}
+
+assert_call_args() {
+  call_file="$1"
+  message="$2"
+  shift 2
+  expected_file="$tmp_dir/expected.args"
+  : >"$expected_file"
+
+  for arg do
+    printf '%s\n' "$arg" >>"$expected_file"
+  done
+
+  if ! cmp -s "$expected_file" "$call_file"; then
+    printf '%s\n' "expected args:" >&2
+    sed 's/^/  /' "$expected_file" >&2
+    printf '%s\n' "actual args:" >&2
+    sed 's/^/  /' "$call_file" >&2
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
+assert_call_count() {
+  expected="$1"
+  message="$2"
+  actual=0
+
+  if [ -f "$GH_CALL_COUNT" ]; then
+    actual="$(cat "$GH_CALL_COUNT")"
+  fi
+
+  if [ "$actual" != "$expected" ]; then
+    fail "$message: expected $expected gh calls, got $actual"
+  fi
+
+  pass "$message"
+}
+
+assert_tmp_empty() {
+  message="$1"
+
+  if find "$TMPDIR" -mindepth 1 | grep . >/dev/null; then
+    find "$TMPDIR" -mindepth 1 >&2
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
+reset_gh_calls() {
+  rm -rf "$GH_CALL_DIR"
+  mkdir -p "$GH_CALL_DIR"
+  rm -f "$GH_CALL_COUNT" "$GH_BODY_CAPTURE" "$GH_BODY_FILE_PATH"
+}
+
+mkdir -p "$tmp_dir/bin" "$tmp_dir/home" "$tmp_dir/editors" "$tmp_dir/tmp" "$tmp_dir/calls"
 
 rendered_config="$(
   chezmoi \
@@ -67,17 +150,25 @@ assert_contains "$rendered_config" "loadingText: Merging PR..." "lazygit command
 helper="$repo_root/dot_config/lazygit/scripts/executable_merge-pr"
 
 write_stub "$tmp_dir/bin/gh" \
-  'printf "%s\n" "$*" >>"$GH_CALL_LOG"' \
+  'count=0' \
+  '[ -f "$GH_CALL_COUNT" ] && count="$(cat "$GH_CALL_COUNT")"' \
+  'count=$((count + 1))' \
+  'printf "%s\n" "$count" >"$GH_CALL_COUNT"' \
+  'call_file="$GH_CALL_DIR/call-$count.args"' \
+  ': >"$call_file"' \
+  'for arg do' \
+  '  printf "%s\n" "$arg" >>"$call_file"' \
+  'done' \
   'if [ "$1" = "pr" ] && [ "$2" = "view" ]; then' \
-  '  printf "%s\n" "Implement lazygit PR merge"' \
-  '  printf "%s\n" "This PR adds a merge menu."' \
+  '  printf "%s\n" "$GH_PR_TITLE"' \
+  '  printf "%s\n" "$GH_PR_BODY"' \
   '  exit 0' \
   'fi' \
   'if [ "$1" = "pr" ] && [ "$2" = "merge" ]; then' \
   '  body_file=""' \
   '  while [ "$#" -gt 0 ]; do' \
   '    if [ "$1" = "--body-file" ]; then' \
-  '      body_file="$2"' \
+  '      body_file="${2:-}"' \
   '      break' \
   '    fi' \
   '    shift' \
@@ -93,35 +184,61 @@ write_stub "$tmp_dir/bin/gh" \
 write_stub "$tmp_dir/editors/append-editor" \
   'printf "%s\n" "Edited body line." >>"$1"'
 
+write_stub "$tmp_dir/editors/require-flag-editor" \
+  'if [ "${1:-}" != "--wait" ]; then' \
+  '  printf "%s\n" "missing --wait flag" >&2' \
+  '  exit 65' \
+  'fi' \
+  'printf "%s\n" "Edited body line." >>"$2"'
+
+write_stub "$tmp_dir/editors/remove-title-editor" \
+  'sed "/^Title:/d" "$1" >"$1.tmp"' \
+  'mv "$1.tmp" "$1"'
+
+write_stub "$tmp_dir/editors/failing-editor" \
+  'printf "%s\n" "editor failed intentionally" >&2' \
+  'exit 42'
+
 export PATH="$tmp_dir/bin:/usr/bin:/bin"
-export GH_CALL_LOG="$tmp_dir/gh-calls.log"
+export GH_CALL_DIR="$tmp_dir/calls"
+export GH_CALL_COUNT="$tmp_dir/gh-call-count"
 export GH_BODY_CAPTURE="$tmp_dir/body.txt"
 export GH_BODY_FILE_PATH="$tmp_dir/body-file-path.txt"
-export EDITOR="$tmp_dir/editors/append-editor"
+export GH_PR_TITLE='Implement lazygit PR merge; keep $HOME safe'
+export GH_PR_BODY="This PR adds a merge menu."
 export TMPDIR="$tmp_dir/tmp"
 
+reset_gh_calls
 sh "$helper" feature/pr-menu merge
 
-if ! grep -F "pr merge feature/pr-menu --merge --delete-branch" "$GH_CALL_LOG" >/dev/null; then
-  fail "merge strategy should call gh pr merge with --merge"
-fi
+assert_call_count 1 "merge strategy should call gh once"
+assert_call_args "$GH_CALL_DIR/call-1.args" \
+  "merge strategy should call gh pr merge with --merge and keep the branch" \
+  pr merge feature/pr-menu --merge
 
-pass "merge strategy calls gh pr merge with --merge"
-
-: >"$GH_CALL_LOG"
+reset_gh_calls
+export EDITOR="$tmp_dir/editors/require-flag-editor --wait"
 sh "$helper" feature/pr-menu squash
 
-if ! grep -F "pr view feature/pr-menu --json title,body --jq .title, .body" "$GH_CALL_LOG" >/dev/null; then
-  fail "squash strategy should read PR title and body"
+assert_call_count 2 "squash strategy should view then merge"
+assert_call_args "$GH_CALL_DIR/call-1.args" \
+  "squash strategy should read PR title and body" \
+  pr view feature/pr-menu --json title,body --jq ".title, .body"
+
+squash_merge_call="$GH_CALL_DIR/call-2.args"
+assert_arg_at "$squash_merge_call" 1 pr "squash merge call starts with gh pr"
+assert_arg_at "$squash_merge_call" 2 merge "squash merge call targets gh merge"
+assert_arg_at "$squash_merge_call" 3 feature/pr-menu "squash merge call targets the selected branch"
+assert_arg_at "$squash_merge_call" 4 --squash "squash merge call uses squash strategy"
+assert_arg_at "$squash_merge_call" 5 --subject "squash merge call passes a subject flag"
+assert_arg_at "$squash_merge_call" 6 "$GH_PR_TITLE" "squash strategy passes the metacharacter title as one subject argument"
+assert_arg_at "$squash_merge_call" 7 --body-file "squash merge call passes a body file"
+line_count="$(wc -l <"$squash_merge_call" | tr -d ' ')"
+if [ "$line_count" != 8 ]; then
+  fail "squash merge call should only pass expected arguments"
 fi
-
-pass "squash strategy reads PR title and body"
-
-if ! grep -F "pr merge feature/pr-menu --squash --delete-branch --subject Implement lazygit PR merge --body-file" "$GH_CALL_LOG" >/dev/null; then
-  fail "squash strategy should pass edited title as subject"
-fi
-
-pass "squash strategy passes edited title as subject"
+pass "squash merge call only passes expected arguments"
+assert_no_arg "$squash_merge_call" --delete-branch "squash strategy should not delete the branch"
 
 if ! grep -F "This PR adds a merge menu." "$GH_BODY_CAPTURE" >/dev/null; then
   fail "squash strategy should pass PR description as body"
@@ -138,16 +255,9 @@ if [ -e "$body_file_path" ]; then
   fail "squash strategy should remove its temporary body file after a successful merge"
 fi
 
-if find "$TMPDIR" -type f | grep . >/dev/null; then
-  fail "squash strategy should not leave temporary files after a successful merge"
-fi
+assert_tmp_empty "squash strategy should not leave temporary files or directories after success"
 
-pass "squash strategy removes temporary files after success"
-
-write_stub "$tmp_dir/editors/remove-title-editor" \
-  'sed "/^Title:/d" "$1" >"$1.tmp"' \
-  'mv "$1.tmp" "$1"'
-
+reset_gh_calls
 export EDITOR="$tmp_dir/editors/remove-title-editor"
 
 if sh "$helper" feature/pr-menu squash >"$tmp_dir/missing-title.out" 2>"$tmp_dir/missing-title.err"; then
@@ -158,8 +268,21 @@ if ! grep -F "missing a Title" "$tmp_dir/missing-title.err" >/dev/null; then
   fail "squash strategy should explain missing title errors"
 fi
 
-if find "$TMPDIR" -type f | grep . >/dev/null; then
-  fail "squash strategy should not leave temporary files after a missing-title abort"
+assert_call_count 1 "missing-title abort should not call gh merge"
+assert_tmp_empty "squash strategy should not leave temporary files or directories after a missing-title abort"
+pass "squash strategy rejects missing title"
+
+reset_gh_calls
+export EDITOR="$tmp_dir/editors/failing-editor"
+
+if sh "$helper" feature/pr-menu squash >"$tmp_dir/editor-failure.out" 2>"$tmp_dir/editor-failure.err"; then
+  fail "squash strategy should fail when the editor exits non-zero"
 fi
 
-pass "squash strategy rejects missing title"
+if ! grep -F "editor exited unsuccessfully" "$tmp_dir/editor-failure.err" >/dev/null; then
+  fail "squash strategy should explain editor failures"
+fi
+
+assert_call_count 1 "editor failure should not call gh merge"
+assert_tmp_empty "squash strategy should not leave temporary files or directories after editor failure"
+pass "squash strategy rejects editor failure"

--- a/tests/lazygit_pr_merge_test.sh
+++ b/tests/lazygit_pr_merge_test.sh
@@ -147,6 +147,20 @@ assert_contains "$rendered_config" "merge-pr {{.SelectedLocalBranch.Name | quote
 assert_contains "$rendered_config" "output: terminal" "lazygit command runs in a terminal"
 assert_contains "$rendered_config" "loadingText: Merging PR..." "lazygit command shows merge progress"
 
+helper_target="$(
+  chezmoi \
+    --source "$repo_root" \
+    --destination "$tmp_dir/home" \
+    target-path dot_config/lazygit/scripts/executable_merge-pr
+)"
+expected_helper_target="$tmp_dir/home/.config/lazygit/scripts/merge-pr"
+
+if [ "$helper_target" != "$expected_helper_target" ]; then
+  fail "chezmoi should install executable_merge-pr as merge-pr; expected '$expected_helper_target', got '$helper_target'"
+fi
+
+pass "chezmoi installs executable_merge-pr as the helper path lazygit calls"
+
 helper="$repo_root/dot_config/lazygit/scripts/executable_merge-pr"
 
 write_stub "$tmp_dir/bin/gh" \

--- a/tests/lazygit_pr_merge_test.sh
+++ b/tests/lazygit_pr_merge_test.sh
@@ -134,7 +134,7 @@ rendered_config="$(
 
 assert_contains "$rendered_config" "key: X" "lazygit config binds the PR merge command to X"
 assert_contains "$rendered_config" "context: localBranches" "lazygit config exposes the command in local branches"
-assert_contains "$rendered_config" "description: Merge GitHub PR" "lazygit config exposes the PR merge command"
+assert_contains "$rendered_config" "description: Merge GitHub PR..." "lazygit config exposes the PR merge command as a follow-up flow"
 assert_contains "$rendered_config" "title: Merge pull request" "lazygit config prompts for merge strategy"
 assert_contains "$rendered_config" "key: MergeStrategy" "lazygit config stores the selected merge strategy"
 assert_contains "$rendered_config" "name: Merge commit" "lazygit config offers merge commit strategy"

--- a/tests/lazygit_pr_merge_test.sh
+++ b/tests/lazygit_pr_merge_test.sh
@@ -1,0 +1,165 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT INT TERM
+
+fail() {
+  printf '%s\n' "not ok - $1" >&2
+  exit 1
+}
+
+pass() {
+  printf '%s\n' "ok - $1"
+}
+
+write_stub() {
+  path="$1"
+  shift
+  {
+    printf '%s\n' '#!/bin/sh'
+    printf '%s\n' "$@"
+  } >"$path"
+  chmod +x "$path"
+}
+
+assert_contains() {
+  haystack="$1"
+  needle="$2"
+  message="$3"
+
+  if ! printf '%s\n' "$haystack" | grep -F "$needle" >/dev/null; then
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
+mkdir -p "$tmp_dir/bin" "$tmp_dir/home" "$tmp_dir/editors" "$tmp_dir/tmp"
+
+rendered_config="$(
+  chezmoi \
+    --source "$repo_root" \
+    --destination "$tmp_dir/home" \
+    cat "$tmp_dir/home/.config/lazygit/config.yml"
+)"
+
+assert_contains "$rendered_config" "key: X" "lazygit config binds the PR merge command to X"
+assert_contains "$rendered_config" "context: localBranches" "lazygit config exposes the command in local branches"
+assert_contains "$rendered_config" "description: Merge GitHub PR" "lazygit config exposes the PR merge command"
+assert_contains "$rendered_config" "title: Merge pull request" "lazygit config prompts for merge strategy"
+assert_contains "$rendered_config" "key: MergeStrategy" "lazygit config stores the selected merge strategy"
+assert_contains "$rendered_config" "name: Merge commit" "lazygit config offers merge commit strategy"
+assert_contains "$rendered_config" "value: merge" "lazygit config maps merge commit to merge"
+assert_contains "$rendered_config" "name: Squash" "lazygit config offers squash strategy"
+assert_contains "$rendered_config" "value: squash" "lazygit config maps squash to squash"
+assert_contains "$rendered_config" "title: Merge PR?" "lazygit config asks for confirmation"
+assert_contains "$rendered_config" "body: Merge the GitHub PR for the selected branch?" "lazygit config explains confirmation"
+assert_contains "$rendered_config" "merge-pr {{.SelectedLocalBranch.Name | quote}} {{.Form.MergeStrategy | quote}}" "lazygit config delegates PR merge behavior to helper"
+assert_contains "$rendered_config" "output: terminal" "lazygit command runs in a terminal"
+assert_contains "$rendered_config" "loadingText: Merging PR..." "lazygit command shows merge progress"
+
+helper="$repo_root/dot_config/lazygit/scripts/executable_merge-pr"
+
+write_stub "$tmp_dir/bin/gh" \
+  'printf "%s\n" "$*" >>"$GH_CALL_LOG"' \
+  'if [ "$1" = "pr" ] && [ "$2" = "view" ]; then' \
+  '  printf "%s\n" "Implement lazygit PR merge"' \
+  '  printf "%s\n" "This PR adds a merge menu."' \
+  '  exit 0' \
+  'fi' \
+  'if [ "$1" = "pr" ] && [ "$2" = "merge" ]; then' \
+  '  body_file=""' \
+  '  while [ "$#" -gt 0 ]; do' \
+  '    if [ "$1" = "--body-file" ]; then' \
+  '      body_file="$2"' \
+  '      break' \
+  '    fi' \
+  '    shift' \
+  '  done' \
+  '  if [ -n "$body_file" ]; then' \
+  '    cat "$body_file" >"$GH_BODY_CAPTURE"' \
+  '    printf "%s\n" "$body_file" >"$GH_BODY_FILE_PATH"' \
+  '  fi' \
+  '  exit 0' \
+  'fi' \
+  'exit 64'
+
+write_stub "$tmp_dir/editors/append-editor" \
+  'printf "%s\n" "Edited body line." >>"$1"'
+
+export PATH="$tmp_dir/bin:/usr/bin:/bin"
+export GH_CALL_LOG="$tmp_dir/gh-calls.log"
+export GH_BODY_CAPTURE="$tmp_dir/body.txt"
+export GH_BODY_FILE_PATH="$tmp_dir/body-file-path.txt"
+export EDITOR="$tmp_dir/editors/append-editor"
+export TMPDIR="$tmp_dir/tmp"
+
+sh "$helper" feature/pr-menu merge
+
+if ! grep -F "pr merge feature/pr-menu --merge --delete-branch" "$GH_CALL_LOG" >/dev/null; then
+  fail "merge strategy should call gh pr merge with --merge"
+fi
+
+pass "merge strategy calls gh pr merge with --merge"
+
+: >"$GH_CALL_LOG"
+sh "$helper" feature/pr-menu squash
+
+if ! grep -F "pr view feature/pr-menu --json title,body --jq .title, .body" "$GH_CALL_LOG" >/dev/null; then
+  fail "squash strategy should read PR title and body"
+fi
+
+pass "squash strategy reads PR title and body"
+
+if ! grep -F "pr merge feature/pr-menu --squash --delete-branch --subject Implement lazygit PR merge --body-file" "$GH_CALL_LOG" >/dev/null; then
+  fail "squash strategy should pass edited title as subject"
+fi
+
+pass "squash strategy passes edited title as subject"
+
+if ! grep -F "This PR adds a merge menu." "$GH_BODY_CAPTURE" >/dev/null; then
+  fail "squash strategy should pass PR description as body"
+fi
+
+if ! grep -F "Edited body line." "$GH_BODY_CAPTURE" >/dev/null; then
+  fail "squash strategy should include editor changes in body"
+fi
+
+pass "squash strategy passes edited description as body"
+
+body_file_path="$(cat "$GH_BODY_FILE_PATH")"
+if [ -e "$body_file_path" ]; then
+  fail "squash strategy should remove its temporary body file after a successful merge"
+fi
+
+if find "$TMPDIR" -type f | grep . >/dev/null; then
+  fail "squash strategy should not leave temporary files after a successful merge"
+fi
+
+pass "squash strategy removes temporary files after success"
+
+write_stub "$tmp_dir/editors/remove-title-editor" \
+  'sed "/^Title:/d" "$1" >"$1.tmp"' \
+  'mv "$1.tmp" "$1"'
+
+export EDITOR="$tmp_dir/editors/remove-title-editor"
+
+if sh "$helper" feature/pr-menu squash >"$tmp_dir/missing-title.out" 2>"$tmp_dir/missing-title.err"; then
+  fail "squash strategy should reject an edited message without a title"
+fi
+
+if ! grep -F "missing a Title" "$tmp_dir/missing-title.err" >/dev/null; then
+  fail "squash strategy should explain missing title errors"
+fi
+
+if find "$TMPDIR" -type f | grep . >/dev/null; then
+  fail "squash strategy should not leave temporary files after a missing-title abort"
+fi
+
+pass "squash strategy rejects missing title"


### PR DESCRIPTION
## Summary
- Add a lazygit `localBranches` custom command for merging the selected branch's GitHub PR.
- Add a POSIX shell helper that supports merge commits and squash merges with an editable PR title/body template.
- Cover the helper path mapping, merge strategies, editor failures, quoting, and cleanup behavior with shell tests.

## Why
Lazygit does not provide a native PR merge action, and the preferred squash flow needs an editable message seeded from the PR title and description.

## Test Plan
- [x] `sh tests/lazygit_pr_merge_test.sh`
- [x] `for test_file in tests/*.sh; do sh "$test_file"; done`
- [x] `for test_file in tests/*.zsh; do zsh "$test_file"; done`

Closes #25