### PR TITLE
Add Terrapod config writer

### DIFF
--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -163,7 +163,7 @@ write_managed_config() {
 
     awk -v managed_data_file="$managed_data_file" '
       function is_data_section(line) {
-        return line ~ "^[[:space:]]*(\\[data\\]|\\[\"data\"\\]|\\[\047data\047\\])[[:space:]]*($|#)"
+        return line ~ "^[[:space:]]*\\[[[:space:]]*(data|\"data\"|\047data\047)[[:space:]]*\\][[:space:]]*($|#)"
       }
 
       function is_section(line) {

--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -194,7 +194,7 @@ reject_unsupported_multiline_strings() {
   fi
 }
 
-reject_unsupported_multiline_arrays() {
+reject_section_like_multiline_arrays() {
   config_file="$1"
 
   if [ ! -f "$config_file" ]; then
@@ -206,20 +206,13 @@ reject_unsupported_multiline_arrays() {
       return line ~ "^[[:space:]]*#"
     }
 
-    function starts_multiline_array(line, i, ch, after_equals, saw_value, in_basic_string, in_literal_string, escaped, balance) {
-      if (is_comment(line)) {
-        return 0
-      }
+    function is_section(line) {
+      return line ~ /^[[:space:]]*(\[[^]]+\]|\[\[[^]]+\]\])[[:space:]]*($|#)/
+    }
 
-      for (i = 1; i <= length(line); i++) {
+    function array_balance_delta(line, start, i, ch, in_basic_string, in_literal_string, escaped, balance) {
+      for (i = start; i <= length(line); i++) {
         ch = substr(line, i, 1)
-
-        if (!after_equals) {
-          if (ch == "=") {
-            after_equals = 1
-          }
-          continue
-        }
 
         if (in_basic_string) {
           if (escaped) {
@@ -243,18 +236,6 @@ reject_unsupported_multiline_arrays() {
           break
         }
 
-        if (!saw_value) {
-          if (ch ~ /[[:space:]]/) {
-            continue
-          }
-
-          if (ch != "[") {
-            return 0
-          }
-
-          saw_value = 1
-        }
-
         if (ch == "\"") {
           in_basic_string = 1
           continue
@@ -272,12 +253,62 @@ reject_unsupported_multiline_arrays() {
         }
       }
 
-      return saw_value && balance > 0
+      return balance
+    }
+
+    function multiline_array_balance(line, i, ch, after_equals, saw_value) {
+      if (is_comment(line)) {
+        return 0
+      }
+
+      for (i = 1; i <= length(line); i++) {
+        ch = substr(line, i, 1)
+
+        if (!after_equals) {
+          if (ch == "=") {
+            after_equals = 1
+          }
+          continue
+        }
+
+        if (ch == "#") {
+          break
+        }
+
+        if (!saw_value) {
+          if (ch ~ /[[:space:]]/) {
+            continue
+          }
+
+          if (ch != "[") {
+            return 0
+          }
+
+          saw_value = 1
+          return array_balance_delta(line, i)
+        }
+      }
+
+      return 0
     }
 
     {
-      if (starts_multiline_array($0)) {
-        found = 1
+      if (in_multiline_array) {
+        if (is_section($0)) {
+          found = 1
+        }
+
+        array_balance += array_balance_delta($0, 1)
+        if (array_balance <= 0) {
+          in_multiline_array = 0
+          array_balance = 0
+        }
+        next
+      }
+
+      array_balance = multiline_array_balance($0)
+      if (array_balance > 0) {
+        in_multiline_array = 1
       }
     }
 
@@ -285,7 +316,7 @@ reject_unsupported_multiline_arrays() {
       exit found ? 0 : 1
     }
   ' "$config_file"; then
-    fatal "unsupported multiline array in config; rewrite multiline arrays before running configure: $config_file"
+    fatal "unsupported multiline array with section-like entries in config; rewrite that array before running configure: $config_file"
   fi
 }
 
@@ -313,7 +344,7 @@ write_managed_config() {
 
   reject_unusable_config_path "$config_file"
   reject_unsupported_multiline_strings "$config_file"
-  reject_unsupported_multiline_arrays "$config_file"
+  reject_section_like_multiline_arrays "$config_file"
   reject_unsupported_inline_data_table "$config_file"
 
   mkdir -p "$config_dir"
@@ -469,7 +500,7 @@ case "$command_name" in
     config_file="$(chezmoi_config_file)"
     reject_unusable_config_path "$config_file"
     reject_unsupported_multiline_strings "$config_file"
-    reject_unsupported_multiline_arrays "$config_file"
+    reject_section_like_multiline_arrays "$config_file"
     reject_unsupported_inline_data_table "$config_file"
     confirm_existing_config_update "$config_file"
     write_managed_config "$config_file" "$preset"

--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -159,6 +159,89 @@ reject_unsupported_inline_data_table() {
   fi
 }
 
+reject_unsupported_multiline_string_data_markers() {
+  config_file="$1"
+
+  if [ ! -f "$config_file" ]; then
+    return 0
+  fi
+
+  if awk '
+    BEGIN {
+      multiline_literal = sprintf("%c%c%c", 39, 39, 39)
+      multiline_basic = "\"\"\""
+    }
+
+    function marker_count(line, marker, count, position) {
+      count = 0
+      while ((position = index(line, marker)) > 0) {
+        count++
+        line = substr(line, position + length(marker))
+      }
+      return count
+    }
+
+    function is_data_section(line) {
+      return line ~ "^[[:space:]]*\\[[[:space:]]*(data|\"data\"|\047data\047)[[:space:]]*\\][[:space:]]*($|#)"
+    }
+
+    function is_managed_key(line) {
+      return line ~ "^[[:space:]]*(\"enableEditorStack\"|\"enableAiCliTools\"|\"enableDevelopmentWorkspace\"|\"enableMacosDesktopApps\"|\"terrapodPreset\"|\047enableEditorStack\047|\047enableAiCliTools\047|\047enableDevelopmentWorkspace\047|\047enableMacosDesktopApps\047|\047terrapodPreset\047|enableEditorStack|enableAiCliTools|enableDevelopmentWorkspace|enableMacosDesktopApps|terrapodPreset)[[:space:]]*="
+    }
+
+    function is_root_dotted_data_key(line) {
+      return line ~ "^[[:space:]]*(data|\"data\"|\047data\047)[[:space:]]*\\."
+    }
+
+    function is_inline_data_table(line) {
+      return line ~ "^[[:space:]]*(data|\"data\"|\047data\047)[[:space:]]*=[[:space:]]*\\{"
+    }
+
+    function has_data_marker(line) {
+      return is_data_section(line) || is_managed_key(line) || is_root_dotted_data_key(line) || is_inline_data_table(line)
+    }
+
+    function toggle_multiline_if_needed(line, marker) {
+      if (marker_count(line, marker) % 2 == 1) {
+        if (in_multiline) {
+          in_multiline = 0
+          multiline_marker = ""
+        } else {
+          in_multiline = 1
+          multiline_marker = marker
+        }
+      }
+    }
+
+    {
+      if (in_multiline) {
+        if (has_data_marker($0)) {
+          found = 1
+        }
+        toggle_multiline_if_needed($0, multiline_marker)
+        next
+      }
+
+      if (marker_count($0, multiline_literal) % 2 == 1) {
+        in_multiline = 1
+        multiline_marker = multiline_literal
+        next
+      }
+
+      if (marker_count($0, multiline_basic) % 2 == 1) {
+        in_multiline = 1
+        multiline_marker = multiline_basic
+      }
+    }
+
+    END {
+      exit found ? 0 : 1
+    }
+  ' "$config_file"; then
+    fatal "unsupported multiline string containing data-like config lines; rewrite that string or convert the real data values to a [data] table before running configure: $config_file"
+  fi
+}
+
 backup_existing_config() {
   config_file="$1"
 
@@ -182,6 +265,7 @@ write_managed_config() {
   managed_data_file=
 
   reject_unusable_config_path "$config_file"
+  reject_unsupported_multiline_string_data_markers "$config_file"
   reject_unsupported_inline_data_table "$config_file"
 
   mkdir -p "$config_dir"
@@ -336,6 +420,7 @@ case "$command_name" in
 
     config_file="$(chezmoi_config_file)"
     reject_unusable_config_path "$config_file"
+    reject_unsupported_multiline_string_data_markers "$config_file"
     reject_unsupported_inline_data_table "$config_file"
     confirm_existing_config_update "$config_file"
     write_managed_config "$config_file" "$preset"

--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -159,7 +159,7 @@ reject_unsupported_inline_data_table() {
   fi
 }
 
-reject_unsupported_multiline_string_data_markers() {
+reject_unsupported_multiline_strings() {
   config_file="$1"
 
   if [ ! -f "$config_file" ]; then
@@ -172,65 +172,17 @@ reject_unsupported_multiline_string_data_markers() {
       multiline_basic = "\"\"\""
     }
 
-    function marker_count(line, marker, count, position) {
-      count = 0
-      while ((position = index(line, marker)) > 0) {
-        count++
-        line = substr(line, position + length(marker))
-      }
-      return count
+    function is_comment(line) {
+      return line ~ "^[[:space:]]*#"
     }
 
-    function is_data_section(line) {
-      return line ~ "^[[:space:]]*\\[[[:space:]]*(data|\"data\"|\047data\047)[[:space:]]*\\][[:space:]]*($|#)"
-    }
-
-    function is_managed_key(line) {
-      return line ~ "^[[:space:]]*(\"enableEditorStack\"|\"enableAiCliTools\"|\"enableDevelopmentWorkspace\"|\"enableMacosDesktopApps\"|\"terrapodPreset\"|\047enableEditorStack\047|\047enableAiCliTools\047|\047enableDevelopmentWorkspace\047|\047enableMacosDesktopApps\047|\047terrapodPreset\047|enableEditorStack|enableAiCliTools|enableDevelopmentWorkspace|enableMacosDesktopApps|terrapodPreset)[[:space:]]*="
-    }
-
-    function is_root_dotted_data_key(line) {
-      return line ~ "^[[:space:]]*(data|\"data\"|\047data\047)[[:space:]]*\\."
-    }
-
-    function is_inline_data_table(line) {
-      return line ~ "^[[:space:]]*(data|\"data\"|\047data\047)[[:space:]]*=[[:space:]]*\\{"
-    }
-
-    function has_data_marker(line) {
-      return is_data_section(line) || is_managed_key(line) || is_root_dotted_data_key(line) || is_inline_data_table(line)
-    }
-
-    function toggle_multiline_if_needed(line, marker) {
-      if (marker_count(line, marker) % 2 == 1) {
-        if (in_multiline) {
-          in_multiline = 0
-          multiline_marker = ""
-        } else {
-          in_multiline = 1
-          multiline_marker = marker
-        }
-      }
+    function has_multiline_string_marker(line) {
+      return !is_comment(line) && (index(line, multiline_basic) > 0 || index(line, multiline_literal) > 0)
     }
 
     {
-      if (in_multiline) {
-        if (has_data_marker($0)) {
-          found = 1
-        }
-        toggle_multiline_if_needed($0, multiline_marker)
-        next
-      }
-
-      if (marker_count($0, multiline_literal) % 2 == 1) {
-        in_multiline = 1
-        multiline_marker = multiline_literal
-        next
-      }
-
-      if (marker_count($0, multiline_basic) % 2 == 1) {
-        in_multiline = 1
-        multiline_marker = multiline_basic
+      if (has_multiline_string_marker($0)) {
+        found = 1
       }
     }
 
@@ -238,7 +190,7 @@ reject_unsupported_multiline_string_data_markers() {
       exit found ? 0 : 1
     }
   ' "$config_file"; then
-    fatal "unsupported multiline string containing data-like config lines; rewrite that string or convert the real data values to a [data] table before running configure: $config_file"
+    fatal "unsupported multiline string in config; rewrite multiline values before running configure: $config_file"
   fi
 }
 
@@ -265,7 +217,7 @@ write_managed_config() {
   managed_data_file=
 
   reject_unusable_config_path "$config_file"
-  reject_unsupported_multiline_string_data_markers "$config_file"
+  reject_unsupported_multiline_strings "$config_file"
   reject_unsupported_inline_data_table "$config_file"
 
   mkdir -p "$config_dir"
@@ -420,7 +372,7 @@ case "$command_name" in
 
     config_file="$(chezmoi_config_file)"
     reject_unusable_config_path "$config_file"
-    reject_unsupported_multiline_string_data_markers "$config_file"
+    reject_unsupported_multiline_strings "$config_file"
     reject_unsupported_inline_data_table "$config_file"
     confirm_existing_config_update "$config_file"
     write_managed_config "$config_file" "$preset"

--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -7,13 +7,16 @@ Terrapod - Dotfiles Management Tool
 
 Usage:
   terrapod [help|--help|-h]
+  terrapod configure <minimal|development>
   terrapod chezmoi -- <args...>
 
 Commands:
-  help                 Show this help.
-  chezmoi -- <args...> Run raw chezmoi for advanced maintenance.
+  help                                  Show this help.
+  configure <minimal|development>       Expand a Preset into concrete chezmoi data values.
+  chezmoi -- <args...>                  Run raw chezmoi for advanced maintenance.
 
 Examples:
+  terrapod configure development
   terrapod chezmoi -- status
 EOF
 }
@@ -24,11 +27,227 @@ fail_usage() {
   exit 64
 }
 
+fatal() {
+  printf '%s\n' "terrapod: $1" >&2
+  exit 1
+}
+
+file_mode() {
+  path="$1"
+
+  if mode="$(stat -c %a "$path" 2>/dev/null)"; then
+    printf '%s\n' "$mode"
+    return 0
+  fi
+
+  stat -f %Lp "$path"
+}
+
+chezmoi_config_file() {
+  if [ -n "${TERRAPOD_CHEZMOI_CONFIG:-}" ]; then
+    printf '%s\n' "$TERRAPOD_CHEZMOI_CONFIG"
+    return
+  fi
+
+  if [ -n "${XDG_CONFIG_HOME:-}" ]; then
+    printf '%s\n' "$XDG_CONFIG_HOME/chezmoi/chezmoi.toml"
+    return
+  fi
+
+  printf '%s\n' "$HOME/.config/chezmoi/chezmoi.toml"
+}
+
+render_preset_data() {
+  preset="$1"
+
+  case "$preset" in
+    minimal)
+      cat <<'EOF'
+enableEditorStack = false
+enableAiCliTools = false
+enableDevelopmentWorkspace = false
+enableMacosDesktopApps = false
+EOF
+      ;;
+    development)
+      cat <<'EOF'
+enableEditorStack = true
+enableAiCliTools = true
+enableDevelopmentWorkspace = true
+enableMacosDesktopApps = false
+EOF
+      ;;
+    *)
+      fail_usage "unknown Preset: $preset"
+      ;;
+  esac
+}
+
+validate_preset() {
+  render_preset_data "$1" >/dev/null
+}
+
+confirm_existing_config_update() {
+  config_file="$1"
+
+  if [ ! -f "$config_file" ]; then
+    return 0
+  fi
+
+  printf 'Update Terrapod-managed data keys in %s? [y/N] ' "$config_file" >&2
+  IFS= read -r answer || answer=
+
+  case "$answer" in
+    y|Y|yes|YES)
+      return 0
+      ;;
+    *)
+      printf '%s\n' "terrapod: config update cancelled" >&2
+      exit 1
+      ;;
+  esac
+}
+
+reject_unusable_config_path() {
+  config_file="$1"
+
+  if [ -L "$config_file" ] || { [ -e "$config_file" ] && [ ! -f "$config_file" ]; }; then
+    fatal "config path is not a regular file: $config_file"
+  fi
+}
+
+backup_existing_config() {
+  config_file="$1"
+
+  if [ ! -f "$config_file" ]; then
+    return 0
+  fi
+
+  backup_file="$config_file.terrapod-backup-$(date +%Y%m%d%H%M%S)-$$"
+  cp "$config_file" "$backup_file"
+}
+
+cleanup_managed_config_temp() {
+  rm -f "${tmp_file:-}" "${managed_data_file:-}"
+}
+
+write_managed_config() {
+  config_file="$1"
+  preset="$2"
+  config_dir="$(dirname -- "$config_file")"
+  tmp_file=
+  managed_data_file=
+
+  reject_unusable_config_path "$config_file"
+
+  mkdir -p "$config_dir"
+  trap cleanup_managed_config_temp EXIT
+  trap 'cleanup_managed_config_temp; exit 1' HUP INT TERM
+
+  tmp_file="$(mktemp "$config_dir/.terrapod-config.XXXXXX")"
+  managed_data_file="$(mktemp "$config_dir/.terrapod-data.XXXXXX")"
+  render_preset_data "$preset" >"$managed_data_file"
+  backup_existing_config "$config_file"
+
+  if [ -f "$config_file" ]; then
+    config_mode="$(file_mode "$config_file")"
+
+    awk -v managed_data_file="$managed_data_file" '
+      function is_data_section(line) {
+        return line ~ /^[[:space:]]*\[data\][[:space:]]*($|#)/
+      }
+
+      function is_section(line) {
+        return line ~ /^[[:space:]]*(\[[^]]+\]|\[\[[^]]+\]\])[[:space:]]*($|#)/
+      }
+
+      function is_managed_key(line) {
+        return line ~ "^[[:space:]]*(\"enableEditorStack\"|\"enableAiCliTools\"|\"enableDevelopmentWorkspace\"|\"enableMacosDesktopApps\"|\"terrapodPreset\"|\047enableEditorStack\047|\047enableAiCliTools\047|\047enableDevelopmentWorkspace\047|\047enableMacosDesktopApps\047|\047terrapodPreset\047|enableEditorStack|enableAiCliTools|enableDevelopmentWorkspace|enableMacosDesktopApps|terrapodPreset)[[:space:]]*="
+      }
+
+      function print_managed_data(line) {
+        if (!printed_managed_data) {
+          while ((getline line < managed_data_file) > 0) {
+            print line
+          }
+          close(managed_data_file)
+          printed_managed_data = 1
+        }
+      }
+
+      {
+        if (is_data_section($0)) {
+          in_data = 1
+          saw_data = 1
+          print
+          next
+        }
+
+        if (in_data && is_section($0)) {
+          print_managed_data()
+          in_data = 0
+          print
+          next
+        }
+
+        if (in_data && is_managed_key($0)) {
+          next
+        }
+
+        print
+      }
+
+      END {
+        if (in_data) {
+          print_managed_data()
+        } else if (!saw_data) {
+          if (NR > 0) {
+            print ""
+          }
+          print "[data]"
+          print_managed_data()
+        }
+      }
+    ' "$config_file" >"$tmp_file"
+
+    chmod "$config_mode" "$tmp_file"
+  else
+    {
+      printf '%s\n' "[data]"
+      cat "$managed_data_file"
+    } >"$tmp_file"
+  fi
+
+  rm -f "$managed_data_file"
+  mv "$tmp_file" "$config_file"
+  trap - EXIT HUP INT TERM
+}
+
 command_name="${1:-help}"
 
 case "$command_name" in
   help|-h|--help)
     show_help
+    ;;
+  configure)
+    shift
+
+    preset="${1:-}"
+    if [ -z "$preset" ]; then
+      fail_usage "Preset is required"
+    fi
+
+    if [ "$#" -gt 1 ]; then
+      fail_usage "configure accepts exactly one Preset"
+    fi
+
+    validate_preset "$preset"
+
+    config_file="$(chezmoi_config_file)"
+    reject_unusable_config_path "$config_file"
+    confirm_existing_config_update "$config_file"
+    write_managed_config "$config_file" "$preset"
+    printf '%s\n' "Configured Terrapod Preset '$preset' in $config_file"
     ;;
   chezmoi)
     shift

--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -194,6 +194,101 @@ reject_unsupported_multiline_strings() {
   fi
 }
 
+reject_unsupported_multiline_arrays() {
+  config_file="$1"
+
+  if [ ! -f "$config_file" ]; then
+    return 0
+  fi
+
+  if awk '
+    function is_comment(line) {
+      return line ~ "^[[:space:]]*#"
+    }
+
+    function starts_multiline_array(line, i, ch, after_equals, saw_value, in_basic_string, in_literal_string, escaped, balance) {
+      if (is_comment(line)) {
+        return 0
+      }
+
+      for (i = 1; i <= length(line); i++) {
+        ch = substr(line, i, 1)
+
+        if (!after_equals) {
+          if (ch == "=") {
+            after_equals = 1
+          }
+          continue
+        }
+
+        if (in_basic_string) {
+          if (escaped) {
+            escaped = 0
+          } else if (ch == "\\") {
+            escaped = 1
+          } else if (ch == "\"") {
+            in_basic_string = 0
+          }
+          continue
+        }
+
+        if (in_literal_string) {
+          if (ch == "\047") {
+            in_literal_string = 0
+          }
+          continue
+        }
+
+        if (ch == "#") {
+          break
+        }
+
+        if (!saw_value) {
+          if (ch ~ /[[:space:]]/) {
+            continue
+          }
+
+          if (ch != "[") {
+            return 0
+          }
+
+          saw_value = 1
+        }
+
+        if (ch == "\"") {
+          in_basic_string = 1
+          continue
+        }
+
+        if (ch == "\047") {
+          in_literal_string = 1
+          continue
+        }
+
+        if (ch == "[") {
+          balance++
+        } else if (ch == "]") {
+          balance--
+        }
+      }
+
+      return saw_value && balance > 0
+    }
+
+    {
+      if (starts_multiline_array($0)) {
+        found = 1
+      }
+    }
+
+    END {
+      exit found ? 0 : 1
+    }
+  ' "$config_file"; then
+    fatal "unsupported multiline array in config; rewrite multiline arrays before running configure: $config_file"
+  fi
+}
+
 backup_existing_config() {
   config_file="$1"
 
@@ -218,6 +313,7 @@ write_managed_config() {
 
   reject_unusable_config_path "$config_file"
   reject_unsupported_multiline_strings "$config_file"
+  reject_unsupported_multiline_arrays "$config_file"
   reject_unsupported_inline_data_table "$config_file"
 
   mkdir -p "$config_dir"
@@ -373,6 +469,7 @@ case "$command_name" in
     config_file="$(chezmoi_config_file)"
     reject_unusable_config_path "$config_file"
     reject_unsupported_multiline_strings "$config_file"
+    reject_unsupported_multiline_arrays "$config_file"
     reject_unsupported_inline_data_table "$config_file"
     confirm_existing_config_update "$config_file"
     write_managed_config "$config_file" "$preset"

--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -154,7 +154,7 @@ write_managed_config() {
 
     awk -v managed_data_file="$managed_data_file" '
       function is_data_section(line) {
-        return line ~ /^[[:space:]]*\[data\][[:space:]]*($|#)/
+        return line ~ "^[[:space:]]*(\\[data\\]|\\[\"data\"\\]|\\[\047data\047\\])[[:space:]]*($|#)"
       }
 
       function is_section(line) {

--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -7,12 +7,13 @@ Terrapod - Dotfiles Management Tool
 
 Usage:
   terrapod [help|--help|-h]
-  terrapod configure <minimal|development>
+  terrapod configure <minimal|development|workstation>
   terrapod chezmoi -- <args...>
 
 Commands:
   help                                  Show this help.
-  configure <minimal|development>       Expand a Preset into concrete chezmoi data values.
+  configure <minimal|development|workstation>
+                                        Expand a Preset into concrete chezmoi data values.
   chezmoi -- <args...>                  Run raw chezmoi for advanced maintenance.
 
 Examples:
@@ -75,6 +76,14 @@ enableEditorStack = true
 enableAiCliTools = true
 enableDevelopmentWorkspace = true
 enableMacosDesktopApps = false
+EOF
+      ;;
+    workstation)
+      cat <<'EOF'
+enableEditorStack = true
+enableAiCliTools = true
+enableDevelopmentWorkspace = true
+enableMacosDesktopApps = true
 EOF
       ;;
     *)

--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -174,6 +174,14 @@ write_managed_config() {
         return line ~ "^[[:space:]]*(\"enableEditorStack\"|\"enableAiCliTools\"|\"enableDevelopmentWorkspace\"|\"enableMacosDesktopApps\"|\"terrapodPreset\"|\047enableEditorStack\047|\047enableAiCliTools\047|\047enableDevelopmentWorkspace\047|\047enableMacosDesktopApps\047|\047terrapodPreset\047|enableEditorStack|enableAiCliTools|enableDevelopmentWorkspace|enableMacosDesktopApps|terrapodPreset)[[:space:]]*="
       }
 
+      function is_root_dotted_data_key(line) {
+        return line ~ "^[[:space:]]*(data|\"data\"|\047data\047)[[:space:]]*\\."
+      }
+
+      function is_root_dotted_managed_key(line) {
+        return line ~ "^[[:space:]]*(data|\"data\"|\047data\047)[[:space:]]*\\.[[:space:]]*(\"enableEditorStack\"|\"enableAiCliTools\"|\"enableDevelopmentWorkspace\"|\"enableMacosDesktopApps\"|\"terrapodPreset\"|\047enableEditorStack\047|\047enableAiCliTools\047|\047enableDevelopmentWorkspace\047|\047enableMacosDesktopApps\047|\047terrapodPreset\047|enableEditorStack|enableAiCliTools|enableDevelopmentWorkspace|enableMacosDesktopApps|terrapodPreset)[[:space:]]*="
+      }
+
       function print_managed_data(line) {
         if (!printed_managed_data) {
           while ((getline line < managed_data_file) > 0) {
@@ -184,10 +192,45 @@ write_managed_config() {
         }
       }
 
+      function print_managed_dotted_data(line) {
+        if (!printed_managed_data) {
+          while ((getline line < managed_data_file) > 0) {
+            print "data." line
+          }
+          close(managed_data_file)
+          printed_managed_data = 1
+        }
+      }
+
+      BEGIN {
+        in_root = 1
+      }
+
       {
+        if (in_root && is_root_dotted_managed_key($0)) {
+          saw_root_data = 1
+          next
+        }
+
+        if (in_root && is_root_dotted_data_key($0)) {
+          saw_root_data = 1
+          print
+          next
+        }
+
         if (is_data_section($0)) {
+          in_root = 0
           in_data = 1
           saw_data = 1
+          print
+          next
+        }
+
+        if (in_root && is_section($0)) {
+          if (saw_root_data) {
+            print_managed_dotted_data()
+          }
+          in_root = 0
           print
           next
         }
@@ -210,11 +253,15 @@ write_managed_config() {
         if (in_data) {
           print_managed_data()
         } else if (!saw_data) {
-          if (NR > 0) {
-            print ""
+          if (saw_root_data) {
+            print_managed_dotted_data()
+          } else {
+            if (NR > 0) {
+              print ""
+            }
+            print "[data]"
+            print_managed_data()
           }
-          print "[data]"
-          print_managed_data()
         }
       }
     ' "$config_file" >"$tmp_file"

--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -125,6 +125,40 @@ reject_unusable_config_path() {
   fi
 }
 
+reject_unsupported_inline_data_table() {
+  config_file="$1"
+
+  if [ ! -f "$config_file" ]; then
+    return 0
+  fi
+
+  if awk '
+    function is_section(line) {
+      return line ~ /^[[:space:]]*(\[[^]]+\]|\[\[[^]]+\]\])[[:space:]]*($|#)/
+    }
+
+    function is_inline_data_table(line) {
+      return line ~ "^[[:space:]]*(data|\"data\"|\047data\047)[[:space:]]*=[[:space:]]*\\{"
+    }
+
+    {
+      if (is_section($0)) {
+        exit
+      }
+
+      if (is_inline_data_table($0)) {
+        found = 1
+      }
+    }
+
+    END {
+      exit found ? 0 : 1
+    }
+  ' "$config_file"; then
+    fatal "unsupported inline data table in config; rewrite data = {...} as a [data] table before running configure: $config_file"
+  fi
+}
+
 backup_existing_config() {
   config_file="$1"
 
@@ -148,6 +182,7 @@ write_managed_config() {
   managed_data_file=
 
   reject_unusable_config_path "$config_file"
+  reject_unsupported_inline_data_table "$config_file"
 
   mkdir -p "$config_dir"
   trap cleanup_managed_config_temp EXIT
@@ -301,6 +336,7 @@ case "$command_name" in
 
     config_file="$(chezmoi_config_file)"
     reject_unusable_config_path "$config_file"
+    reject_unsupported_inline_data_table "$config_file"
     confirm_existing_config_update "$config_file"
     write_managed_config "$config_file" "$preset"
     printf '%s\n' "Configured Terrapod Preset '$preset' in $config_file"

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -187,6 +187,16 @@ assert_contains \
 
 assert_contains \
   "$help_output" \
+  "terrapod configure <minimal|development>" \
+  "Terrapod help documents Preset configuration"
+
+assert_contains \
+  "$help_output" \
+  "Expand a Preset into concrete chezmoi data values." \
+  "Terrapod help describes Preset configuration"
+
+assert_contains \
+  "$help_output" \
   "Run raw chezmoi for advanced maintenance." \
   "Terrapod help describes raw chezmoi as advanced maintenance"
 

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -187,7 +187,7 @@ assert_contains \
 
 assert_contains \
   "$help_output" \
-  "terrapod configure <minimal|development>" \
+  "terrapod configure <minimal|development|workstation>" \
   "Terrapod help documents Preset configuration"
 
 assert_contains \

--- a/tests/terrapod_config_test.sh
+++ b/tests/terrapod_config_test.sh
@@ -550,6 +550,37 @@ if [ "$fake_stat_mode" != "600" ]; then
 fi
 pass "existing update preserves mode with GNU-first stat fallback"
 
+inline_table_home="$tmp_dir/inline-table-home"
+inline_table_xdg="$tmp_dir/inline-table-xdg"
+inline_table_config="$inline_table_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$inline_table_home" "$(dirname "$inline_table_config")"
+
+cat >"$inline_table_config" <<'TOML'
+data = { email = "minu@example.com", enableEditorStack = false }
+
+[sourceState]
+branch = "main"
+TOML
+cp "$inline_table_config" "$tmp_dir/inline-table-before.toml"
+
+if printf '%s\n' "y" |
+  HOME="$inline_table_home" XDG_CONFIG_HOME="$inline_table_xdg" sh "$terrapod" configure development >"$tmp_dir/inline-table.out" 2>"$tmp_dir/inline-table.err"; then
+  fail "inline data table config is rejected instead of rewritten"
+fi
+pass "inline data table config is rejected instead of rewritten"
+
+assert_contains "$tmp_dir/inline-table.err" "unsupported inline data table" "inline data table rejection explains unsupported format"
+assert_not_contains "$tmp_dir/inline-table.err" "Update Terrapod-managed data keys" "inline data table rejection does not prompt before failing"
+assert_not_contains "$tmp_dir/inline-table.out" "Configured Terrapod Preset" "inline data table rejection does not report success"
+
+if ! cmp -s "$inline_table_config" "$tmp_dir/inline-table-before.toml"; then
+  fail "inline data table rejection leaves existing config unchanged"
+fi
+pass "inline data table rejection leaves existing config unchanged"
+
+assert_backup_count "$inline_table_config" 0 "inline data table rejection does not create a backup"
+assert_no_terrapod_temp_files "$inline_table_config" "inline data table rejection leaves no Terrapod temp files"
+
 decline_home="$tmp_dir/decline-home"
 decline_xdg="$tmp_dir/decline-xdg"
 decline_config="$decline_xdg/chezmoi/chezmoi.toml"

--- a/tests/terrapod_config_test.sh
+++ b/tests/terrapod_config_test.sh
@@ -581,6 +581,41 @@ pass "inline data table rejection leaves existing config unchanged"
 assert_backup_count "$inline_table_config" 0 "inline data table rejection does not create a backup"
 assert_no_terrapod_temp_files "$inline_table_config" "inline data table rejection leaves no Terrapod temp files"
 
+multiline_string_home="$tmp_dir/multiline-string-home"
+multiline_string_xdg="$tmp_dir/multiline-string-xdg"
+multiline_string_config="$multiline_string_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$multiline_string_home" "$(dirname "$multiline_string_config")"
+
+cat >"$multiline_string_config" <<'TOML'
+notes = '''
+[data]
+enableEditorStack = false
+keep this line in the string
+'''
+
+[sourceState]
+branch = "main"
+TOML
+cp "$multiline_string_config" "$tmp_dir/multiline-string-before.toml"
+
+if printf '%s\n' "y" |
+  HOME="$multiline_string_home" XDG_CONFIG_HOME="$multiline_string_xdg" sh "$terrapod" configure development >"$tmp_dir/multiline-string.out" 2>"$tmp_dir/multiline-string.err"; then
+  fail "multiline string with data-like content is rejected instead of rewritten"
+fi
+pass "multiline string with data-like content is rejected instead of rewritten"
+
+assert_contains "$tmp_dir/multiline-string.err" "unsupported multiline string" "multiline string rejection explains unsupported format"
+assert_not_contains "$tmp_dir/multiline-string.err" "Update Terrapod-managed data keys" "multiline string rejection does not prompt before failing"
+assert_not_contains "$tmp_dir/multiline-string.out" "Configured Terrapod Preset" "multiline string rejection does not report success"
+
+if ! cmp -s "$multiline_string_config" "$tmp_dir/multiline-string-before.toml"; then
+  fail "multiline string rejection leaves existing config unchanged"
+fi
+pass "multiline string rejection leaves existing config unchanged"
+
+assert_backup_count "$multiline_string_config" 0 "multiline string rejection does not create a backup"
+assert_no_terrapod_temp_files "$multiline_string_config" "multiline string rejection leaves no Terrapod temp files"
+
 decline_home="$tmp_dir/decline-home"
 decline_xdg="$tmp_dir/decline-xdg"
 decline_config="$decline_xdg/chezmoi/chezmoi.toml"

--- a/tests/terrapod_config_test.sh
+++ b/tests/terrapod_config_test.sh
@@ -51,7 +51,7 @@ extract_data_section() {
 
   awk '
     function is_data_section(line) {
-      return line ~ "^[[:space:]]*(\\[data\\]|\\[\"data\"\\]|\\[\047data\047\\])[[:space:]]*($|#)"
+      return line ~ "^[[:space:]]*\\[[[:space:]]*(data|\"data\"|\047data\047)[[:space:]]*\\][[:space:]]*($|#)"
     }
 
     function is_section(line) {
@@ -369,6 +369,33 @@ assert_data_key_once_with_value "$quoted_table_config" "enableAiCliTools" "true"
 assert_data_key_once_with_value "$quoted_table_config" "enableDevelopmentWorkspace" "true" "quoted data table update writes Development Workspace in data"
 assert_data_key_once_with_value "$quoted_table_config" "enableMacosDesktopApps" "false" "quoted data table update writes macOS desktop-app boundary in data"
 assert_not_contains "$quoted_table_config" "terrapodPreset" "quoted data table update removes stale dynamic Preset key"
+
+spaced_table_home="$tmp_dir/spaced-table-home"
+spaced_table_xdg="$tmp_dir/spaced-table-xdg"
+spaced_table_config="$spaced_table_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$spaced_table_home" "$(dirname "$spaced_table_config")"
+
+cat >"$spaced_table_config" <<'TOML'
+[ data ]
+keepSpacedTable = "preserve"
+enableEditorStack = false
+terrapodPreset = "minimal"
+
+[sourceState]
+branch = "main"
+TOML
+
+run_terrapod_configure development "y" "$spaced_table_home" "$spaced_table_xdg"
+
+assert_contains "$spaced_table_config" "[ data ]" "spaced data table header is preserved"
+assert_not_contains "$spaced_table_config" "[data]" "spaced data table update does not append a duplicate bare data table"
+assert_contains "$spaced_table_config" "keepSpacedTable = \"preserve\"" "spaced data table update preserves unrelated data values"
+assert_contains "$spaced_table_config" "branch = \"main\"" "spaced data table update preserves later sections"
+assert_data_key_once_with_value "$spaced_table_config" "enableEditorStack" "true" "spaced data table update writes Editor Stack in data"
+assert_data_key_once_with_value "$spaced_table_config" "enableAiCliTools" "true" "spaced data table update writes AI Tool Stack in data"
+assert_data_key_once_with_value "$spaced_table_config" "enableDevelopmentWorkspace" "true" "spaced data table update writes Development Workspace in data"
+assert_data_key_once_with_value "$spaced_table_config" "enableMacosDesktopApps" "false" "spaced data table update writes macOS desktop-app boundary in data"
+assert_not_contains "$spaced_table_config" "terrapodPreset" "spaced data table update removes stale dynamic Preset key"
 
 dotted_home="$tmp_dir/dotted-home"
 dotted_xdg="$tmp_dir/dotted-xdg"

--- a/tests/terrapod_config_test.sh
+++ b/tests/terrapod_config_test.sh
@@ -51,7 +51,7 @@ extract_data_section() {
 
   awk '
     function is_data_section(line) {
-      return line ~ /^[[:space:]]*\[data\][[:space:]]*($|#)/
+      return line ~ "^[[:space:]]*(\\[data\\]|\\[\"data\"\\]|\\[\047data\047\\])[[:space:]]*($|#)"
     }
 
     function is_section(line) {
@@ -323,6 +323,33 @@ assert_data_key_once_with_value "$existing_config" "enableDevelopmentWorkspace" 
 assert_data_key_once_with_value "$existing_config" "enableMacosDesktopApps" "false" "development Preset leaves macOS App Groups disabled exactly once in data"
 assert_not_contains "$existing_config" "terrapodPreset" "existing update removes stale dynamic Preset key"
 assert_single_backup_matches "$existing_config" "$tmp_dir/existing-before.toml" "existing update creates one backup before changing managed keys"
+
+quoted_table_home="$tmp_dir/quoted-table-home"
+quoted_table_xdg="$tmp_dir/quoted-table-xdg"
+quoted_table_config="$quoted_table_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$quoted_table_home" "$(dirname "$quoted_table_config")"
+
+cat >"$quoted_table_config" <<'TOML'
+["data"]
+keepQuotedTable = "preserve"
+enableEditorStack = false
+terrapodPreset = "minimal"
+
+[sourceState]
+branch = "main"
+TOML
+
+run_terrapod_configure development "y" "$quoted_table_home" "$quoted_table_xdg"
+
+assert_contains "$quoted_table_config" "[\"data\"]" "quoted data table header is preserved"
+assert_not_contains "$quoted_table_config" "[data]" "quoted data table update does not append a duplicate bare data table"
+assert_contains "$quoted_table_config" "keepQuotedTable = \"preserve\"" "quoted data table update preserves unrelated data values"
+assert_contains "$quoted_table_config" "branch = \"main\"" "quoted data table update preserves later sections"
+assert_data_key_once_with_value "$quoted_table_config" "enableEditorStack" "true" "quoted data table update writes Editor Stack in data"
+assert_data_key_once_with_value "$quoted_table_config" "enableAiCliTools" "true" "quoted data table update writes AI Tool Stack in data"
+assert_data_key_once_with_value "$quoted_table_config" "enableDevelopmentWorkspace" "true" "quoted data table update writes Development Workspace in data"
+assert_data_key_once_with_value "$quoted_table_config" "enableMacosDesktopApps" "false" "quoted data table update writes macOS desktop-app boundary in data"
+assert_not_contains "$quoted_table_config" "terrapodPreset" "quoted data table update removes stale dynamic Preset key"
 
 quoted_home="$tmp_dir/quoted-home"
 quoted_xdg="$tmp_dir/quoted-xdg"

--- a/tests/terrapod_config_test.sh
+++ b/tests/terrapod_config_test.sh
@@ -616,6 +616,74 @@ pass "multiline string rejection leaves existing config unchanged"
 assert_backup_count "$multiline_string_config" 0 "multiline string rejection does not create a backup"
 assert_no_terrapod_temp_files "$multiline_string_config" "multiline string rejection leaves no Terrapod temp files"
 
+dotted_multiline_home="$tmp_dir/dotted-multiline-home"
+dotted_multiline_xdg="$tmp_dir/dotted-multiline-xdg"
+dotted_multiline_config="$dotted_multiline_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$dotted_multiline_home" "$(dirname "$dotted_multiline_config")"
+
+cat >"$dotted_multiline_config" <<'TOML'
+data.email = "minu@example.com"
+data.enableEditorStack = false
+notes = '''
+[profile]
+keep this line in the string
+'''
+TOML
+cp "$dotted_multiline_config" "$tmp_dir/dotted-multiline-before.toml"
+
+if printf '%s\n' "y" |
+  HOME="$dotted_multiline_home" XDG_CONFIG_HOME="$dotted_multiline_xdg" sh "$terrapod" configure development >"$tmp_dir/dotted-multiline.out" 2>"$tmp_dir/dotted-multiline.err"; then
+  fail "dotted data update rejects multiline strings before injecting managed keys"
+fi
+pass "dotted data update rejects multiline strings before injecting managed keys"
+
+assert_contains "$tmp_dir/dotted-multiline.err" "unsupported multiline string" "dotted multiline rejection explains unsupported format"
+assert_not_contains "$tmp_dir/dotted-multiline.err" "Update Terrapod-managed data keys" "dotted multiline rejection does not prompt before failing"
+assert_not_contains "$tmp_dir/dotted-multiline.out" "Configured Terrapod Preset" "dotted multiline rejection does not report success"
+
+if ! cmp -s "$dotted_multiline_config" "$tmp_dir/dotted-multiline-before.toml"; then
+  fail "dotted multiline rejection leaves existing config unchanged"
+fi
+pass "dotted multiline rejection leaves existing config unchanged"
+
+assert_backup_count "$dotted_multiline_config" 0 "dotted multiline rejection does not create a backup"
+assert_no_terrapod_temp_files "$dotted_multiline_config" "dotted multiline rejection leaves no Terrapod temp files"
+
+dotted_array_multiline_home="$tmp_dir/dotted-array-multiline-home"
+dotted_array_multiline_xdg="$tmp_dir/dotted-array-multiline-xdg"
+dotted_array_multiline_config="$dotted_array_multiline_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$dotted_array_multiline_home" "$(dirname "$dotted_array_multiline_config")"
+
+cat >"$dotted_array_multiline_config" <<'TOML'
+data.email = "minu@example.com"
+data.enableEditorStack = false
+notes = [
+'''
+[profile]
+keep this line in the string
+'''
+]
+TOML
+cp "$dotted_array_multiline_config" "$tmp_dir/dotted-array-multiline-before.toml"
+
+if printf '%s\n' "y" |
+  HOME="$dotted_array_multiline_home" XDG_CONFIG_HOME="$dotted_array_multiline_xdg" sh "$terrapod" configure development >"$tmp_dir/dotted-array-multiline.out" 2>"$tmp_dir/dotted-array-multiline.err"; then
+  fail "dotted data update rejects multiline strings in arrays before injecting managed keys"
+fi
+pass "dotted data update rejects multiline strings in arrays before injecting managed keys"
+
+assert_contains "$tmp_dir/dotted-array-multiline.err" "unsupported multiline string" "dotted array multiline rejection explains unsupported format"
+assert_not_contains "$tmp_dir/dotted-array-multiline.err" "Update Terrapod-managed data keys" "dotted array multiline rejection does not prompt before failing"
+assert_not_contains "$tmp_dir/dotted-array-multiline.out" "Configured Terrapod Preset" "dotted array multiline rejection does not report success"
+
+if ! cmp -s "$dotted_array_multiline_config" "$tmp_dir/dotted-array-multiline-before.toml"; then
+  fail "dotted array multiline rejection leaves existing config unchanged"
+fi
+pass "dotted array multiline rejection leaves existing config unchanged"
+
+assert_backup_count "$dotted_array_multiline_config" 0 "dotted array multiline rejection does not create a backup"
+assert_no_terrapod_temp_files "$dotted_array_multiline_config" "dotted array multiline rejection leaves no Terrapod temp files"
+
 decline_home="$tmp_dir/decline-home"
 decline_xdg="$tmp_dir/decline-xdg"
 decline_config="$decline_xdg/chezmoi/chezmoi.toml"

--- a/tests/terrapod_config_test.sh
+++ b/tests/terrapod_config_test.sh
@@ -501,6 +501,33 @@ pass "existing update preserves config file mode"
 
 assert_no_terrapod_temp_files "$array_config" "successful array-table update cleans Terrapod temp files"
 
+signers_home="$tmp_dir/signers-home"
+signers_xdg="$tmp_dir/signers-xdg"
+signers_config="$signers_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$signers_home" "$(dirname "$signers_config")"
+
+cat >"$signers_config" <<'TOML'
+[data]
+gitAllowedSigners = [
+  "name@company.com ssh-ed25519 AAAA_COMPANY_PUBLIC_KEY company",
+]
+enableEditorStack = false
+enableAiCliTools = false
+
+[sourceState]
+branch = "main"
+TOML
+
+run_terrapod_configure development "y" "$signers_home" "$signers_xdg"
+
+assert_contains "$signers_config" "gitAllowedSigners = [" "documented signer array update preserves array header"
+assert_contains "$signers_config" "name@company.com ssh-ed25519 AAAA_COMPANY_PUBLIC_KEY company" "documented signer array update preserves signer value"
+assert_data_key_once_with_value "$signers_config" "enableEditorStack" "true" "documented signer array update writes Editor Stack in data"
+assert_data_key_once_with_value "$signers_config" "enableAiCliTools" "true" "documented signer array update writes AI Tool Stack in data"
+assert_data_key_once_with_value "$signers_config" "enableDevelopmentWorkspace" "true" "documented signer array update writes Development Workspace in data"
+assert_data_key_once_with_value "$signers_config" "enableMacosDesktopApps" "false" "documented signer array update writes macOS desktop-app boundary in data"
+assert_contains "$signers_config" "branch = \"main\"" "documented signer array update preserves later sections"
+
 multiline_array_home="$tmp_dir/multiline-array-home"
 multiline_array_xdg="$tmp_dir/multiline-array-xdg"
 multiline_array_config="$multiline_array_xdg/chezmoi/chezmoi.toml"
@@ -522,21 +549,21 @@ cp "$multiline_array_config" "$tmp_dir/multiline-array-before.toml"
 
 if printf '%s\n' "y" |
   HOME="$multiline_array_home" XDG_CONFIG_HOME="$multiline_array_xdg" sh "$terrapod" configure development >"$tmp_dir/multiline-array.out" 2>"$tmp_dir/multiline-array.err"; then
-  fail "multiline array config is rejected before rewriting"
+  fail "section-like multiline array config is rejected before rewriting"
 fi
-pass "multiline array config is rejected before rewriting"
+pass "section-like multiline array config is rejected before rewriting"
 
-assert_contains "$tmp_dir/multiline-array.err" "unsupported multiline array" "multiline array rejection explains unsupported format"
-assert_not_contains "$tmp_dir/multiline-array.err" "Update Terrapod-managed data keys" "multiline array rejection does not prompt before failing"
-assert_not_contains "$tmp_dir/multiline-array.out" "Configured Terrapod Preset" "multiline array rejection does not report success"
+assert_contains "$tmp_dir/multiline-array.err" "unsupported multiline array" "section-like multiline array rejection explains unsupported format"
+assert_not_contains "$tmp_dir/multiline-array.err" "Update Terrapod-managed data keys" "section-like multiline array rejection does not prompt before failing"
+assert_not_contains "$tmp_dir/multiline-array.out" "Configured Terrapod Preset" "section-like multiline array rejection does not report success"
 
 if ! cmp -s "$multiline_array_config" "$tmp_dir/multiline-array-before.toml"; then
-  fail "multiline array rejection leaves existing config unchanged"
+  fail "section-like multiline array rejection leaves existing config unchanged"
 fi
-pass "multiline array rejection leaves existing config unchanged"
+pass "section-like multiline array rejection leaves existing config unchanged"
 
-assert_backup_count "$multiline_array_config" 0 "multiline array rejection does not create a backup"
-assert_no_terrapod_temp_files "$multiline_array_config" "multiline array rejection leaves no Terrapod temp files"
+assert_backup_count "$multiline_array_config" 0 "section-like multiline array rejection does not create a backup"
+assert_no_terrapod_temp_files "$multiline_array_config" "section-like multiline array rejection leaves no Terrapod temp files"
 
 fake_stat_home="$tmp_dir/fake-stat-home"
 fake_stat_xdg="$tmp_dir/fake-stat-xdg"

--- a/tests/terrapod_config_test.sh
+++ b/tests/terrapod_config_test.sh
@@ -1,0 +1,587 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT INT TERM
+
+fail() {
+  printf '%s\n' "not ok - $1" >&2
+  exit 1
+}
+
+pass() {
+  printf '%s\n' "ok - $1"
+}
+
+assert_contains() {
+  file="$1"
+  needle="$2"
+  message="$3"
+
+  if ! grep -F "$needle" "$file" >/dev/null; then
+    printf '%s\n' "file contents:" >&2
+    sed 's/^/  /' "$file" >&2
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
+assert_not_contains() {
+  file="$1"
+  needle="$2"
+  message="$3"
+
+  if grep -F "$needle" "$file" >/dev/null; then
+    printf '%s\n' "file contents:" >&2
+    sed 's/^/  /' "$file" >&2
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
+extract_data_section() {
+  file="$1"
+
+  awk '
+    function is_data_section(line) {
+      return line ~ /^[[:space:]]*\[data\][[:space:]]*($|#)/
+    }
+
+    function is_section(line) {
+      return line ~ /^[[:space:]]*(\[[^]]+\]|\[\[[^]]+\]\])[[:space:]]*($|#)/
+    }
+
+    {
+      if (is_data_section($0)) {
+        in_data = 1
+        print
+        next
+      }
+
+      if (in_data && is_section($0)) {
+        exit
+      }
+
+      if (in_data) {
+        print
+      }
+    }
+  ' "$file"
+}
+
+assert_data_key_once_with_value() {
+  file="$1"
+  key="$2"
+  expected_value="$3"
+  message="$4"
+  expected_line="$key = $expected_value"
+  data_section="$(extract_data_section "$file")"
+
+  actual_count="$(
+    printf '%s\n' "$data_section" |
+      grep -E "^[[:space:]]*(\"$key\"|'$key'|$key)[[:space:]]*=" |
+      wc -l |
+      tr -d ' '
+  )"
+
+  if [ "$actual_count" -ne 1 ]; then
+    printf '%s\n' "file contents:" >&2
+    sed 's/^/  /' "$file" >&2
+    printf '%s\n' "data section:" >&2
+    printf '%s\n' "$data_section" | sed 's/^/  /' >&2
+    fail "$message; expected one $key entry in [data], found $actual_count"
+  fi
+
+  if ! printf '%s\n' "$data_section" | grep -Fx "$expected_line" >/dev/null; then
+    printf '%s\n' "file contents:" >&2
+    sed 's/^/  /' "$file" >&2
+    printf '%s\n' "data section:" >&2
+    printf '%s\n' "$data_section" | sed 's/^/  /' >&2
+    fail "$message; expected $expected_line in [data]"
+  fi
+
+  pass "$message"
+}
+
+assert_lines_after_header_not_contains() {
+  file="$1"
+  header="$2"
+  needle="$3"
+  message="$4"
+
+  if awk -v header="$header" '
+    found {
+      print
+    }
+
+    $0 == header {
+      found = 1
+    }
+  ' "$file" | grep -F "$needle" >/dev/null; then
+    printf '%s\n' "file contents:" >&2
+    sed 's/^/  /' "$file" >&2
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
+file_mode() {
+  path="$1"
+
+  if mode="$(stat -c %a "$path" 2>/dev/null)"; then
+    printf '%s\n' "$mode"
+    return 0
+  fi
+
+  stat -f %Lp "$path"
+}
+
+assert_backup_count() {
+  config_file="$1"
+  expected_count="$2"
+  message="$3"
+
+  set -- "$config_file".terrapod-backup-*
+  if [ "$1" = "$config_file.terrapod-backup-*" ]; then
+    actual_count=0
+  else
+    actual_count=$#
+  fi
+
+  if [ "$actual_count" -ne "$expected_count" ]; then
+    fail "$message; expected $expected_count backup(s), found $actual_count"
+  fi
+
+  pass "$message"
+}
+
+assert_single_backup_matches() {
+  config_file="$1"
+  expected_file="$2"
+  message="$3"
+
+  set -- "$config_file".terrapod-backup-*
+  if [ "$1" = "$config_file.terrapod-backup-*" ]; then
+    fail "$message; expected one backup, found 0"
+  fi
+
+  if [ "$#" -ne 1 ]; then
+    fail "$message; expected one backup, found $#"
+  fi
+
+  if ! cmp -s "$1" "$expected_file"; then
+    printf '%s\n' "expected backup contents:" >&2
+    sed 's/^/  /' "$expected_file" >&2
+    printf '%s\n' "actual backup contents:" >&2
+    sed 's/^/  /' "$1" >&2
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
+assert_no_terrapod_temp_files() {
+  config_file="$1"
+  message="$2"
+  config_dir="$(dirname -- "$config_file")"
+  found_file="$tmp_dir/found-temp-files"
+
+  find "$config_dir" \
+    \( -name '.terrapod-config.*' \
+    -o -name '.terrapod-data.*' \
+    -o -name "$(basename -- "$config_file").terrapod-tmp-*" \
+    -o -name "$(basename -- "$config_file").terrapod-data-*" \) \
+    -print >"$found_file"
+
+  if [ -s "$found_file" ]; then
+    printf '%s\n' "unexpected temp files:" >&2
+    sed 's/^/  /' "$found_file" >&2
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
+assert_no_terrapod_artifacts_near_path() {
+  path="$1"
+  message="$2"
+  path_dir="$(dirname -- "$path")"
+  path_base="$(basename -- "$path")"
+  found_file="$tmp_dir/found-artifacts"
+
+  find "$path_dir" \
+    \( -name '.terrapod-config.*' \
+    -o -name '.terrapod-data.*' \
+    -o -name "$path_base.terrapod-backup-*" \
+    -o -name "$path_base.terrapod-tmp-*" \
+    -o -name "$path_base.terrapod-data-*" \) \
+    -print >"$found_file"
+
+  if [ -s "$found_file" ]; then
+    printf '%s\n' "unexpected Terrapod artifacts:" >&2
+    sed 's/^/  /' "$found_file" >&2
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
+run_terrapod_configure() {
+  preset="$1"
+  input="${2:-}"
+  home_dir="$3"
+  xdg_config_home="$4"
+
+  if [ -n "$input" ]; then
+    printf '%s\n' "$input" |
+      TERRAPOD_CHEZMOI_CONFIG= HOME="$home_dir" XDG_CONFIG_HOME="$xdg_config_home" sh "$terrapod" configure "$preset"
+  else
+    TERRAPOD_CHEZMOI_CONFIG= HOME="$home_dir" XDG_CONFIG_HOME="$xdg_config_home" sh "$terrapod" configure "$preset" </dev/null
+  fi
+}
+
+terrapod="$repo_root/dot_local/bin/executable_terrapod"
+
+new_home="$tmp_dir/new-home"
+new_xdg="$tmp_dir/new-xdg"
+new_config="$new_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$new_home"
+
+run_terrapod_configure minimal "" "$new_home" "$new_xdg"
+
+if [ ! -f "$new_config" ]; then
+  fail "minimal Preset creates a chezmoi config file"
+fi
+pass "minimal Preset creates a chezmoi config file"
+
+assert_contains "$new_config" "[data]" "new config contains a data section"
+assert_data_key_once_with_value "$new_config" "enableEditorStack" "false" "minimal Preset disables Optional Editor Stack exactly once in data"
+assert_data_key_once_with_value "$new_config" "enableAiCliTools" "false" "minimal Preset disables Optional AI Tool Stack exactly once in data"
+assert_data_key_once_with_value "$new_config" "enableDevelopmentWorkspace" "false" "minimal Preset disables Optional Development Workspace exactly once in data"
+assert_data_key_once_with_value "$new_config" "enableMacosDesktopApps" "false" "minimal Preset disables macOS App Groups through the desktop-app boundary exactly once in data"
+assert_not_contains "$new_config" "terrapodPreset" "minimal Preset stores concrete values instead of a dynamic Preset"
+assert_backup_count "$new_config" 0 "new config creation does not create a backup"
+
+default_env_home="$tmp_dir/default-env-home"
+default_env_xdg="$tmp_dir/default-env-xdg"
+default_env_config="$default_env_xdg/chezmoi/chezmoi.toml"
+escape_config="$tmp_dir/escape.toml"
+mkdir -p "$default_env_home"
+
+export TERRAPOD_CHEZMOI_CONFIG="$escape_config"
+run_terrapod_configure minimal "" "$default_env_home" "$default_env_xdg"
+unset TERRAPOD_CHEZMOI_CONFIG
+
+if [ ! -f "$default_env_config" ]; then
+  fail "default-path configure ignores exported TERRAPOD_CHEZMOI_CONFIG"
+fi
+pass "default-path configure ignores exported TERRAPOD_CHEZMOI_CONFIG"
+
+if [ -e "$escape_config" ]; then
+  fail "default-path configure does not write to exported TERRAPOD_CHEZMOI_CONFIG"
+fi
+pass "default-path configure does not write to exported TERRAPOD_CHEZMOI_CONFIG"
+
+existing_home="$tmp_dir/existing-home"
+existing_xdg="$tmp_dir/existing-xdg"
+existing_config="$existing_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$existing_home" "$(dirname "$existing_config")"
+
+cat >"$existing_config" <<'TOML'
+[sourceState]
+branch = "main"
+
+[data]
+email = "minu@example.com"
+enableEditorStack = false
+enableAiCliTools = false
+enableDevelopmentWorkspace = false
+enableMacosDesktopApps = true
+terrapodPreset = "minimal"
+
+[edit]
+command = "nvim"
+TOML
+cp "$existing_config" "$tmp_dir/existing-before.toml"
+
+run_terrapod_configure development "y" "$existing_home" "$existing_xdg"
+
+assert_contains "$existing_config" "branch = \"main\"" "existing update preserves unrelated sourceState values"
+assert_contains "$existing_config" "email = \"minu@example.com\"" "existing update preserves unrelated data values"
+assert_contains "$existing_config" "command = \"nvim\"" "existing update preserves unrelated later sections"
+assert_data_key_once_with_value "$existing_config" "enableEditorStack" "true" "development Preset enables Optional Editor Stack exactly once in data"
+assert_data_key_once_with_value "$existing_config" "enableAiCliTools" "true" "development Preset enables Optional AI Tool Stack exactly once in data"
+assert_data_key_once_with_value "$existing_config" "enableDevelopmentWorkspace" "true" "development Preset enables Optional Development Workspace exactly once in data"
+assert_data_key_once_with_value "$existing_config" "enableMacosDesktopApps" "false" "development Preset leaves macOS App Groups disabled exactly once in data"
+assert_not_contains "$existing_config" "terrapodPreset" "existing update removes stale dynamic Preset key"
+assert_single_backup_matches "$existing_config" "$tmp_dir/existing-before.toml" "existing update creates one backup before changing managed keys"
+
+quoted_home="$tmp_dir/quoted-home"
+quoted_xdg="$tmp_dir/quoted-xdg"
+quoted_config="$quoted_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$quoted_home" "$(dirname "$quoted_config")"
+
+cat >"$quoted_config" <<'TOML'
+[data]
+'enableEditorStack' = false
+'enableAiCliTools' = false
+'enableDevelopmentWorkspace' = false
+'enableMacosDesktopApps' = true
+'terrapodPreset' = "minimal"
+keepLiteral = "preserve"
+TOML
+
+run_terrapod_configure development "y" "$quoted_home" "$quoted_xdg"
+
+assert_data_key_once_with_value "$quoted_config" "enableEditorStack" "true" "quoted managed key update writes one Editor Stack value in data"
+assert_data_key_once_with_value "$quoted_config" "enableAiCliTools" "true" "quoted managed key update writes one AI Tool Stack value in data"
+assert_data_key_once_with_value "$quoted_config" "enableDevelopmentWorkspace" "true" "quoted managed key update writes one Development Workspace value in data"
+assert_data_key_once_with_value "$quoted_config" "enableMacosDesktopApps" "false" "quoted managed key update writes one macOS desktop-app boundary value in data"
+assert_not_contains "$quoted_config" "\"enableEditorStack\"" "quoted managed key update removes quoted Editor Stack key"
+assert_not_contains "$quoted_config" "\"enableAiCliTools\"" "quoted managed key update removes quoted AI Tool Stack key"
+assert_not_contains "$quoted_config" "\"enableDevelopmentWorkspace\"" "quoted managed key update removes quoted Development Workspace key"
+assert_not_contains "$quoted_config" "\"enableMacosDesktopApps\"" "quoted managed key update removes quoted macOS desktop-app boundary key"
+assert_not_contains "$quoted_config" "'enableEditorStack'" "quoted managed key update removes literal Editor Stack key"
+assert_not_contains "$quoted_config" "'enableAiCliTools'" "quoted managed key update removes literal AI Tool Stack key"
+assert_not_contains "$quoted_config" "'enableDevelopmentWorkspace'" "quoted managed key update removes literal Development Workspace key"
+assert_not_contains "$quoted_config" "'enableMacosDesktopApps'" "quoted managed key update removes literal macOS desktop-app boundary key"
+assert_not_contains "$quoted_config" "terrapodPreset" "quoted managed key update removes stale dynamic Preset key"
+assert_contains "$quoted_config" "keepLiteral = \"preserve\"" "quoted managed key update preserves unrelated literal data values"
+
+array_home="$tmp_dir/array-home"
+array_xdg="$tmp_dir/array-xdg"
+array_config="$array_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$array_home" "$(dirname "$array_config")"
+
+cat >"$array_config" <<'TOML'
+[data]
+keepMe = "yes"
+enableEditorStack = false
+
+[[merge.command]]
+name = "external"
+enableEditorStack = "do-not-touch"
+TOML
+chmod 600 "$array_config"
+
+run_terrapod_configure development "y" "$array_home" "$array_xdg"
+
+assert_contains "$array_config" "keepMe = \"yes\"" "array-table update preserves unrelated data values"
+assert_data_key_once_with_value "$array_config" "enableEditorStack" "true" "array-table update writes Editor Stack only in data"
+assert_data_key_once_with_value "$array_config" "enableAiCliTools" "true" "array-table update writes AI Tool Stack only in data"
+assert_data_key_once_with_value "$array_config" "enableDevelopmentWorkspace" "true" "array-table update writes Development Workspace only in data"
+assert_data_key_once_with_value "$array_config" "enableMacosDesktopApps" "false" "array-table update writes macOS desktop-app boundary only in data"
+assert_contains "$array_config" "[[merge.command]]" "array-table update preserves TOML array table"
+assert_contains "$array_config" "enableEditorStack = \"do-not-touch\"" "array-table update preserves same-named external key"
+assert_lines_after_header_not_contains "$array_config" "[[merge.command]]" "enableAiCliTools = true" "array-table update does not append AI Tool Stack under array table"
+assert_lines_after_header_not_contains "$array_config" "[[merge.command]]" "enableDevelopmentWorkspace = true" "array-table update does not append Development Workspace under array table"
+assert_lines_after_header_not_contains "$array_config" "[[merge.command]]" "enableMacosDesktopApps = false" "array-table update does not append macOS desktop-app boundary under array table"
+
+array_mode="$(file_mode "$array_config")"
+if [ "$array_mode" != "600" ]; then
+  fail "existing update preserves config file mode; expected 600, got $array_mode"
+fi
+pass "existing update preserves config file mode"
+
+assert_no_terrapod_temp_files "$array_config" "successful array-table update cleans Terrapod temp files"
+
+fake_stat_home="$tmp_dir/fake-stat-home"
+fake_stat_xdg="$tmp_dir/fake-stat-xdg"
+fake_stat_config="$fake_stat_xdg/chezmoi/chezmoi.toml"
+fake_stat_bin="$tmp_dir/fake-stat-bin"
+mkdir -p "$fake_stat_home" "$(dirname "$fake_stat_config")" "$fake_stat_bin"
+
+cat >"$fake_stat_config" <<'TOML'
+[data]
+enableEditorStack = false
+TOML
+chmod 600 "$fake_stat_config"
+
+cat >"$fake_stat_bin/stat" <<'SH'
+#!/bin/sh
+
+if [ "${1:-}" = "-f" ]; then
+  printf '%s\n' "GNU stat filesystem output that is not a file mode"
+  exit 1
+fi
+
+if [ "${1:-}" = "-c" ] && [ "${2:-}" = "%a" ]; then
+  printf '%s\n' "600"
+  exit 0
+fi
+
+printf '%s\n' "unexpected stat invocation: $*" >&2
+exit 2
+SH
+chmod +x "$fake_stat_bin/stat"
+
+if ! printf '%s\n' "y" |
+  PATH="$fake_stat_bin:$PATH" HOME="$fake_stat_home" XDG_CONFIG_HOME="$fake_stat_xdg" sh "$terrapod" configure development >"$tmp_dir/fake-stat.out" 2>"$tmp_dir/fake-stat.err"; then
+  printf '%s\n' "stdout:" >&2
+  sed 's/^/  /' "$tmp_dir/fake-stat.out" >&2
+  printf '%s\n' "stderr:" >&2
+  sed 's/^/  /' "$tmp_dir/fake-stat.err" >&2
+  fail "existing update ignores stdout from failing GNU stat -f fallback"
+fi
+pass "existing update ignores stdout from failing GNU stat -f fallback"
+
+fake_stat_mode="$(
+  PATH="$fake_stat_bin:$PATH"
+  file_mode "$fake_stat_config"
+)"
+if [ "$fake_stat_mode" != "600" ]; then
+  fail "existing update preserves mode with GNU-first stat fallback; expected 600, got $fake_stat_mode"
+fi
+pass "existing update preserves mode with GNU-first stat fallback"
+
+decline_home="$tmp_dir/decline-home"
+decline_xdg="$tmp_dir/decline-xdg"
+decline_config="$decline_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$decline_home" "$(dirname "$decline_config")"
+
+cat >"$decline_config" <<'TOML'
+[data]
+enableEditorStack = false
+keepMe = "yes"
+TOML
+cp "$decline_config" "$tmp_dir/decline-before.toml"
+
+if run_terrapod_configure development "n" "$decline_home" "$decline_xdg" >"$tmp_dir/decline.out" 2>"$tmp_dir/decline.err"; then
+  fail "existing config update can be declined"
+fi
+pass "existing config update can be declined"
+
+if ! cmp -s "$decline_config" "$tmp_dir/decline-before.toml"; then
+  fail "declined config update leaves existing config unchanged"
+fi
+pass "declined config update leaves existing config unchanged"
+
+assert_contains "$tmp_dir/decline.err" "Update Terrapod-managed data keys" "existing config update asks before writing"
+assert_backup_count "$decline_config" 0 "declined config update does not create a backup"
+
+directory_home="$tmp_dir/directory-home"
+directory_xdg="$tmp_dir/directory-xdg"
+directory_config="$directory_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$directory_home" "$directory_config"
+
+if TERRAPOD_CHEZMOI_CONFIG="$directory_config" HOME="$directory_home" XDG_CONFIG_HOME="$directory_xdg" sh "$terrapod" configure minimal >"$tmp_dir/directory.out" 2>"$tmp_dir/directory.err" </dev/null; then
+  fail "config path that is a directory fails explicitly"
+fi
+pass "config path that is a directory fails explicitly"
+
+assert_contains "$tmp_dir/directory.err" "not a regular file" "directory config path explains it is not usable"
+assert_not_contains "$tmp_dir/directory.out" "Configured Terrapod Preset" "directory config path does not report success"
+assert_no_terrapod_temp_files "$directory_config" "directory config path leaves no Terrapod temp files"
+
+symlink_home="$tmp_dir/symlink-home"
+symlink_xdg="$tmp_dir/symlink-xdg"
+symlink_dir="$tmp_dir/symlink-config-dir"
+symlink_target="$symlink_dir/target.toml"
+symlink_config="$symlink_dir/symlink_config.toml"
+mkdir -p "$symlink_home" "$symlink_dir"
+
+cat >"$symlink_target" <<'TOML'
+[data]
+enableEditorStack = false
+TOML
+chmod 600 "$symlink_target"
+cp "$symlink_target" "$tmp_dir/symlink-target-before.toml"
+symlink_target_mode="$(file_mode "$symlink_target")"
+ln -s "$symlink_target" "$symlink_config"
+
+if TERRAPOD_CHEZMOI_CONFIG="$symlink_config" HOME="$symlink_home" XDG_CONFIG_HOME="$symlink_xdg" sh "$terrapod" configure development >"$tmp_dir/symlink.out" 2>"$tmp_dir/symlink.err" </dev/null; then
+  fail "config path that is a symlink to a regular file fails explicitly"
+fi
+pass "config path that is a symlink to a regular file fails explicitly"
+
+assert_contains "$tmp_dir/symlink.err" "not a regular file" "symlink config path explains it is not usable"
+assert_not_contains "$tmp_dir/symlink.err" "Update Terrapod-managed data keys" "symlink config path does not prompt before failing"
+assert_not_contains "$tmp_dir/symlink.err" "config update cancelled" "symlink config path does not report a declined update"
+
+if [ ! -L "$symlink_config" ]; then
+  fail "symlink config path remains a symlink after failed update"
+fi
+pass "symlink config path remains a symlink after failed update"
+
+if ! cmp -s "$symlink_target" "$tmp_dir/symlink-target-before.toml"; then
+  fail "symlink config target remains unchanged after failed update"
+fi
+pass "symlink config target remains unchanged after failed update"
+
+symlink_target_mode_after="$(file_mode "$symlink_target")"
+if [ "$symlink_target_mode_after" != "$symlink_target_mode" ]; then
+  fail "symlink config target mode remains unchanged; expected $symlink_target_mode, got $symlink_target_mode_after"
+fi
+pass "symlink config target mode remains unchanged"
+
+assert_no_terrapod_artifacts_near_path "$symlink_config" "symlink config path leaves no Terrapod artifacts"
+assert_no_terrapod_artifacts_near_path "$symlink_target" "symlink config target leaves no Terrapod artifacts"
+
+dangling_home="$tmp_dir/dangling-home"
+dangling_xdg="$tmp_dir/dangling-xdg"
+dangling_dir="$tmp_dir/dangling-config-dir"
+dangling_config="$dangling_dir/dangling_config.toml"
+dangling_target="$dangling_dir/missing-target.toml"
+mkdir -p "$dangling_home" "$dangling_dir"
+ln -s "$dangling_target" "$dangling_config"
+
+if TERRAPOD_CHEZMOI_CONFIG="$dangling_config" HOME="$dangling_home" XDG_CONFIG_HOME="$dangling_xdg" sh "$terrapod" configure minimal >"$tmp_dir/dangling.out" 2>"$tmp_dir/dangling.err" </dev/null; then
+  fail "config path that is a dangling symlink fails explicitly"
+fi
+pass "config path that is a dangling symlink fails explicitly"
+
+assert_contains "$tmp_dir/dangling.err" "not a regular file" "dangling symlink config path explains it is not usable"
+
+if [ ! -L "$dangling_config" ]; then
+  fail "dangling symlink config path remains a symlink after failed update"
+fi
+pass "dangling symlink config path remains a symlink after failed update"
+
+if [ -e "$dangling_target" ]; then
+  fail "dangling symlink target remains missing after failed update"
+fi
+pass "dangling symlink target remains missing after failed update"
+
+assert_no_terrapod_artifacts_near_path "$dangling_config" "dangling symlink config path leaves no Terrapod artifacts"
+
+invalid_home="$tmp_dir/invalid-home"
+invalid_xdg="$tmp_dir/invalid-xdg"
+invalid_config="$invalid_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$invalid_home" "$(dirname "$invalid_config")"
+
+cat >"$invalid_config" <<'TOML'
+[data]
+enableEditorStack = false
+keepMe = "yes"
+TOML
+cp "$invalid_config" "$tmp_dir/invalid-before.toml"
+
+if HOME="$invalid_home" XDG_CONFIG_HOME="$invalid_xdg" sh "$terrapod" configure typo >"$tmp_dir/invalid.out" 2>"$tmp_dir/invalid.err" </dev/null; then
+  fail "invalid Preset fails before prompting"
+else
+  invalid_status="$?"
+fi
+
+if [ "$invalid_status" -ne 64 ]; then
+  fail "invalid Preset exits with usage status 64; got $invalid_status"
+fi
+pass "invalid Preset exits with usage status 64"
+
+assert_contains "$tmp_dir/invalid.err" "unknown Preset: typo" "invalid Preset names rejected Preset"
+assert_not_contains "$tmp_dir/invalid.err" "Update Terrapod-managed data keys" "invalid Preset does not prompt before failing"
+
+if ! cmp -s "$invalid_config" "$tmp_dir/invalid-before.toml"; then
+  fail "invalid Preset leaves existing config unchanged"
+fi
+pass "invalid Preset leaves existing config unchanged"
+
+assert_backup_count "$invalid_config" 0 "invalid Preset does not create a backup"
+assert_no_terrapod_temp_files "$invalid_config" "invalid Preset leaves no Terrapod temp files"

--- a/tests/terrapod_config_test.sh
+++ b/tests/terrapod_config_test.sh
@@ -270,6 +270,25 @@ assert_data_key_once_with_value "$new_config" "enableMacosDesktopApps" "false" "
 assert_not_contains "$new_config" "terrapodPreset" "minimal Preset stores concrete values instead of a dynamic Preset"
 assert_backup_count "$new_config" 0 "new config creation does not create a backup"
 
+workstation_home="$tmp_dir/workstation-home"
+workstation_xdg="$tmp_dir/workstation-xdg"
+workstation_config="$workstation_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$workstation_home"
+
+run_terrapod_configure workstation "" "$workstation_home" "$workstation_xdg"
+
+if [ ! -f "$workstation_config" ]; then
+  fail "workstation Preset creates a chezmoi config file"
+fi
+pass "workstation Preset creates a chezmoi config file"
+
+assert_data_key_once_with_value "$workstation_config" "enableEditorStack" "true" "workstation Preset enables Optional Editor Stack exactly once in data"
+assert_data_key_once_with_value "$workstation_config" "enableAiCliTools" "true" "workstation Preset enables Optional AI Tool Stack exactly once in data"
+assert_data_key_once_with_value "$workstation_config" "enableDevelopmentWorkspace" "true" "workstation Preset enables Optional Development Workspace exactly once in data"
+assert_data_key_once_with_value "$workstation_config" "enableMacosDesktopApps" "true" "workstation Preset enables macOS App Groups through the desktop-app boundary exactly once in data"
+assert_not_contains "$workstation_config" "terrapodPreset" "workstation Preset stores concrete values instead of a dynamic Preset"
+assert_backup_count "$workstation_config" 0 "workstation config creation does not create a backup"
+
 default_env_home="$tmp_dir/default-env-home"
 default_env_xdg="$tmp_dir/default-env-xdg"
 default_env_config="$default_env_xdg/chezmoi/chezmoi.toml"

--- a/tests/terrapod_config_test.sh
+++ b/tests/terrapod_config_test.sh
@@ -501,6 +501,43 @@ pass "existing update preserves config file mode"
 
 assert_no_terrapod_temp_files "$array_config" "successful array-table update cleans Terrapod temp files"
 
+multiline_array_home="$tmp_dir/multiline-array-home"
+multiline_array_xdg="$tmp_dir/multiline-array-xdg"
+multiline_array_config="$multiline_array_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$multiline_array_home" "$(dirname "$multiline_array_config")"
+
+cat >"$multiline_array_config" <<'TOML'
+[data]
+keepMe = "yes"
+matrix = [
+[1, 2]
+]
+enableEditorStack = false
+enableAiCliTools = false
+
+[sourceState]
+branch = "main"
+TOML
+cp "$multiline_array_config" "$tmp_dir/multiline-array-before.toml"
+
+if printf '%s\n' "y" |
+  HOME="$multiline_array_home" XDG_CONFIG_HOME="$multiline_array_xdg" sh "$terrapod" configure development >"$tmp_dir/multiline-array.out" 2>"$tmp_dir/multiline-array.err"; then
+  fail "multiline array config is rejected before rewriting"
+fi
+pass "multiline array config is rejected before rewriting"
+
+assert_contains "$tmp_dir/multiline-array.err" "unsupported multiline array" "multiline array rejection explains unsupported format"
+assert_not_contains "$tmp_dir/multiline-array.err" "Update Terrapod-managed data keys" "multiline array rejection does not prompt before failing"
+assert_not_contains "$tmp_dir/multiline-array.out" "Configured Terrapod Preset" "multiline array rejection does not report success"
+
+if ! cmp -s "$multiline_array_config" "$tmp_dir/multiline-array-before.toml"; then
+  fail "multiline array rejection leaves existing config unchanged"
+fi
+pass "multiline array rejection leaves existing config unchanged"
+
+assert_backup_count "$multiline_array_config" 0 "multiline array rejection does not create a backup"
+assert_no_terrapod_temp_files "$multiline_array_config" "multiline array rejection leaves no Terrapod temp files"
+
 fake_stat_home="$tmp_dir/fake-stat-home"
 fake_stat_xdg="$tmp_dir/fake-stat-xdg"
 fake_stat_config="$fake_stat_xdg/chezmoi/chezmoi.toml"

--- a/tests/terrapod_config_test.sh
+++ b/tests/terrapod_config_test.sh
@@ -370,6 +370,41 @@ assert_data_key_once_with_value "$quoted_table_config" "enableDevelopmentWorkspa
 assert_data_key_once_with_value "$quoted_table_config" "enableMacosDesktopApps" "false" "quoted data table update writes macOS desktop-app boundary in data"
 assert_not_contains "$quoted_table_config" "terrapodPreset" "quoted data table update removes stale dynamic Preset key"
 
+dotted_home="$tmp_dir/dotted-home"
+dotted_xdg="$tmp_dir/dotted-xdg"
+dotted_config="$dotted_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$dotted_home" "$(dirname "$dotted_config")"
+
+cat >"$dotted_config" <<'TOML'
+data.email = "minu@example.com"
+data.enableEditorStack = false
+data.enableAiCliTools = false
+data.enableDevelopmentWorkspace = false
+data.enableMacosDesktopApps = true
+data.terrapodPreset = "minimal"
+
+[sourceState]
+branch = "main"
+TOML
+
+run_terrapod_configure development "y" "$dotted_home" "$dotted_xdg"
+
+assert_not_contains "$dotted_config" "[data]" "dotted data update does not append a duplicate data table"
+assert_contains "$dotted_config" "data.email = \"minu@example.com\"" "dotted data update preserves unrelated data values"
+assert_contains "$dotted_config" "branch = \"main\"" "dotted data update preserves later sections"
+assert_contains "$dotted_config" "data.enableEditorStack = true" "dotted data update writes Editor Stack as a dotted data key"
+assert_contains "$dotted_config" "data.enableAiCliTools = true" "dotted data update writes AI Tool Stack as a dotted data key"
+assert_contains "$dotted_config" "data.enableDevelopmentWorkspace = true" "dotted data update writes Development Workspace as a dotted data key"
+assert_contains "$dotted_config" "data.enableMacosDesktopApps = false" "dotted data update writes macOS desktop-app boundary as a dotted data key"
+assert_not_contains "$dotted_config" "data.terrapodPreset" "dotted data update removes stale dynamic Preset key"
+
+if ! HOME="$dotted_home" XDG_CONFIG_HOME="$dotted_xdg" chezmoi --config "$dotted_config" data >"$tmp_dir/dotted-data.out" 2>"$tmp_dir/dotted-data.err"; then
+  printf '%s\n' "stderr:" >&2
+  sed 's/^/  /' "$tmp_dir/dotted-data.err" >&2
+  fail "dotted data update leaves a chezmoi-parseable config"
+fi
+pass "dotted data update leaves a chezmoi-parseable config"
+
 quoted_home="$tmp_dir/quoted-home"
 quoted_xdg="$tmp_dir/quoted-xdg"
 quoted_config="$quoted_xdg/chezmoi/chezmoi.toml"


### PR DESCRIPTION
## Summary

- Add `terrapod configure <minimal|development>` to expand Presets into concrete chezmoi `[data]` settings.
- Add a conservative config writer that updates only Terrapod-managed data keys, preserves unrelated config, backs up existing configs, and asks before interactive updates.
- Add shell tests for new config creation, existing updates, stale managed key replacement, backup behavior, path safety, quoted TOML keys, and raw `chezmoi` command preservation.

## Why

Issue #33 needs the shared configuration-writing path that first-run setup and later Terrapod configuration flows can both use without storing a permanent dynamic Preset policy.

## Impact

Users can now choose minimal or development Presets through Terrapod and get concrete saved settings. Existing chezmoi config values outside Terrapod-managed keys are preserved, and existing config files are backed up before managed keys are changed.

## Validation

- `sh -n dot_local/bin/executable_terrapod tests/terrapod_config_test.sh tests/terrapod_command_test.sh`
- `for test_file in tests/*.sh; do sh "$test_file" || exit 1; done`
- `zsh tests/zshrc_zoxide_test.zsh`
- `git diff --check origin/main...HEAD`
- Final base review: no findings

Closes #33