### PR TITLE
Add Terrapod update command

### DIFF
--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -122,9 +122,9 @@ show_update_context() {
   fi
 
   if [ -n "${TERRAPOD_CHEZMOI_CONFIG:-}" ]; then
-    printf '%s\n' "Delegating repository update to: chezmoi --config $TERRAPOD_CHEZMOI_CONFIG update"
+    printf '%s\n' "Delegating repository update to: chezmoi --config $TERRAPOD_CHEZMOI_CONFIG update --exclude scripts"
   else
-    printf '%s\n' "Delegating repository update to: chezmoi update"
+    printf '%s\n' "Delegating repository update to: chezmoi update --exclude scripts"
   fi
 }
 
@@ -135,9 +135,9 @@ run_update() {
 
   show_update_context
   if [ -n "${TERRAPOD_CHEZMOI_CONFIG:-}" ]; then
-    chezmoi --config "$TERRAPOD_CHEZMOI_CONFIG" update
+    chezmoi --config "$TERRAPOD_CHEZMOI_CONFIG" update --exclude scripts
   else
-    chezmoi update
+    chezmoi update --exclude scripts
   fi
 }
 

--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -8,16 +8,19 @@ Terrapod - Dotfiles Management Tool
 Usage:
   terrapod [help|--help|-h]
   terrapod configure <minimal|development|workstation>
+  terrapod update
   terrapod chezmoi -- <args...>
 
 Commands:
   help                                  Show this help.
   configure <minimal|development|workstation>
                                         Expand a Preset into concrete chezmoi data values.
+  update                                Run chezmoi update with Terrapod profile and config context.
   chezmoi -- <args...>                  Run raw chezmoi for advanced maintenance.
 
 Examples:
   terrapod configure development
+  terrapod update
   terrapod chezmoi -- status
 EOF
 }
@@ -56,6 +59,78 @@ chezmoi_config_file() {
   fi
 
   printf '%s\n' "$HOME/.config/chezmoi/chezmoi.toml"
+}
+
+os_release_value() {
+  key="$1"
+  file="$2"
+
+  if [ ! -r "$file" ]; then
+    return 1
+  fi
+
+  awk -F= -v key="$key" '
+    $1 == key {
+      value = $2
+      gsub(/^"/, "", value)
+      gsub(/"$/, "", value)
+      print value
+      found = 1
+      exit
+    }
+
+    END {
+      exit found ? 0 : 1
+    }
+  ' "$file"
+}
+
+terrapod_profile_context() {
+  os_name="$(uname -s 2>/dev/null || printf '%s\n' unknown)"
+
+  case "$os_name" in
+    Darwin)
+      printf '%s\n' "macOS Terminal Profile"
+      ;;
+    Linux)
+      os_release_file="${TERRAPOD_OS_RELEASE_FILE:-/etc/os-release}"
+      os_id="$(os_release_value ID "$os_release_file" 2>/dev/null || true)"
+      version_id="$(os_release_value VERSION_ID "$os_release_file" 2>/dev/null || true)"
+
+      if [ "$os_id" = "ubuntu" ] && [ "$version_id" = "24.04" ]; then
+        printf '%s\n' "VPS Shell Profile"
+      else
+        printf '%s\n' "unsupported Linux profile"
+      fi
+      ;;
+    *)
+      printf '%s\n' "unsupported profile"
+      ;;
+  esac
+}
+
+show_update_context() {
+  config_file="$(chezmoi_config_file)"
+
+  printf '%s\n' "Terrapod update"
+  printf '%s\n' "Profile: $(terrapod_profile_context)"
+
+  if [ -f "$config_file" ]; then
+    printf '%s\n' "Config: $config_file (present)"
+  else
+    printf '%s\n' "Config: $config_file (missing; chezmoi defaults apply)"
+  fi
+
+  printf '%s\n' "Delegating repository update to: chezmoi update"
+}
+
+run_update() {
+  if [ "$#" -ne 0 ]; then
+    fail_usage "update accepts no arguments"
+  fi
+
+  show_update_context
+  chezmoi update
 }
 
 render_preset_data() {
@@ -505,6 +580,10 @@ case "$command_name" in
     confirm_existing_config_update "$config_file"
     write_managed_config "$config_file" "$preset"
     printf '%s\n' "Configured Terrapod Preset '$preset' in $config_file"
+    ;;
+  update)
+    shift
+    run_update "$@"
     ;;
   chezmoi)
     shift

