### PR TITLE
Add Terrapod command scaffold and tpod alias

### DIFF
--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -eu
+
+show_help() {
+  cat <<'EOF'
+Terrapod - Dotfiles Management Tool
+
+Usage:
+  terrapod [help|--help|-h]
+
+Commands:
+  help  Show this help.
+EOF
+}
+
+fail_usage() {
+  printf '%s\n' "terrapod: $1" >&2
+  printf '%s\n' "Run 'terrapod help' for usage." >&2
+  exit 64
+}
+
+command_name="${1:-help}"
+
+case "$command_name" in
+  help|-h|--help)
+    show_help
+    ;;
+  *)
+    fail_usage "unknown command: $command_name"
+    ;;
+esac

--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -7,9 +7,14 @@ Terrapod - Dotfiles Management Tool
 
 Usage:
   terrapod [help|--help|-h]
+  terrapod chezmoi -- <args...>
 
 Commands:
-  help  Show this help.
+  help                 Show this help.
+  chezmoi -- <args...> Run raw chezmoi for advanced maintenance.
+
+Examples:
+  terrapod chezmoi -- status
 EOF
 }
 
@@ -24,6 +29,21 @@ command_name="${1:-help}"
 case "$command_name" in
   help|-h|--help)
     show_help
+    ;;
+  chezmoi)
+    shift
+
+    if [ "${1:-}" != "--" ]; then
+      fail_usage "raw chezmoi commands must be separated with '--'"
+    fi
+
+    shift
+
+    if [ "$#" -eq 0 ]; then
+      fail_usage "raw chezmoi command is required"
+    fi
+
+    exec chezmoi "$@"
     ;;
   *)
     fail_usage "unknown command: $command_name"

--- a/dot_local/bin/symlink_tpod
+++ b/dot_local/bin/symlink_tpod
@@ -1,0 +1,1 @@
+terrapod

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -3,11 +3,14 @@ set -eu
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 tmp_dir="$(mktemp -d)"
+chezmoi_config="$tmp_dir/chezmoi.toml"
 
 cleanup() {
   rm -rf "$tmp_dir"
 }
 trap cleanup EXIT INT TERM
