### PR TITLE
Install gh on Ubuntu

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -50,7 +50,7 @@ _Avoid_: Homebrew replacement, standalone aqua
 - The **VPS Shell Profile** targets exactly one **Supported Ubuntu Release**.
 - The **VPS Shell Profile** includes the **Core Shell Stack**.
 - The **VPS Shell Profile** includes the **Development Runtime Stack**.
-- The **Core Shell Stack** includes Oh My Zsh and modern CLI tools such as fd, ripgrep, zoxide, lazygit, and plain Neovim.
+- The **Core Shell Stack** includes Oh My Zsh and modern CLI tools such as fd, ripgrep, zoxide, lazygit, GitHub CLI (`gh`), and plain Neovim.
 - The **Development Runtime Stack** includes mise-managed Bun, Node.js, Python, and uv.
 - pnpm belongs to the **Development Runtime Stack** through Node.js Corepack, not as a mise-managed tool.
 - Rich Neovim configuration belongs to the **Optional Editor Stack**, not the **Core Shell Stack**, and is opt-in for every machine profile.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ the initial terminal environment:
 - Homebrew bootstrap and the macOS `Brewfile` bundle
 - Ghostty, cmux, Hammerspoon, and font casks
 - mise
-- CLI tools such as ripgrep, neovim, zellij, lazygit, and starship via mise
+- CLI tools such as ripgrep, neovim, zellij, lazygit, GitHub CLI (`gh`), and starship via mise
 - btop via Homebrew, because its mise-managed release assets do not support macOS arm64
 - Oh My Zsh, zinit, and SCM Breeze
 - Bun, Python, uv/uvx, and Node.js via `~/.config/mise/config.toml`
@@ -67,7 +67,7 @@ On Ubuntu, `chezmoi apply` runs setup scripts for the VPS shell profile:
 - Python build dependencies required by the mise-managed Python runtime
 - mise from the official mise APT repository
 - Oh My Zsh, zinit, and SCM Breeze
-- CLI tools such as ripgrep, neovim, zellij, lazygit, and starship via mise
+- CLI tools such as ripgrep, neovim, zellij, lazygit, GitHub CLI (`gh`), and starship via mise
 - Bun, Python, uv/uvx, and Node.js via mise
 - pnpm through Node.js Corepack
 - Login shell switch to zsh

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -206,6 +206,12 @@ fi
 
 pass "Ubuntu VPS keeps plain Neovim in the Core Shell Stack"
 
+if ! printf '%s\n' "$ubuntu_mise_config" | grep -F '"aqua:cli/cli" = "latest"' >/dev/null; then
+  fail "Ubuntu VPS installs GitHub CLI gh in the Core Shell Stack"
+fi
+
+pass "Ubuntu VPS installs GitHub CLI gh in the Core Shell Stack"
+
 mise_tools_installer="$(render_template "$ubuntu_data" ".chezmoiscripts/run_onchange_after_20-install-mise-tools.sh.tmpl")"
 
 if ! printf '%s\n' "$mise_tools_installer" |

--- a/tests/readme_optional_stack_profiles_test.sh
+++ b/tests/readme_optional_stack_profiles_test.sh
@@ -33,6 +33,8 @@ assert_contains '| `enableDevelopmentWorkspace` | `false` |' \
 
 assert_contains 'All three optional stack profiles are disabled by default.' \
   "README states optional stack profiles are disabled by default"
+assert_contains 'GitHub CLI (`gh`)' \
+  "README documents gh as part of the Ubuntu Core Shell Stack"
 assert_contains 'When `enableDevelopmentWorkspace` is `true`, it enables both the Optional Editor Stack and Optional AI Tool Stack even if `enableEditorStack` or `enableAiCliTools` are false or omitted.' \
   "README documents full workspace preset precedence"
 assert_contains 'Opting out of an optional stack excludes its files from chezmoi management; it does not remove files already present on a machine.' \

--- a/tests/readme_optional_stack_profiles_test.sh
+++ b/tests/readme_optional_stack_profiles_test.sh
@@ -24,6 +24,21 @@ assert_contains() {
   pass "$message"
 }
 
+assert_ubuntu_setup_contains() {
+  needle="$1"
+  message="$2"
+
+  if ! awk '
+    /^### Ubuntu 24.04 VPS$/ { in_ubuntu = 1; next }
+    /^## Updates$/ { in_ubuntu = 0 }
+    in_ubuntu { print }
+  ' "$readme" | grep -F "$needle" >/dev/null; then
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
 assert_contains '| `enableEditorStack` | `false` |' \
   "README documents enableEditorStack default"
 assert_contains '| `enableAiCliTools` | `false` |' \
@@ -33,7 +48,7 @@ assert_contains '| `enableDevelopmentWorkspace` | `false` |' \
 
 assert_contains 'All three optional stack profiles are disabled by default.' \
   "README states optional stack profiles are disabled by default"
-assert_contains 'GitHub CLI (`gh`)' \
+assert_ubuntu_setup_contains 'GitHub CLI (`gh`)' \
   "README documents gh as part of the Ubuntu Core Shell Stack"
 assert_contains 'When `enableDevelopmentWorkspace` is `true`, it enables both the Optional Editor Stack and Optional AI Tool Stack even if `enableEditorStack` or `enableAiCliTools` are false or omitted.' \
   "README documents full workspace preset precedence"


### PR DESCRIPTION
## Summary

- Document GitHub CLI (`gh`) as part of the shared Core Shell Stack for macOS and Ubuntu.
- Add a Ubuntu render test that verifies the mise/aqua GitHub CLI package remains installed.
- Add a README regression check so the Ubuntu setup docs continue to mention `gh`.

## Why

The Ubuntu VPS profile already installs `gh` through mise/aqua as `aqua:cli/cli`, but the guarantee was easy to miss because the README and domain context did not call it out. This makes the intended setup explicit and protects it with tests.

## Impact

Ubuntu machines continue to install `gh` through the existing Modern CLI Provider path, without adding a duplicate APT installation path.

## Validation

- `sh tests/chezmoiignore_test.sh`
- `sh tests/readme_optional_stack_profiles_test.sh`
- `sh tests/bootstrap_ubuntu_test.sh`
- `sh tests/lazygit_pr_merge_test.sh`
- `sh tests/karabiner_config_test.sh`
- `zsh tests/zshrc_zoxide_test.zsh`
- `sh tests/zshenv_local_bin_test.sh`
- `sh tests/ghostty_config_test.sh`