### PR TITLE
Route hammerspoon launcher to ghostty

### DIFF
--- a/dot_hammerspoon/init.lua
+++ b/dot_hammerspoon/init.lua
@@ -17,7 +17,7 @@ local helpToastStyle = {
 }
 
 local appBindings = {
-  { key = "t", label = "cmux", bundleID = "com.cmuxterm.app" },
+  { key = "t", label = ghosttyAppName, bundleID = ghosttyBundleID },
   { key = "s", label = "Slack", bundleID = "com.tinyspeck.slackmacgap" },
   { key = "d", label = "Discord", bundleID = "com.hnc.Discord" },
   { key = "n", label = "Notion", bundleID = "notion.id" },


### PR DESCRIPTION
## Summary

- Change the Hammerspoon app launcher `T` binding from cmux to Ghostty.
- Reuse the existing Ghostty app name and bundle ID constants for the launcher entry.

## Impact

Pressing the app launcher `T` shortcut now opens or focuses Ghostty instead of cmux. The help toast will show Ghostty for that binding.

## Validation

- Ran `nvim --headless -u NONE -i NONE -n +'lua assert(loadfile("dot_hammerspoon/init.lua"))' +qa`.
- Ran `chezmoi diff /Users/minu/.hammerspoon/init.lua` and confirmed no pending live-file diff after apply.
- Confirmed both source and live Hammerspoon configs contain `label = ghosttyAppName, bundleID = ghosttyBundleID` for the `T` launcher binding.