+
+: >"$chezmoi_config"
 
 fail() {
   printf '%s\n' "not ok - $1" >&2
@@ -21,6 +24,7 @@ pass() {
 managed_source_paths() {
   data="$1"
   chezmoi \
+    --config "$chezmoi_config" \
     --source "$repo_root" \
     --override-data "$data" \
     managed \
@@ -30,6 +34,7 @@ managed_source_paths() {
 managed_target_paths() {
   data="$1"
   chezmoi \
+    --config "$chezmoi_config" \
     --source "$repo_root" \
     --override-data "$data" \
     managed
@@ -39,7 +44,9 @@ render_template() {
   data="$1"
   file="$2"
 
-  chezmoi execute-template \
+  chezmoi \
+    --config "$chezmoi_config" \
+    execute-template \
     --override-data "$data" \
     --file "$repo_root/$file"
 }
@@ -49,6 +56,7 @@ render_managed_file() {
   destination="$2"
 
   chezmoi \
+    --config "$chezmoi_config" \
     --source "$repo_root" \
     --destination "$tmp_dir/home" \
     --override-data "$data" \
@@ -105,6 +113,7 @@ assert_managed_paths_include_prefix() {
 
 managed_tests="$(
   chezmoi \
+    --config "$chezmoi_config" \
     --source "$repo_root" \
     managed \
     --path-style source-relative |

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -78,6 +78,7 @@ assert_call_args() {
 mkdir -p "$tmp_dir/bin" "$tmp_dir/home"
 
 terrapod="$repo_root/dot_local/bin/executable_terrapod"
+tpod_source="$repo_root/dot_local/bin/symlink_tpod"
 
 managed_targets="$(
   chezmoi \
@@ -90,6 +91,11 @@ assert_line \
   "$managed_targets" \
   ".local/bin/terrapod" \
   "chezmoi manages Terrapod as the primary user-facing command"
+
+assert_line \
+  "$managed_targets" \
+  ".local/bin/tpod" \
+  "chezmoi manages tpod as an alias to Terrapod"
 
 terrapod_target="$(
   chezmoi \
@@ -105,6 +111,20 @@ fi
 
 pass "chezmoi installs Terrapod at ~/.local/bin/terrapod"
 
+tpod_target="$(
+  chezmoi \
+    --source "$repo_root" \
+    --destination "$tmp_dir/home" \
+    target-path dot_local/bin/symlink_tpod
+)"
+expected_tpod_target="$tmp_dir/home/.local/bin/tpod"
+
+if [ "$tpod_target" != "$expected_tpod_target" ]; then
+  fail "chezmoi installs tpod at ~/.local/bin/tpod; expected '$expected_tpod_target', got '$tpod_target'"
+fi
+
+pass "chezmoi installs tpod at ~/.local/bin/tpod"
+
 if [ ! -f "$terrapod" ]; then
   fail "Terrapod command source exists"
 fi
@@ -117,10 +137,33 @@ fi
 
 pass "Terrapod command source is executable"
 
+if [ ! -f "$tpod_source" ]; then
+  fail "tpod alias source exists"
+fi
+
+pass "tpod alias source exists"
+
+IFS= read -r tpod_source_line <"$tpod_source"
+
+if [ "$tpod_source_line" != "terrapod" ]; then
+  fail "tpod alias points to Terrapod"
+fi
+
+pass "tpod alias points to Terrapod"
+
 sh -n "$terrapod" || fail "Terrapod command is valid POSIX shell"
 pass "Terrapod command is valid POSIX shell"
 
 help_output="$(sh "$terrapod" help)"
+
+ln -s "$terrapod" "$tmp_dir/bin/tpod"
+tpod_help_output="$(PATH="$tmp_dir/bin:/usr/bin:/bin" "$tmp_dir/bin/tpod" help)"
+
+if [ "$tpod_help_output" != "$help_output" ]; then
+  fail "tpod shows the same help as Terrapod"
+fi
+
+pass "tpod shows the same help as Terrapod"
 
 assert_contains \
   "$help_output" \
@@ -194,6 +237,13 @@ assert_call_args \
   "$CHEZMOI_CALL_FILE" \
   "Terrapod passes raw arguments to chezmoi after --" \
   status --include files
+
+"$tmp_dir/bin/tpod" chezmoi -- diff
+
+assert_call_args \
+  "$CHEZMOI_CALL_FILE" \
+  "tpod uses the same raw chezmoi escape hatch as Terrapod" \
+  diff
 
 if sh "$terrapod" chezmoi status >"$tmp_dir/missing-separator.out" 2>"$tmp_dir/missing-separator.err"; then
   fail "raw chezmoi escape hatch requires -- separator"

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -1,0 +1,135 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT INT TERM
+
+fail() {
+  printf '%s\n' "not ok - $1" >&2
+  exit 1
+}
+
+pass() {
+  printf '%s\n' "ok - $1"
+}
+
+assert_contains() {
+  haystack="$1"
+  needle="$2"
+  message="$3"
+
+  if ! printf '%s\n' "$haystack" | grep -F "$needle" >/dev/null; then
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
+assert_line() {
+  haystack="$1"
+  expected_line="$2"
+  message="$3"
+
+  if ! printf '%s\n' "$haystack" | grep -Fx "$expected_line" >/dev/null; then
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
+mkdir -p "$tmp_dir/home"
+
+terrapod="$repo_root/dot_local/bin/executable_terrapod"
+
+managed_targets="$(
+  chezmoi \
+    --source "$repo_root" \
+    --destination "$tmp_dir/home" \
+    managed
+)"
+
+assert_line \
+  "$managed_targets" \
+  ".local/bin/terrapod" \
+  "chezmoi manages Terrapod as the primary user-facing command"
+
+terrapod_target="$(
+  chezmoi \
+    --source "$repo_root" \
+    --destination "$tmp_dir/home" \
+    target-path dot_local/bin/executable_terrapod
+)"
+expected_terrapod_target="$tmp_dir/home/.local/bin/terrapod"
+
+if [ "$terrapod_target" != "$expected_terrapod_target" ]; then
+  fail "chezmoi installs Terrapod at ~/.local/bin/terrapod; expected '$expected_terrapod_target', got '$terrapod_target'"
+fi
+
+pass "chezmoi installs Terrapod at ~/.local/bin/terrapod"
+
+if [ ! -f "$terrapod" ]; then
+  fail "Terrapod command source exists"
+fi
+
+pass "Terrapod command source exists"
+
+if [ ! -x "$terrapod" ]; then
+  fail "Terrapod command source is executable"
+fi
+
+pass "Terrapod command source is executable"
+
+sh -n "$terrapod" || fail "Terrapod command is valid POSIX shell"
+pass "Terrapod command is valid POSIX shell"
+
+help_output="$(sh "$terrapod" help)"
+
+assert_contains \
+  "$help_output" \
+  "Terrapod - Dotfiles Management Tool" \
+  "Terrapod help names the Dotfiles Management Tool"
+
+assert_contains \
+  "$help_output" \
+  "Usage:" \
+  "Terrapod help shows usage"
+
+assert_contains \
+  "$help_output" \
+  "Commands:" \
+  "Terrapod help shows command list"
+
+default_output="$(sh "$terrapod")"
+
+assert_contains \
+  "$default_output" \
+  "Terrapod - Dotfiles Management Tool" \
+  "Terrapod with no arguments shows help"
+
+dash_help_output="$(sh "$terrapod" --help)"
+
+assert_contains \
+  "$dash_help_output" \
+  "Terrapod - Dotfiles Management Tool" \
+  "Terrapod --help shows help"
+
+if sh "$terrapod" frobnicate >"$tmp_dir/unknown.out" 2>"$tmp_dir/unknown.err"; then
+  fail "unknown Terrapod subcommands fail"
+fi
+
+unknown_error="$(cat "$tmp_dir/unknown.err")"
+
+assert_contains \
+  "$unknown_error" \
+  "terrapod: unknown command: frobnicate" \
+  "unknown Terrapod subcommands name the rejected command"
+
+assert_contains \
+  "$unknown_error" \
+  "Run 'terrapod help' for usage." \
+  "unknown Terrapod subcommands point to help"

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -18,6 +18,16 @@ pass() {
   printf '%s\n' "ok - $1"
 }
 
+write_stub() {
+  path="$1"
+  shift
+  {
+    printf '%s\n' '#!/bin/sh'
+    printf '%s\n' "$@"
+  } >"$path"
+  chmod +x "$path"
+}
+
 assert_contains() {
   haystack="$1"
   needle="$2"
@@ -42,7 +52,30 @@ assert_line() {
   pass "$message"
 }
 
-mkdir -p "$tmp_dir/home"
+assert_call_args() {
+  call_file="$1"
+  message="$2"
+  shift 2
+
+  expected_file="$tmp_dir/expected.args"
+  : >"$expected_file"
+
+  for arg do
+    printf '%s\n' "$arg" >>"$expected_file"
+  done
+
+  if ! cmp -s "$expected_file" "$call_file"; then
+    printf '%s\n' "expected args:" >&2
+    sed 's/^/  /' "$expected_file" >&2
+    printf '%s\n' "actual args:" >&2
+    sed 's/^/  /' "$call_file" >&2
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
+mkdir -p "$tmp_dir/bin" "$tmp_dir/home"
 
 terrapod="$repo_root/dot_local/bin/executable_terrapod"
 
@@ -104,6 +137,16 @@ assert_contains \
   "Commands:" \
   "Terrapod help shows command list"
 
+assert_contains \
+  "$help_output" \
+  "terrapod chezmoi -- <args...>" \
+  "Terrapod help documents the raw chezmoi escape hatch"
+
+assert_contains \
+  "$help_output" \
+  "Run raw chezmoi for advanced maintenance." \
+  "Terrapod help describes raw chezmoi as advanced maintenance"
+
 default_output="$(sh "$terrapod")"
 
 assert_contains \
@@ -133,3 +176,43 @@ assert_contains \
   "$unknown_error" \
   "Run 'terrapod help' for usage." \
   "unknown Terrapod subcommands point to help"
+
+export CHEZMOI_CALL_FILE="$tmp_dir/chezmoi.args"
+
+write_stub "$tmp_dir/bin/chezmoi" \
+  ': >"$CHEZMOI_CALL_FILE"' \
+  'for arg do' \
+  '  printf "%s\n" "$arg" >>"$CHEZMOI_CALL_FILE"' \
+  'done' \
+  'exit 0'
+
+export PATH="$tmp_dir/bin:/usr/bin:/bin"
+
+sh "$terrapod" chezmoi -- status --include files
+
+assert_call_args \
+  "$CHEZMOI_CALL_FILE" \
+  "Terrapod passes raw arguments to chezmoi after --" \
+  status --include files
+
+if sh "$terrapod" chezmoi status >"$tmp_dir/missing-separator.out" 2>"$tmp_dir/missing-separator.err"; then
+  fail "raw chezmoi escape hatch requires -- separator"
+fi
+
+missing_separator_error="$(cat "$tmp_dir/missing-separator.err")"
+
+assert_contains \
+  "$missing_separator_error" \
+  "terrapod: raw chezmoi commands must be separated with '--'" \
+  "Terrapod explains missing raw chezmoi separator"
+
+if sh "$terrapod" chezmoi -- >"$tmp_dir/missing-command.out" 2>"$tmp_dir/missing-command.err"; then
+  fail "raw chezmoi escape hatch requires a command after --"
+fi
+
+missing_command_error="$(cat "$tmp_dir/missing-command.err")"
+
+assert_contains \
+  "$missing_command_error" \
+  "terrapod: raw chezmoi command is required" \
+  "Terrapod explains missing raw chezmoi command"


### PR DESCRIPTION
## Summary
- Add the `terrapod` POSIX shell command as the managed post-install entry point.
- Add `tpod` as a chezmoi symlink alias to the same command interface.
- Add shell coverage for command dispatch, alias behavior, and the raw `terrapod chezmoi -- ...` escape hatch.
- Isolate `tests/chezmoiignore_test.sh` from local chezmoi config values discovered during full-suite verification.

## Validation
- `sh tests/terrapod_command_test.sh`
- `sh tests/chezmoiignore_test.sh`
- `for test_file in tests/*_test.sh; do sh "$test_file"; done`
- `for test_file in tests/*_test.zsh; do zsh "$test_file"; done`
- Broad package-upgrade grep against `dot_local/bin` and `tests`

## Notes
This intentionally does not implement installer, Preset wizard, config writer, or first-class `status`/`diff`/`apply`/`update` command behavior. Those remain later Terrapod slices from the parent PRD.