--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -121,7 +121,11 @@ show_update_context() {
     printf '%s\n' "Config: $config_file (missing; chezmoi defaults apply)"
   fi
 
-  printf '%s\n' "Delegating repository update to: chezmoi update"
+  if [ -n "${TERRAPOD_CHEZMOI_CONFIG:-}" ]; then
+    printf '%s\n' "Delegating repository update to: chezmoi --config $TERRAPOD_CHEZMOI_CONFIG update"
+  else
+    printf '%s\n' "Delegating repository update to: chezmoi update"
+  fi
 }
 
 run_update() {
@@ -130,7 +134,11 @@ run_update() {
   fi
 
   show_update_context
-  chezmoi update
+  if [ -n "${TERRAPOD_CHEZMOI_CONFIG:-}" ]; then
+    chezmoi --config "$TERRAPOD_CHEZMOI_CONFIG" update
+  else
+    chezmoi update
+  fi
 }
 
 render_preset_data() {

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -276,3 +276,123 @@ assert_contains \
   "$missing_command_error" \
   "terrapod: raw chezmoi command is required" \
   "Terrapod explains missing raw chezmoi command"
+
+export CHEZMOI_CALL_FILE="$tmp_dir/chezmoi-update.args"
+export CHEZMOI_INVOKED_FILE="$tmp_dir/chezmoi-update.invoked"
+export BROAD_UPGRADE_CALL_FILE="$tmp_dir/broad-upgrade.calls"
+
+write_stub "$tmp_dir/bin/chezmoi" \
+  'printf "%s\n" invoked >"$CHEZMOI_INVOKED_FILE"' \
+  ': >"$CHEZMOI_CALL_FILE"' \
+  'for arg do' \
+  '  printf "%s\n" "$arg" >>"$CHEZMOI_CALL_FILE"' \
+  'done' \
+  'exit 0'
+
+write_stub "$tmp_dir/bin/brew" \
+  'printf "%s\n" "brew $*" >>"$BROAD_UPGRADE_CALL_FILE"' \
+  'exit 90'
+
+write_stub "$tmp_dir/bin/apt" \
+  'printf "%s\n" "apt $*" >>"$BROAD_UPGRADE_CALL_FILE"' \
+  'exit 90'
+
+write_stub "$tmp_dir/bin/sudo" \
+  'printf "%s\n" "sudo $*" >>"$BROAD_UPGRADE_CALL_FILE"' \
+  'exit 90'
+
+write_stub "$tmp_dir/bin/mise" \
+  'printf "%s\n" "mise $*" >>"$BROAD_UPGRADE_CALL_FILE"' \
+  'exit 90'
+
+write_stub "$tmp_dir/bin/npm" \
+  'printf "%s\n" "npm $*" >>"$BROAD_UPGRADE_CALL_FILE"' \
+  'exit 90'
+
+write_stub "$tmp_dir/bin/uname" \
+  'printf "%s\n" "Darwin"'
+
+update_home="$tmp_dir/update-home"
+update_xdg="$tmp_dir/update-xdg"
+update_config="$update_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$update_home" "$(dirname "$update_config")"
+
+cat >"$update_config" <<'TOML'
+[data]
+enableEditorStack = true
+enableAiCliTools = false
+enableDevelopmentWorkspace = false
+enableMacosDesktopApps = false
+TOML
+
+if ! HOME="$update_home" XDG_CONFIG_HOME="$update_xdg" PATH="$tmp_dir/bin:/usr/bin:/bin" \
+  sh "$terrapod" update >"$tmp_dir/update.out" 2>"$tmp_dir/update.err"; then
+  printf '%s\n' "update stdout:" >&2
+  sed 's/^/  /' "$tmp_dir/update.out" >&2
+  printf '%s\n' "update stderr:" >&2
+  sed 's/^/  /' "$tmp_dir/update.err" >&2
+  fail "Terrapod update runs successfully"
+fi
+
+update_output="$(cat "$tmp_dir/update.out")"
+
+assert_call_args \
+  "$CHEZMOI_CALL_FILE" \
+  "Terrapod update delegates repository update semantics to chezmoi update" \
+  update
+
+assert_contains \
+  "$update_output" \
+  "Terrapod update" \
+  "Terrapod update prints command context"
+
+assert_contains \
+  "$update_output" \
+  "Profile: macOS Terminal Profile" \
+  "Terrapod update prints profile context"
+
+assert_contains \
+  "$update_output" \
+  "Config: $update_config (present)" \
+  "Terrapod update prints managed config context"
+
+assert_contains \
+  "$update_output" \
+  "Delegating repository update to: chezmoi update" \
+  "Terrapod update explains the delegated command"
+
+if [ -e "$BROAD_UPGRADE_CALL_FILE" ]; then
+  printf '%s\n' "unexpected broad upgrade command calls:" >&2
+  sed 's/^/  /' "$BROAD_UPGRADE_CALL_FILE" >&2
+  fail "Terrapod update does not call brew, apt, sudo, mise, or npm upgrade flows"
+fi
+
+pass "Terrapod update does not call brew, apt, sudo, mise, or npm upgrade flows"
+
+rm -f "$CHEZMOI_CALL_FILE" "$CHEZMOI_INVOKED_FILE"
+
+if HOME="$update_home" XDG_CONFIG_HOME="$update_xdg" PATH="$tmp_dir/bin:/usr/bin:/bin" \
+  sh "$terrapod" update --aggressive >"$tmp_dir/update-extra.out" 2>"$tmp_dir/update-extra.err"; then
+  fail "Terrapod update rejects extra arguments"
+fi
+
+update_extra_error="$(cat "$tmp_dir/update-extra.err")"
+
+assert_contains \
+  "$update_extra_error" \
+  "terrapod: update accepts no arguments" \
+  "Terrapod update explains rejected extra arguments"
+
+if [ -e "$CHEZMOI_INVOKED_FILE" ]; then
+  fail "Terrapod update rejects extra arguments before calling chezmoi"
+fi
+
+pass "Terrapod update rejects extra arguments before calling chezmoi"
+
+if [ -e "$BROAD_UPGRADE_CALL_FILE" ]; then
+  printf '%s\n' "unexpected broad upgrade command calls after rejected extra arguments:" >&2
+  sed 's/^/  /' "$BROAD_UPGRADE_CALL_FILE" >&2
+  fail "Terrapod update rejects extra arguments before broad upgrade flows"
+fi
+
+pass "Terrapod update rejects extra arguments before broad upgrade flows"

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -369,6 +369,52 @@ fi
 
 pass "Terrapod update does not call brew, apt, sudo, mise, or npm upgrade flows"
 
+override_config="$tmp_dir/override-chezmoi.toml"
+
+cat >"$override_config" <<'TOML'
+[data]
+enableEditorStack = false
+enableAiCliTools = true
+enableDevelopmentWorkspace = false
+enableMacosDesktopApps = false
+TOML
+
+rm -f "$CHEZMOI_CALL_FILE" "$CHEZMOI_INVOKED_FILE"
+
+if ! HOME="$update_home" XDG_CONFIG_HOME="$update_xdg" TERRAPOD_CHEZMOI_CONFIG="$override_config" PATH="$tmp_dir/bin:/usr/bin:/bin" \
+  sh "$terrapod" update >"$tmp_dir/update-override.out" 2>"$tmp_dir/update-override.err"; then
+  printf '%s\n' "override update stdout:" >&2
+  sed 's/^/  /' "$tmp_dir/update-override.out" >&2
+  printf '%s\n' "override update stderr:" >&2
+  sed 's/^/  /' "$tmp_dir/update-override.err" >&2
+  fail "Terrapod update runs successfully with an explicit config override"
+fi
+
+override_update_output="$(cat "$tmp_dir/update-override.out")"
+
+assert_call_args \
+  "$CHEZMOI_CALL_FILE" \
+  "Terrapod update passes explicit config overrides to chezmoi update" \
+  --config "$override_config" update
+
+assert_contains \
+  "$override_update_output" \
+  "Config: $override_config (present)" \
+  "Terrapod update prints explicit config override context"
+
+assert_contains \
+  "$override_update_output" \
+  "Delegating repository update to: chezmoi --config $override_config update" \
+  "Terrapod update explains delegated explicit config command"
+
+if [ -e "$BROAD_UPGRADE_CALL_FILE" ]; then
+  printf '%s\n' "unexpected broad upgrade command calls with explicit config override:" >&2
+  sed 's/^/  /' "$BROAD_UPGRADE_CALL_FILE" >&2
+  fail "Terrapod update with explicit config override does not call broad upgrade flows"
+fi
+
+pass "Terrapod update with explicit config override does not call broad upgrade flows"
+
 rm -f "$CHEZMOI_CALL_FILE" "$CHEZMOI_INVOKED_FILE"
 
 if HOME="$update_home" XDG_CONFIG_HOME="$update_xdg" PATH="$tmp_dir/bin:/usr/bin:/bin" \

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -339,7 +339,7 @@ update_output="$(cat "$tmp_dir/update.out")"
 assert_call_args \
   "$CHEZMOI_CALL_FILE" \
   "Terrapod update delegates repository update semantics to chezmoi update" \
-  update
+  update --exclude scripts
 
 assert_contains \
   "$update_output" \
@@ -358,7 +358,7 @@ assert_contains \
 
 assert_contains \
   "$update_output" \
-  "Delegating repository update to: chezmoi update" \
+  "Delegating repository update to: chezmoi update --exclude scripts" \
   "Terrapod update explains the delegated command"
 
 if [ -e "$BROAD_UPGRADE_CALL_FILE" ]; then
@@ -395,7 +395,7 @@ override_update_output="$(cat "$tmp_dir/update-override.out")"
 assert_call_args \
   "$CHEZMOI_CALL_FILE" \
   "Terrapod update passes explicit config overrides to chezmoi update" \
-  --config "$override_config" update
+  --config "$override_config" update --exclude scripts
 
 assert_contains \
   "$override_update_output" \
@@ -404,7 +404,7 @@ assert_contains \
 
 assert_contains \
   "$override_update_output" \
-  "Delegating repository update to: chezmoi --config $override_config update" \
+  "Delegating repository update to: chezmoi --config $override_config update --exclude scripts" \
   "Terrapod update explains delegated explicit config command"
 
 if [ -e "$BROAD_UPGRADE_CALL_FILE" ]; then


### PR DESCRIPTION
## Summary

- Add `terrapod update` as a policy-aware wrapper around `chezmoi update`.
- Print Terrapod context before delegation, including detected profile and chezmoi config path state.
- Add shell tests that verify the delegated `chezmoi update` call and guard against broad upgrade flows through `brew`, `apt`, `sudo`, `mise`, and `npm` stubs.

## Why

Issue #38 asks Terrapod to delegate repository update semantics to chezmoi while explicitly avoiding package-manager or tool-version upgrades. This keeps Terrapod aligned with the Dotfiles Management Tool boundary: it can add context and validation, but it should not become a package upgrade frontend.

## Impact

Users can now run `terrapod update` and see Terrapod-specific context before the underlying `chezmoi update` runs. Extra arguments are rejected before delegation so the command surface stays narrow for this slice.

Closes #38.

## Validation

- `sh tests/terrapod_command_test.sh`
- `for test_file in tests/*_test.sh; do sh "$test_file" || exit 1; done`

## Review

Base-diff review found no blocking issues. Residual test gap: Linux/Ubuntu profile-context branches are not separately exercised in this slice; the delegated update behavior and broad-upgrade guard are covered with deterministic stubs.