### PR TITLE
Add macOS workstation app groups

### DIFF
--- a/.chezmoiscripts/run_onchange_after_50-open-karabiner-if-needed.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_50-open-karabiner-if-needed.sh.tmpl
@@ -1,13 +1,19 @@
 {{- if eq .chezmoi.os "darwin" -}}
+{{- $enableMacosAppGroups := or
+  (default false (get . "enableMacosAppGroupTerminalApps"))
+  (default false (get . "enableMacosAppGroupAutomation"))
+  (default false (get . "enableMacosAppGroupLauncher"))
+  (default false (get . "enableMacosAppGroupMonitoring"))
+-}}
 #!/bin/sh
 set -eu
 
 karabiner_cli="/Library/Application Support/org.pqrs/Karabiner-Elements/bin/karabiner_cli"
 
 # Brewfile checksum: {{ include "Brewfile" | sha256sum }}
-# macOS Desktop App Stack enabled: {{ default false (get . "enableMacosDesktopApps") }}
-{{- if default false (get . "enableMacosDesktopApps") }}
-# macOS Desktop App Stack Brewfile checksum: {{ include "Brewfile.macos-desktop-apps" | sha256sum }}
+# macOS Desktop App Stack enabled: {{ $enableMacosAppGroups }}
+{{- if $enableMacosAppGroups }}
+# macOS Desktop App Stack Brewfile checksum: {{ includeTemplate "Brewfile.macos-desktop-apps.tmpl" . | sha256sum }}
 {{- end }}
 # Karabiner config checksum: {{ include "dot_config/private_karabiner/private_karabiner.json" | sha256sum }}
 

--- a/.chezmoiscripts/run_onchange_before_00-bootstrap-homebrew.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_00-bootstrap-homebrew.sh.tmpl
@@ -1,4 +1,10 @@
 {{- if eq .chezmoi.os "darwin" -}}
+{{- $enableMacosAppGroups := or
+  (default false (get . "enableMacosAppGroupTerminalApps"))
+  (default false (get . "enableMacosAppGroupAutomation"))
+  (default false (get . "enableMacosAppGroupLauncher"))
+  (default false (get . "enableMacosAppGroupMonitoring"))
+-}}
 #!/bin/sh
 set -eu
 
@@ -44,11 +50,19 @@ if [ -f "$core_brewfile" ]; then
   brew bundle --no-upgrade --file="$core_brewfile"
 fi
 
-{{ if default false (get . "enableMacosDesktopApps") -}}
-desktop_brewfile="{{ .chezmoi.sourceDir }}/Brewfile.macos-desktop-apps"
+{{ if $enableMacosAppGroups -}}
+desktop_brewfile="$(mktemp "${TMPDIR:-/tmp}/terrapod-macos-desktop-apps.XXXXXX")"
+cleanup_desktop_brewfile() {
+  rm -f "$desktop_brewfile"
+}
+trap cleanup_desktop_brewfile EXIT HUP INT TERM
 
-# macOS Desktop App Stack Brewfile checksum: {{ include "Brewfile.macos-desktop-apps" | sha256sum }}
-if [ -f "$desktop_brewfile" ]; then
+# macOS Desktop App Stack App Groups checksum: {{ include "Brewfile.macos-desktop-apps.tmpl" | sha256sum }}
+cat >"$desktop_brewfile" <<'BREWFILE'
+{{ includeTemplate "Brewfile.macos-desktop-apps.tmpl" . -}}
+BREWFILE
+
+if [ -s "$desktop_brewfile" ]; then
   brew bundle --no-upgrade --file="$desktop_brewfile"
 fi
 {{- end }}

--- a/Brewfile.macos-desktop-apps
+++ b/Brewfile.macos-desktop-apps
@@ -1,9 +1,0 @@
-# Opt-in macOS Desktop App Stack.
-
-cask "ghostty"
-cask "cmux"
-cask "hammerspoon"
-cask "istat-menus"
-cask "karabiner-elements"
-cask "raycast"
-cask "1password-cli"

--- a/Brewfile.macos-desktop-apps.tmpl
+++ b/Brewfile.macos-desktop-apps.tmpl
@@ -1,0 +1,20 @@
+# Rendered opt-in macOS Desktop App Stack.
+{{ if default false (get . "enableMacosAppGroupTerminalApps") -}}
+# terminal-apps macOS App Group
+cask "ghostty"
+cask "cmux"
+{{ end -}}
+{{ if default false (get . "enableMacosAppGroupAutomation") -}}
+# automation macOS App Group
+cask "hammerspoon"
+cask "karabiner-elements"
+{{ end -}}
+{{ if default false (get . "enableMacosAppGroupLauncher") -}}
+# launcher macOS App Group
+cask "raycast"
+cask "1password-cli"
+{{ end -}}
+{{ if default false (get . "enableMacosAppGroupMonitoring") -}}
+# monitoring macOS App Group
+cask "istat-menus"
+{{ end -}}

--- a/README.md
+++ b/README.md
@@ -32,10 +32,15 @@ the initial terminal environment:
 - Bun, Python, uv/uvx, and Node.js via `~/.config/mise/config.toml`
 - pnpm through Node.js Corepack
 
-When `enableMacosDesktopApps` is `true`, macOS also installs the opt-in
-macOS Desktop App Stack from `Brewfile.macos-desktop-apps`:
+macOS desktop applications are split into opt-in App Groups controlled by
+machine-local data keys. During Homebrew bootstrap, chezmoi renders selected
+groups from `Brewfile.macos-desktop-apps.tmpl` into a temporary Brewfile and
+installs that rendered bundle:
 
-- Desktop terminals, launchers, keyboard automation, menu bar tools, and password manager CLI.
+- `terminal-apps`: Ghostty and cmux.
+- `automation`: Hammerspoon and Karabiner-Elements.
+- `launcher`: Raycast and 1Password CLI.
+- `monitoring`: iStat Menus.
 
 Machine-specific Homebrew packages should live outside the tracked `Brewfile`.
 
@@ -125,7 +130,7 @@ Raycast Store extensions and app state are restored manually from a
 `.rayconfig` backup stored in 1Password, rather than tracked directly in this
 repo.
 
-1. Enable/install the opt-in macOS Desktop App Stack, or otherwise ensure Raycast is installed.
+1. Enable/install the launcher macOS App Group with `enableMacosAppGroupLauncher`, or otherwise ensure Raycast is installed.
 2. Open the 1Password item for the Raycast settings export.
 3. Download the latest `.rayconfig` file.
 4. Run `Import Settings & Data` in Raycast.
@@ -142,17 +147,22 @@ Machine-local options are configured outside this repo with
 `chezmoi edit-config`. Keep only the option names, defaults, and examples here;
 do not commit workstation-specific values.
 
-All three optional stack profiles are disabled by default.
+Optional stack profiles and macOS App Group settings are disabled by default.
 
 | Key | Default | Purpose |
 | --- | --- | --- |
 | `enableEditorStack` | `false` | Enables the Optional Editor Stack, which manages the rich Neovim configuration. Plain Neovim remains in the Core Shell Stack either way. |
 | `enableAiCliTools` | `false` | Installs Gemini CLI, Claude Code, and Codex with npm through the mise-managed Node.js runtime. |
 | `enableDevelopmentWorkspace` | `false` | Enables the Optional Development Workspace preset, including the Optional Editor Stack, Optional AI Tool Stack, and development-specific Zellij workspace surfaces. |
-| `enableMacosDesktopApps` | `false` | Installs the opt-in macOS Desktop App Stack from `Brewfile.macos-desktop-apps`. This remains separate from `enableDevelopmentWorkspace` because desktop casks can affect shared applications outside one user's home directory. |
+| `enableMacosAppGroupTerminalApps` | `false` | Installs the terminal-apps macOS App Group: Ghostty and cmux. |
+| `enableMacosAppGroupAutomation` | `false` | Installs the automation macOS App Group: Hammerspoon and Karabiner-Elements. |
+| `enableMacosAppGroupLauncher` | `false` | Installs the launcher macOS App Group: Raycast and 1Password CLI. |
+| `enableMacosAppGroupMonitoring` | `false` | Installs the monitoring macOS App Group: iStat Menus. |
 | `gitAllowedSigners` | `[]` | Adds workstation-specific SSH signing identities to `~/.ssh/allowed_signers`. |
 
 When `enableDevelopmentWorkspace` is `true`, it enables both the Optional Editor Stack and Optional AI Tool Stack even if `enableEditorStack` or `enableAiCliTools` are false or omitted.
+
+macOS Desktop App Stack installation remains separate from `enableDevelopmentWorkspace` because desktop casks can affect shared applications outside one user's home directory.
 
 Opting out of an optional stack excludes its files from chezmoi management; it does not remove files already present on a machine.
 

--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -2,17 +2,19 @@
 set -eu
 
 show_help() {
-  cat <<'EOF'
+  preset_args="$(available_preset_args "$(current_profile)")"
+
+  cat <<EOF
 Terrapod - Dotfiles Management Tool
 
 Usage:
   terrapod [help|--help|-h]
-  terrapod configure <minimal|development|workstation>
+  terrapod configure <$preset_args>
   terrapod chezmoi -- <args...>
 
 Commands:
   help                                  Show this help.
-  configure <minimal|development|workstation>
+  configure <$preset_args>
                                         Expand a Preset into concrete chezmoi data values.
   chezmoi -- <args...>                  Run raw chezmoi for advanced maintenance.
 
@@ -58,6 +60,38 @@ chezmoi_config_file() {
   printf '%s\n' "$HOME/.config/chezmoi/chezmoi.toml"
 }
 
+current_profile() {
+  case "${TERRAPOD_PROFILE:-}" in
+    macos-terminal|vps-shell)
+      printf '%s\n' "$TERRAPOD_PROFILE"
+      return
+      ;;
+  esac
+
+  case "$(uname -s 2>/dev/null || printf unknown)" in
+    Darwin)
+      printf '%s\n' "macos-terminal"
+      ;;
+    Linux)
+      printf '%s\n' "vps-shell"
+      ;;
+    *)
+      printf '%s\n' "unsupported"
+      ;;
+  esac
+}
+
+available_preset_args() {
+  case "$1" in
+    macos-terminal)
+      printf '%s\n' "minimal|development|workstation"
+      ;;
+    *)
+      printf '%s\n' "minimal|development"
+      ;;
+  esac
+}
+
 render_preset_data() {
   preset="$1"
 
@@ -67,7 +101,10 @@ render_preset_data() {
 enableEditorStack = false
 enableAiCliTools = false
 enableDevelopmentWorkspace = false
-enableMacosDesktopApps = false
+enableMacosAppGroupTerminalApps = false
+enableMacosAppGroupAutomation = false
+enableMacosAppGroupLauncher = false
+enableMacosAppGroupMonitoring = false
 EOF
       ;;
     development)
@@ -75,7 +112,10 @@ EOF
 enableEditorStack = true
 enableAiCliTools = true
 enableDevelopmentWorkspace = true
-enableMacosDesktopApps = false
+enableMacosAppGroupTerminalApps = false
+enableMacosAppGroupAutomation = false
+enableMacosAppGroupLauncher = false
+enableMacosAppGroupMonitoring = false
 EOF
       ;;
     workstation)
@@ -83,7 +123,10 @@ EOF
 enableEditorStack = true
 enableAiCliTools = true
 enableDevelopmentWorkspace = true
-enableMacosDesktopApps = true
+enableMacosAppGroupTerminalApps = true
+enableMacosAppGroupAutomation = true
+enableMacosAppGroupLauncher = true
+enableMacosAppGroupMonitoring = true
 EOF
       ;;
     *)
@@ -94,6 +137,17 @@ EOF
 
 validate_preset() {
   render_preset_data "$1" >/dev/null
+}
+
+validate_preset_for_profile() {
+  preset="$1"
+  profile="$2"
+
+  validate_preset "$preset"
+
+  if [ "$preset" = "workstation" ] && [ "$profile" != "macos-terminal" ]; then
+    fail_usage "workstation Preset is only available for the macOS Terminal Profile"
+  fi
 }
 
 confirm_existing_config_update() {
@@ -368,8 +422,56 @@ write_managed_config() {
         return line ~ /^[[:space:]]*(\[[^]]+\]|\[\[[^]]+\]\])[[:space:]]*($|#)/
       }
 
+      function strip_space(value) {
+        sub(/^[[:space:]]*/, "", value)
+        sub(/[[:space:]]*$/, "", value)
+        return value
+      }
+
+      function unquote_key(value, quote) {
+        value = strip_space(value)
+        quote = substr(value, 1, 1)
+
+        if ((quote == "\"" || quote == "\047") && substr(value, length(value), 1) == quote) {
+          return substr(value, 2, length(value) - 2)
+        }
+
+        return value
+      }
+
+      function assignment_key_name(line, key) {
+        key = line
+        sub(/^[[:space:]]*/, "", key)
+        sub(/[[:space:]]*=.*/, "", key)
+        return unquote_key(key)
+      }
+
+      function dotted_data_key_name(line, key) {
+        key = line
+        sub(/^[[:space:]]*/, "", key)
+        sub(/[[:space:]]*=.*/, "", key)
+        sub("^[[:space:]]*(data|\"data\"|\047data\047)[[:space:]]*\\.[[:space:]]*", "", key)
+        return unquote_key(key)
+      }
+
+      function is_managed_name(name) {
+        return name == "enableEditorStack" ||
+          name == "enableAiCliTools" ||
+          name == "enableDevelopmentWorkspace" ||
+          name == "enableMacosAppGroupTerminalApps" ||
+          name == "enableMacosAppGroupAutomation" ||
+          name == "enableMacosAppGroupLauncher" ||
+          name == "enableMacosAppGroupMonitoring" ||
+          name == "enableMacosDesktopApps" ||
+          name == "terrapodPreset"
+      }
+
+      function is_key_assignment(line) {
+        return line ~ "^[[:space:]]*(\"[^\"]+\"|\047[^\047]+\047|[A-Za-z0-9_-]+)[[:space:]]*="
+      }
+
       function is_managed_key(line) {
-        return line ~ "^[[:space:]]*(\"enableEditorStack\"|\"enableAiCliTools\"|\"enableDevelopmentWorkspace\"|\"enableMacosDesktopApps\"|\"terrapodPreset\"|\047enableEditorStack\047|\047enableAiCliTools\047|\047enableDevelopmentWorkspace\047|\047enableMacosDesktopApps\047|\047terrapodPreset\047|enableEditorStack|enableAiCliTools|enableDevelopmentWorkspace|enableMacosDesktopApps|terrapodPreset)[[:space:]]*="
+        return is_key_assignment(line) && is_managed_name(assignment_key_name(line))
       }
 
       function is_root_dotted_data_key(line) {
@@ -377,7 +479,7 @@ write_managed_config() {
       }
 
       function is_root_dotted_managed_key(line) {
-        return line ~ "^[[:space:]]*(data|\"data\"|\047data\047)[[:space:]]*\\.[[:space:]]*(\"enableEditorStack\"|\"enableAiCliTools\"|\"enableDevelopmentWorkspace\"|\"enableMacosDesktopApps\"|\"terrapodPreset\"|\047enableEditorStack\047|\047enableAiCliTools\047|\047enableDevelopmentWorkspace\047|\047enableMacosDesktopApps\047|\047terrapodPreset\047|enableEditorStack|enableAiCliTools|enableDevelopmentWorkspace|enableMacosDesktopApps|terrapodPreset)[[:space:]]*="
+        return is_root_dotted_data_key(line) && is_managed_name(dotted_data_key_name(line))
       }
 
       function print_managed_data(line) {
@@ -495,7 +597,8 @@ case "$command_name" in
       fail_usage "configure accepts exactly one Preset"
     fi
 
-    validate_preset "$preset"
+    profile="$(current_profile)"
+    validate_preset_for_profile "$preset" "$profile"
 
     config_file="$(chezmoi_config_file)"
     reject_unusable_config_path "$config_file"

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -46,6 +46,7 @@ render_template() {
 
   chezmoi \
     --config "$chezmoi_config" \
+    --source "$repo_root" \
     execute-template \
     --override-data "$data" \
     --file "$repo_root/$file"
@@ -81,6 +82,18 @@ assert_not_contains_text() {
   message="$3"
 
   if printf '%s\n' "$text" | grep -F "$needle" >/dev/null; then
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
+assert_texts_differ() {
+  left="$1"
+  right="$2"
+  message="$3"
+
+  if [ "$left" = "$right" ]; then
     fail "$message"
   fi
 
@@ -131,8 +144,11 @@ ubuntu_managed="$(managed_source_paths "$ubuntu_data")"
 macos_data='{"chezmoi":{"os":"darwin"},"enableEditorStack":false,"enableAiCliTools":false,"enableDevelopmentWorkspace":false}'
 macos_managed="$(managed_source_paths "$macos_data")"
 macos_managed_targets="$(managed_target_paths "$macos_data")"
-macos_desktop_apps_data='{"chezmoi":{"os":"darwin"},"enableEditorStack":false,"enableAiCliTools":false,"enableDevelopmentWorkspace":false,"enableMacosDesktopApps":true}'
-macos_desktop_apps_managed_targets="$(managed_target_paths "$macos_desktop_apps_data")"
+macos_terminal_apps_data='{"chezmoi":{"os":"darwin"},"enableMacosAppGroupTerminalApps":true,"enableMacosAppGroupAutomation":false,"enableMacosAppGroupLauncher":false,"enableMacosAppGroupMonitoring":false}'
+macos_automation_apps_data='{"chezmoi":{"os":"darwin"},"enableMacosAppGroupTerminalApps":false,"enableMacosAppGroupAutomation":true,"enableMacosAppGroupLauncher":false,"enableMacosAppGroupMonitoring":false}'
+macos_launcher_apps_data='{"chezmoi":{"os":"darwin"},"enableMacosAppGroupTerminalApps":false,"enableMacosAppGroupAutomation":false,"enableMacosAppGroupLauncher":true,"enableMacosAppGroupMonitoring":false}'
+macos_monitoring_apps_data='{"chezmoi":{"os":"darwin"},"enableMacosAppGroupTerminalApps":false,"enableMacosAppGroupAutomation":false,"enableMacosAppGroupLauncher":false,"enableMacosAppGroupMonitoring":true}'
+macos_terminal_apps_managed_targets="$(managed_target_paths "$macos_terminal_apps_data")"
 macos_ai_cli_tools_data='{"chezmoi":{"os":"darwin"},"enableEditorStack":false,"enableAiCliTools":true,"enableDevelopmentWorkspace":false}'
 macos_ai_cli_tools_managed="$(managed_source_paths "$macos_ai_cli_tools_data")"
 macos_development_workspace_data='{"chezmoi":{"os":"darwin"},"enableEditorStack":false,"enableAiCliTools":false,"enableDevelopmentWorkspace":true}'
@@ -162,11 +178,17 @@ done
 
 pass "Ubuntu VPS ignores macOS-only entries"
 
+macos_brewfile="$(render_template "$macos_data" "Brewfile.macos-desktop-apps.tmpl")"
+terminal_apps_brewfile="$(render_template "$macos_terminal_apps_data" "Brewfile.macos-desktop-apps.tmpl")"
+automation_apps_brewfile="$(render_template "$macos_automation_apps_data" "Brewfile.macos-desktop-apps.tmpl")"
+launcher_apps_brewfile="$(render_template "$macos_launcher_apps_data" "Brewfile.macos-desktop-apps.tmpl")"
+monitoring_apps_brewfile="$(render_template "$macos_monitoring_apps_data" "Brewfile.macos-desktop-apps.tmpl")"
 macos_bootstrap="$(render_template "$macos_data" ".chezmoiscripts/run_onchange_before_00-bootstrap-homebrew.sh.tmpl")"
-macos_desktop_apps_bootstrap="$(render_template "$macos_desktop_apps_data" ".chezmoiscripts/run_onchange_before_00-bootstrap-homebrew.sh.tmpl")"
+macos_terminal_apps_bootstrap="$(render_template "$macos_terminal_apps_data" ".chezmoiscripts/run_onchange_before_00-bootstrap-homebrew.sh.tmpl")"
 macos_development_workspace_bootstrap="$(render_template "$macos_development_workspace_data" ".chezmoiscripts/run_onchange_before_00-bootstrap-homebrew.sh.tmpl")"
 macos_karabiner_opener="$(render_template "$macos_data" ".chezmoiscripts/run_onchange_after_50-open-karabiner-if-needed.sh.tmpl")"
-macos_desktop_apps_karabiner_opener="$(render_template "$macos_desktop_apps_data" ".chezmoiscripts/run_onchange_after_50-open-karabiner-if-needed.sh.tmpl")"
+macos_terminal_apps_karabiner_opener="$(render_template "$macos_terminal_apps_data" ".chezmoiscripts/run_onchange_after_50-open-karabiner-if-needed.sh.tmpl")"
+macos_automation_apps_karabiner_opener="$(render_template "$macos_automation_apps_data" ".chezmoiscripts/run_onchange_after_50-open-karabiner-if-needed.sh.tmpl")"
 
 assert_contains_text \
   "$macos_bootstrap" \
@@ -178,15 +200,55 @@ assert_not_contains_text \
   "Brewfile.macos-desktop-apps" \
   "macOS bootstrap default skips macOS Desktop App Stack Brewfile"
 
-assert_contains_text \
-  "$macos_desktop_apps_bootstrap" \
+assert_not_contains_text \
+  "$macos_bootstrap" \
+  "terrapod-macos-desktop-apps" \
+  "macOS bootstrap default skips macOS Desktop App Stack temp Brewfile"
+
+assert_not_contains_text \
+  "$macos_bootstrap" \
+  'brew bundle --no-upgrade --file="$desktop_brewfile"' \
+  "macOS bootstrap default skips macOS Desktop App Stack bundle"
+
+assert_managed_paths_exclude_prefix \
+  "$macos_managed_targets" \
   "Brewfile.macos-desktop-apps" \
-  "enableMacosDesktopApps renders macOS Desktop App Stack Brewfile"
+  "macOS default does not manage rendered macOS Desktop App Stack Brewfile target"
+
+assert_managed_paths_exclude_prefix \
+  "$macos_terminal_apps_managed_targets" \
+  "Brewfile.macos-desktop-apps" \
+  "terminal-apps group does not manage rendered macOS Desktop App Stack Brewfile target"
+
+assert_not_contains_text "$macos_brewfile" 'cask "ghostty"' "macOS default does not render Ghostty"
+assert_not_contains_text "$macos_brewfile" 'cask "cmux"' "macOS default does not render cmux"
+assert_not_contains_text "$macos_brewfile" 'cask "hammerspoon"' "macOS default does not render Hammerspoon"
+assert_not_contains_text "$macos_brewfile" 'cask "karabiner-elements"' "macOS default does not render Karabiner-Elements"
+assert_not_contains_text "$macos_brewfile" 'cask "raycast"' "macOS default does not render Raycast"
+assert_not_contains_text "$macos_brewfile" 'cask "1password-cli"' "macOS default does not render 1Password CLI"
+assert_not_contains_text "$macos_brewfile" 'cask "istat-menus"' "macOS default does not render iStat Menus"
+
+assert_contains_text "$terminal_apps_brewfile" 'cask "ghostty"' "terminal-apps group renders Ghostty"
+assert_contains_text "$terminal_apps_brewfile" 'cask "cmux"' "terminal-apps group renders cmux"
+assert_not_contains_text "$terminal_apps_brewfile" 'cask "hammerspoon"' "terminal-apps group does not render automation casks"
+
+assert_contains_text "$automation_apps_brewfile" 'cask "hammerspoon"' "automation group renders Hammerspoon"
+assert_contains_text "$automation_apps_brewfile" 'cask "karabiner-elements"' "automation group renders Karabiner-Elements"
+
+assert_contains_text "$launcher_apps_brewfile" 'cask "raycast"' "launcher group renders Raycast"
+assert_contains_text "$launcher_apps_brewfile" 'cask "1password-cli"' "launcher group renders 1Password CLI"
+
+assert_contains_text "$monitoring_apps_brewfile" 'cask "istat-menus"' "monitoring group renders iStat Menus"
 
 assert_contains_text \
-  "$macos_desktop_apps_bootstrap" \
+  "$macos_terminal_apps_bootstrap" \
+  "terrapod-macos-desktop-apps" \
+  "terminal-apps group renders macOS Desktop App Stack Brewfile"
+
+assert_contains_text \
+  "$macos_terminal_apps_bootstrap" \
   'brew bundle --no-upgrade --file="$desktop_brewfile"' \
-  "enableMacosDesktopApps runs macOS Desktop App Stack Brewfile"
+  "terminal-apps group runs macOS Desktop App Stack Brewfile"
 
 assert_not_contains_text \
   "$macos_development_workspace_bootstrap" \
@@ -204,14 +266,19 @@ assert_not_contains_text \
   "Karabiner opener default skips macOS Desktop App Stack Brewfile checksum"
 
 assert_contains_text \
-  "$macos_desktop_apps_karabiner_opener" \
+  "$macos_automation_apps_karabiner_opener" \
   "macOS Desktop App Stack enabled: true" \
   "Karabiner opener tracks enabled macOS Desktop App Stack state"
 
 assert_contains_text \
-  "$macos_desktop_apps_karabiner_opener" \
+  "$macos_automation_apps_karabiner_opener" \
   "macOS Desktop App Stack Brewfile checksum" \
   "Karabiner opener tracks macOS Desktop App Stack Brewfile changes"
+
+assert_texts_differ \
+  "$macos_terminal_apps_karabiner_opener" \
+  "$macos_automation_apps_karabiner_opener" \
+  "Karabiner opener tracks different macOS Desktop App Group combinations"
 
 for cask in \
   font-jetbrains-mono-nerd-font \
@@ -230,28 +297,6 @@ fi
 
 pass "core Brewfile casks are terminal font casks only"
 
-for cask in \
-  ghostty \
-  cmux \
-  hammerspoon \
-  istat-menus \
-  karabiner-elements \
-  raycast \
-  1password-cli
-do
-  if ! grep -Fx "cask \"$cask\"" "$repo_root/Brewfile.macos-desktop-apps" >/dev/null; then
-    fail "macOS Desktop App Stack Brewfile contains expected cask: $cask"
-  fi
-done
-
-pass "macOS Desktop App Stack Brewfile contains expected casks"
-
-if grep -Ev '^[[:space:]]*($|#|cask[[:space:]])' "$repo_root/Brewfile.macos-desktop-apps" >/dev/null; then
-  fail "macOS Desktop App Stack Brewfile contains only cask entries"
-fi
-
-pass "macOS Desktop App Stack Brewfile contains only cask entries"
-
 for app_config in \
   ".config/ghostty/config" \
   ".config/cmux/settings.json" \
@@ -262,12 +307,12 @@ do
     fail "macOS default manages user-scoped app config: $app_config"
   fi
 
-  if ! printf '%s\n' "$macos_desktop_apps_managed_targets" | grep -Fx "$app_config" >/dev/null; then
-    fail "enableMacosDesktopApps manages user-scoped app config: $app_config"
+  if ! printf '%s\n' "$macos_terminal_apps_managed_targets" | grep -Fx "$app_config" >/dev/null; then
+    fail "terminal-apps group manages user-scoped app config: $app_config"
   fi
 done
 
-pass "user-scoped macOS app config remains managed regardless of enableMacosDesktopApps"
+pass "user-scoped macOS app config remains managed regardless of app group selection"
 
 assert_managed_paths_exclude_prefix \
   "$macos_managed" \

--- a/tests/readme_optional_stack_profiles_test.sh
+++ b/tests/readme_optional_stack_profiles_test.sh
@@ -24,6 +24,29 @@ assert_contains() {
   pass "$message"
 }
 
+assert_not_contains() {
+  needle="$1"
+  message="$2"
+
+  if grep -F "$needle" "$readme" >/dev/null; then
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
+assert_key_row_contains() {
+  key="$1"
+  needle="$2"
+  message="$3"
+
+  if ! awk -v key="$key" -v needle="$needle" 'index($0, key) && index($0, needle) { found=1 } END { exit found ? 0 : 1 }' "$readme"; then
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
 assert_ubuntu_setup_contains() {
   needle="$1"
   message="$2"
@@ -39,22 +62,68 @@ assert_ubuntu_setup_contains() {
   pass "$message"
 }
 
+assert_raycast_restore_contains() {
+  needle="$1"
+  message="$2"
+
+  if ! awk '
+    /^### Raycast$/ { in_raycast = 1; next }
+    /^## Local overrides$/ { in_raycast = 0 }
+    in_raycast { print }
+  ' "$readme" | grep -F "$needle" >/dev/null; then
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
 assert_contains '| `enableEditorStack` | `false` |' \
   "README documents enableEditorStack default"
 assert_contains '| `enableAiCliTools` | `false` |' \
   "README documents enableAiCliTools default"
 assert_contains '| `enableDevelopmentWorkspace` | `false` |' \
   "README documents enableDevelopmentWorkspace default"
-assert_contains '`enableMacosDesktopApps`' \
-  "README documents enableMacosDesktopApps option"
-if ! awk -F '|' '/`enableMacosDesktopApps`/ { gsub(/^[[:space:]]+|[[:space:]]+$/, "", $3); if ($3 == "`false`") found=1 } END { exit found ? 0 : 1 }' "$readme"; then
-  fail "README documents enableMacosDesktopApps default"
-fi
+assert_not_contains 'enableMacosDesktopApps' \
+  "README does not document legacy enableMacosDesktopApps option"
 
-pass "README documents enableMacosDesktopApps default"
+for key in \
+  enableMacosAppGroupTerminalApps \
+  enableMacosAppGroupAutomation \
+  enableMacosAppGroupLauncher \
+  enableMacosAppGroupMonitoring
+do
+  assert_contains "\`$key\`" "README documents $key option"
+  if ! awk -F '|' -v key="\`$key\`" '$0 ~ key { gsub(/^[[:space:]]+|[[:space:]]+$/, "", $3); if ($3 == "`false`") found=1 } END { exit found ? 0 : 1 }' "$readme"; then
+    fail "README documents $key default"
+  fi
+  pass "README documents $key default"
+done
 
-assert_contains 'All three optional stack profiles are disabled by default.' \
-  "README states optional stack profiles are disabled by default"
+assert_key_row_contains '`enableMacosAppGroupTerminalApps`' 'terminal-apps' \
+  "README documents terminal-apps group on its option row"
+assert_key_row_contains '`enableMacosAppGroupTerminalApps`' 'Ghostty' \
+  "README documents Ghostty on the terminal-apps option row"
+assert_key_row_contains '`enableMacosAppGroupTerminalApps`' 'cmux' \
+  "README documents cmux on the terminal-apps option row"
+assert_key_row_contains '`enableMacosAppGroupAutomation`' 'automation' \
+  "README documents automation group on its option row"
+assert_key_row_contains '`enableMacosAppGroupAutomation`' 'Hammerspoon' \
+  "README documents Hammerspoon on the automation option row"
+assert_key_row_contains '`enableMacosAppGroupAutomation`' 'Karabiner-Elements' \
+  "README documents Karabiner-Elements on the automation option row"
+assert_key_row_contains '`enableMacosAppGroupLauncher`' 'launcher' \
+  "README documents launcher group on its option row"
+assert_key_row_contains '`enableMacosAppGroupLauncher`' 'Raycast' \
+  "README documents Raycast on the launcher option row"
+assert_key_row_contains '`enableMacosAppGroupLauncher`' '1Password CLI' \
+  "README documents 1Password CLI on the launcher option row"
+assert_key_row_contains '`enableMacosAppGroupMonitoring`' 'monitoring' \
+  "README documents monitoring group on its option row"
+assert_key_row_contains '`enableMacosAppGroupMonitoring`' 'iStat Menus' \
+  "README documents iStat Menus on the monitoring option row"
+
+assert_contains 'Optional stack profiles and macOS App Group settings are disabled by default.' \
+  "README states optional stack profiles and App Groups are disabled by default"
 assert_ubuntu_setup_contains 'GitHub CLI (`gh`)' \
   "README documents gh as part of the Ubuntu Core Shell Stack"
 assert_contains 'When `enableDevelopmentWorkspace` is `true`' \
@@ -64,9 +133,11 @@ assert_contains 'Optional Editor Stack and Optional AI Tool Stack' \
 assert_contains 'macOS Desktop App Stack' \
   "README documents macOS Desktop App Stack"
 assert_contains 'separate from `enableDevelopmentWorkspace`' \
-  "README documents enableMacosDesktopApps separation from enableDevelopmentWorkspace"
+  "README documents macOS Desktop App Stack separation from enableDevelopmentWorkspace"
 assert_contains 'casks can affect shared applications' \
   "README documents why macOS Desktop App Stack remains separate"
+assert_raycast_restore_contains '`enableMacosAppGroupLauncher`' \
+  "README Raycast restore procedure mentions launcher App Group"
 assert_contains 'Opting out of an optional stack excludes its files from chezmoi management; it does not remove files already present on a machine.' \
   "README documents non-destructive optional stack opt-out"
 

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -40,6 +40,18 @@ assert_contains() {
   pass "$message"
 }
 
+assert_not_contains() {
+  haystack="$1"
+  needle="$2"
+  message="$3"
+
+  if printf '%s\n' "$haystack" | grep -F "$needle" >/dev/null; then
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
 assert_line() {
   haystack="$1"
   expected_line="$2"
@@ -69,6 +81,31 @@ assert_call_args() {
     sed 's/^/  /' "$expected_file" >&2
     printf '%s\n' "actual args:" >&2
     sed 's/^/  /' "$call_file" >&2
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
+assert_no_terrapod_artifacts_under() {
+  dir="$1"
+  message="$2"
+  found_file="$tmp_dir/found-terrapod-artifacts"
+
+  : >"$found_file"
+  if [ -d "$dir" ]; then
+    find "$dir" \
+      \( -name '.terrapod-config.*' \
+      -o -name '.terrapod-data.*' \
+      -o -name '*.terrapod-backup-*' \
+      -o -name '*.terrapod-tmp-*' \
+      -o -name '*.terrapod-data-*' \) \
+      -print >"$found_file"
+  fi
+
+  if [ -s "$found_file" ]; then
+    printf '%s\n' "unexpected Terrapod artifacts:" >&2
+    sed 's/^/  /' "$found_file" >&2
     fail "$message"
   fi
 
@@ -154,10 +191,10 @@ pass "tpod alias points to Terrapod"
 sh -n "$terrapod" || fail "Terrapod command is valid POSIX shell"
 pass "Terrapod command is valid POSIX shell"
 
-help_output="$(sh "$terrapod" help)"
+help_output="$(TERRAPOD_PROFILE=macos-terminal sh "$terrapod" help)"
 
 ln -s "$terrapod" "$tmp_dir/bin/tpod"
-tpod_help_output="$(PATH="$tmp_dir/bin:/usr/bin:/bin" "$tmp_dir/bin/tpod" help)"
+tpod_help_output="$(TERRAPOD_PROFILE=macos-terminal PATH="$tmp_dir/bin:/usr/bin:/bin" "$tmp_dir/bin/tpod" help)"
 
 if [ "$tpod_help_output" != "$help_output" ]; then
   fail "tpod shows the same help as Terrapod"
@@ -189,6 +226,46 @@ assert_contains \
   "$help_output" \
   "terrapod configure <minimal|development|workstation>" \
   "Terrapod help documents Preset configuration"
+
+macos_help_output="$(TERRAPOD_PROFILE=macos-terminal sh "$terrapod" help)"
+
+assert_contains \
+  "$macos_help_output" \
+  "terrapod configure <minimal|development|workstation>" \
+  "macOS Terminal Profile help exposes workstation Preset"
+
+vps_help_output="$(TERRAPOD_PROFILE=vps-shell sh "$terrapod" help)"
+
+assert_contains \
+  "$vps_help_output" \
+  "terrapod configure <minimal|development>" \
+  "VPS Shell Profile help hides workstation Preset"
+
+assert_not_contains \
+  "$vps_help_output" \
+  "workstation" \
+  "VPS Shell Profile help does not mention workstation anywhere"
+
+if TERRAPOD_PROFILE=vps-shell HOME="$tmp_dir/home" XDG_CONFIG_HOME="$tmp_dir/xdg" sh "$terrapod" configure workstation >"$tmp_dir/vps-workstation.out" 2>"$tmp_dir/vps-workstation.err"; then
+  fail "VPS Shell Profile rejects workstation Preset"
+fi
+pass "VPS Shell Profile rejects workstation Preset"
+
+if [ -e "$tmp_dir/xdg/chezmoi/chezmoi.toml" ]; then
+  fail "VPS Shell Profile rejects workstation Preset before writing config"
+fi
+pass "VPS Shell Profile rejects workstation Preset before writing config"
+
+assert_no_terrapod_artifacts_under \
+  "$tmp_dir/xdg/chezmoi" \
+  "VPS Shell Profile workstation rejection leaves no Terrapod artifacts"
+
+vps_workstation_error="$(cat "$tmp_dir/vps-workstation.err")"
+
+assert_contains \
+  "$vps_workstation_error" \
+  "workstation Preset is only available for the macOS Terminal Profile" \
+  "VPS Shell Profile explains workstation Preset rejection"
 
 assert_contains \
   "$help_output" \

--- a/tests/terrapod_config_test.sh
+++ b/tests/terrapod_config_test.sh
@@ -266,7 +266,11 @@ assert_contains "$new_config" "[data]" "new config contains a data section"
 assert_data_key_once_with_value "$new_config" "enableEditorStack" "false" "minimal Preset disables Optional Editor Stack exactly once in data"
 assert_data_key_once_with_value "$new_config" "enableAiCliTools" "false" "minimal Preset disables Optional AI Tool Stack exactly once in data"
 assert_data_key_once_with_value "$new_config" "enableDevelopmentWorkspace" "false" "minimal Preset disables Optional Development Workspace exactly once in data"
-assert_data_key_once_with_value "$new_config" "enableMacosDesktopApps" "false" "minimal Preset disables macOS App Groups through the desktop-app boundary exactly once in data"
+assert_data_key_once_with_value "$new_config" "enableMacosAppGroupTerminalApps" "false" "minimal Preset disables terminal-apps macOS App Group exactly once in data"
+assert_data_key_once_with_value "$new_config" "enableMacosAppGroupAutomation" "false" "minimal Preset disables automation macOS App Group exactly once in data"
+assert_data_key_once_with_value "$new_config" "enableMacosAppGroupLauncher" "false" "minimal Preset disables launcher macOS App Group exactly once in data"
+assert_data_key_once_with_value "$new_config" "enableMacosAppGroupMonitoring" "false" "minimal Preset disables monitoring macOS App Group exactly once in data"
+assert_not_contains "$new_config" "enableMacosDesktopApps" "minimal Preset does not write the legacy all-in desktop app toggle"
 assert_not_contains "$new_config" "terrapodPreset" "minimal Preset stores concrete values instead of a dynamic Preset"
 assert_backup_count "$new_config" 0 "new config creation does not create a backup"
 
@@ -275,7 +279,7 @@ workstation_xdg="$tmp_dir/workstation-xdg"
 workstation_config="$workstation_xdg/chezmoi/chezmoi.toml"
 mkdir -p "$workstation_home"
 
-run_terrapod_configure workstation "" "$workstation_home" "$workstation_xdg"
+TERRAPOD_PROFILE=macos-terminal run_terrapod_configure workstation "" "$workstation_home" "$workstation_xdg"
 
 if [ ! -f "$workstation_config" ]; then
   fail "workstation Preset creates a chezmoi config file"
@@ -285,7 +289,11 @@ pass "workstation Preset creates a chezmoi config file"
 assert_data_key_once_with_value "$workstation_config" "enableEditorStack" "true" "workstation Preset enables Optional Editor Stack exactly once in data"
 assert_data_key_once_with_value "$workstation_config" "enableAiCliTools" "true" "workstation Preset enables Optional AI Tool Stack exactly once in data"
 assert_data_key_once_with_value "$workstation_config" "enableDevelopmentWorkspace" "true" "workstation Preset enables Optional Development Workspace exactly once in data"
-assert_data_key_once_with_value "$workstation_config" "enableMacosDesktopApps" "true" "workstation Preset enables macOS App Groups through the desktop-app boundary exactly once in data"
+assert_data_key_once_with_value "$workstation_config" "enableMacosAppGroupTerminalApps" "true" "workstation Preset enables terminal-apps macOS App Group exactly once in data"
+assert_data_key_once_with_value "$workstation_config" "enableMacosAppGroupAutomation" "true" "workstation Preset enables automation macOS App Group exactly once in data"
+assert_data_key_once_with_value "$workstation_config" "enableMacosAppGroupLauncher" "true" "workstation Preset enables launcher macOS App Group exactly once in data"
+assert_data_key_once_with_value "$workstation_config" "enableMacosAppGroupMonitoring" "true" "workstation Preset enables monitoring macOS App Group exactly once in data"
+assert_not_contains "$workstation_config" "enableMacosDesktopApps" "workstation Preset does not write the legacy all-in desktop app toggle"
 assert_not_contains "$workstation_config" "terrapodPreset" "workstation Preset stores concrete values instead of a dynamic Preset"
 assert_backup_count "$workstation_config" 0 "workstation config creation does not create a backup"
 
@@ -339,7 +347,11 @@ assert_contains "$existing_config" "command = \"nvim\"" "existing update preserv
 assert_data_key_once_with_value "$existing_config" "enableEditorStack" "true" "development Preset enables Optional Editor Stack exactly once in data"
 assert_data_key_once_with_value "$existing_config" "enableAiCliTools" "true" "development Preset enables Optional AI Tool Stack exactly once in data"
 assert_data_key_once_with_value "$existing_config" "enableDevelopmentWorkspace" "true" "development Preset enables Optional Development Workspace exactly once in data"
-assert_data_key_once_with_value "$existing_config" "enableMacosDesktopApps" "false" "development Preset leaves macOS App Groups disabled exactly once in data"
+assert_data_key_once_with_value "$existing_config" "enableMacosAppGroupTerminalApps" "false" "development Preset disables terminal-apps macOS App Group exactly once in data"
+assert_data_key_once_with_value "$existing_config" "enableMacosAppGroupAutomation" "false" "development Preset disables automation macOS App Group exactly once in data"
+assert_data_key_once_with_value "$existing_config" "enableMacosAppGroupLauncher" "false" "development Preset disables launcher macOS App Group exactly once in data"
+assert_data_key_once_with_value "$existing_config" "enableMacosAppGroupMonitoring" "false" "development Preset disables monitoring macOS App Group exactly once in data"
+assert_not_contains "$existing_config" "enableMacosDesktopApps" "existing update removes the legacy all-in desktop app toggle"
 assert_not_contains "$existing_config" "terrapodPreset" "existing update removes stale dynamic Preset key"
 assert_single_backup_matches "$existing_config" "$tmp_dir/existing-before.toml" "existing update creates one backup before changing managed keys"
 
@@ -352,6 +364,7 @@ cat >"$quoted_table_config" <<'TOML'
 ["data"]
 keepQuotedTable = "preserve"
 enableEditorStack = false
+enableMacosDesktopApps = true
 terrapodPreset = "minimal"
 
 [sourceState]
@@ -367,7 +380,11 @@ assert_contains "$quoted_table_config" "branch = \"main\"" "quoted data table up
 assert_data_key_once_with_value "$quoted_table_config" "enableEditorStack" "true" "quoted data table update writes Editor Stack in data"
 assert_data_key_once_with_value "$quoted_table_config" "enableAiCliTools" "true" "quoted data table update writes AI Tool Stack in data"
 assert_data_key_once_with_value "$quoted_table_config" "enableDevelopmentWorkspace" "true" "quoted data table update writes Development Workspace in data"
-assert_data_key_once_with_value "$quoted_table_config" "enableMacosDesktopApps" "false" "quoted data table update writes macOS desktop-app boundary in data"
+assert_data_key_once_with_value "$quoted_table_config" "enableMacosAppGroupTerminalApps" "false" "quoted data table update writes terminal-apps App Group in data"
+assert_data_key_once_with_value "$quoted_table_config" "enableMacosAppGroupAutomation" "false" "quoted data table update writes automation App Group in data"
+assert_data_key_once_with_value "$quoted_table_config" "enableMacosAppGroupLauncher" "false" "quoted data table update writes launcher App Group in data"
+assert_data_key_once_with_value "$quoted_table_config" "enableMacosAppGroupMonitoring" "false" "quoted data table update writes monitoring App Group in data"
+assert_not_contains "$quoted_table_config" "enableMacosDesktopApps" "quoted data table update removes the legacy all-in desktop app toggle"
 assert_not_contains "$quoted_table_config" "terrapodPreset" "quoted data table update removes stale dynamic Preset key"
 
 spaced_table_home="$tmp_dir/spaced-table-home"
@@ -379,6 +396,7 @@ cat >"$spaced_table_config" <<'TOML'
 [ data ]
 keepSpacedTable = "preserve"
 enableEditorStack = false
+enableMacosDesktopApps = true
 terrapodPreset = "minimal"
 
 [sourceState]
@@ -394,7 +412,11 @@ assert_contains "$spaced_table_config" "branch = \"main\"" "spaced data table up
 assert_data_key_once_with_value "$spaced_table_config" "enableEditorStack" "true" "spaced data table update writes Editor Stack in data"
 assert_data_key_once_with_value "$spaced_table_config" "enableAiCliTools" "true" "spaced data table update writes AI Tool Stack in data"
 assert_data_key_once_with_value "$spaced_table_config" "enableDevelopmentWorkspace" "true" "spaced data table update writes Development Workspace in data"
-assert_data_key_once_with_value "$spaced_table_config" "enableMacosDesktopApps" "false" "spaced data table update writes macOS desktop-app boundary in data"
+assert_data_key_once_with_value "$spaced_table_config" "enableMacosAppGroupTerminalApps" "false" "spaced data table update writes terminal-apps App Group in data"
+assert_data_key_once_with_value "$spaced_table_config" "enableMacosAppGroupAutomation" "false" "spaced data table update writes automation App Group in data"
+assert_data_key_once_with_value "$spaced_table_config" "enableMacosAppGroupLauncher" "false" "spaced data table update writes launcher App Group in data"
+assert_data_key_once_with_value "$spaced_table_config" "enableMacosAppGroupMonitoring" "false" "spaced data table update writes monitoring App Group in data"
+assert_not_contains "$spaced_table_config" "enableMacosDesktopApps" "spaced data table update removes the legacy all-in desktop app toggle"
 assert_not_contains "$spaced_table_config" "terrapodPreset" "spaced data table update removes stale dynamic Preset key"
 
 dotted_home="$tmp_dir/dotted-home"
@@ -422,7 +444,11 @@ assert_contains "$dotted_config" "branch = \"main\"" "dotted data update preserv
 assert_contains "$dotted_config" "data.enableEditorStack = true" "dotted data update writes Editor Stack as a dotted data key"
 assert_contains "$dotted_config" "data.enableAiCliTools = true" "dotted data update writes AI Tool Stack as a dotted data key"
 assert_contains "$dotted_config" "data.enableDevelopmentWorkspace = true" "dotted data update writes Development Workspace as a dotted data key"
-assert_contains "$dotted_config" "data.enableMacosDesktopApps = false" "dotted data update writes macOS desktop-app boundary as a dotted data key"
+assert_contains "$dotted_config" "data.enableMacosAppGroupTerminalApps = false" "dotted data update writes terminal-apps App Group as a dotted data key"
+assert_contains "$dotted_config" "data.enableMacosAppGroupAutomation = false" "dotted data update writes automation App Group as a dotted data key"
+assert_contains "$dotted_config" "data.enableMacosAppGroupLauncher = false" "dotted data update writes launcher App Group as a dotted data key"
+assert_contains "$dotted_config" "data.enableMacosAppGroupMonitoring = false" "dotted data update writes monitoring App Group as a dotted data key"
+assert_not_contains "$dotted_config" "data.enableMacosDesktopApps" "dotted data update removes the legacy all-in desktop app toggle"
 assert_not_contains "$dotted_config" "data.terrapodPreset" "dotted data update removes stale dynamic Preset key"
 
 if ! HOME="$dotted_home" XDG_CONFIG_HOME="$dotted_xdg" chezmoi --config "$dotted_config" data >"$tmp_dir/dotted-data.out" 2>"$tmp_dir/dotted-data.err"; then
@@ -452,7 +478,10 @@ run_terrapod_configure development "y" "$quoted_home" "$quoted_xdg"
 assert_data_key_once_with_value "$quoted_config" "enableEditorStack" "true" "quoted managed key update writes one Editor Stack value in data"
 assert_data_key_once_with_value "$quoted_config" "enableAiCliTools" "true" "quoted managed key update writes one AI Tool Stack value in data"
 assert_data_key_once_with_value "$quoted_config" "enableDevelopmentWorkspace" "true" "quoted managed key update writes one Development Workspace value in data"
-assert_data_key_once_with_value "$quoted_config" "enableMacosDesktopApps" "false" "quoted managed key update writes one macOS desktop-app boundary value in data"
+assert_data_key_once_with_value "$quoted_config" "enableMacosAppGroupTerminalApps" "false" "quoted managed key update writes one terminal-apps App Group value in data"
+assert_data_key_once_with_value "$quoted_config" "enableMacosAppGroupAutomation" "false" "quoted managed key update writes one automation App Group value in data"
+assert_data_key_once_with_value "$quoted_config" "enableMacosAppGroupLauncher" "false" "quoted managed key update writes one launcher App Group value in data"
+assert_data_key_once_with_value "$quoted_config" "enableMacosAppGroupMonitoring" "false" "quoted managed key update writes one monitoring App Group value in data"
 assert_not_contains "$quoted_config" "\"enableEditorStack\"" "quoted managed key update removes quoted Editor Stack key"
 assert_not_contains "$quoted_config" "\"enableAiCliTools\"" "quoted managed key update removes quoted AI Tool Stack key"
 assert_not_contains "$quoted_config" "\"enableDevelopmentWorkspace\"" "quoted managed key update removes quoted Development Workspace key"
@@ -486,12 +515,18 @@ assert_contains "$array_config" "keepMe = \"yes\"" "array-table update preserves
 assert_data_key_once_with_value "$array_config" "enableEditorStack" "true" "array-table update writes Editor Stack only in data"
 assert_data_key_once_with_value "$array_config" "enableAiCliTools" "true" "array-table update writes AI Tool Stack only in data"
 assert_data_key_once_with_value "$array_config" "enableDevelopmentWorkspace" "true" "array-table update writes Development Workspace only in data"
-assert_data_key_once_with_value "$array_config" "enableMacosDesktopApps" "false" "array-table update writes macOS desktop-app boundary only in data"
+assert_data_key_once_with_value "$array_config" "enableMacosAppGroupTerminalApps" "false" "array-table update writes terminal-apps App Group only in data"
+assert_data_key_once_with_value "$array_config" "enableMacosAppGroupAutomation" "false" "array-table update writes automation App Group only in data"
+assert_data_key_once_with_value "$array_config" "enableMacosAppGroupLauncher" "false" "array-table update writes launcher App Group only in data"
+assert_data_key_once_with_value "$array_config" "enableMacosAppGroupMonitoring" "false" "array-table update writes monitoring App Group only in data"
 assert_contains "$array_config" "[[merge.command]]" "array-table update preserves TOML array table"
 assert_contains "$array_config" "enableEditorStack = \"do-not-touch\"" "array-table update preserves same-named external key"
 assert_lines_after_header_not_contains "$array_config" "[[merge.command]]" "enableAiCliTools = true" "array-table update does not append AI Tool Stack under array table"
 assert_lines_after_header_not_contains "$array_config" "[[merge.command]]" "enableDevelopmentWorkspace = true" "array-table update does not append Development Workspace under array table"
-assert_lines_after_header_not_contains "$array_config" "[[merge.command]]" "enableMacosDesktopApps = false" "array-table update does not append macOS desktop-app boundary under array table"
+assert_lines_after_header_not_contains "$array_config" "[[merge.command]]" "enableMacosAppGroupTerminalApps = false" "array-table update does not append terminal-apps App Group under array table"
+assert_lines_after_header_not_contains "$array_config" "[[merge.command]]" "enableMacosAppGroupAutomation = false" "array-table update does not append automation App Group under array table"
+assert_lines_after_header_not_contains "$array_config" "[[merge.command]]" "enableMacosAppGroupLauncher = false" "array-table update does not append launcher App Group under array table"
+assert_lines_after_header_not_contains "$array_config" "[[merge.command]]" "enableMacosAppGroupMonitoring = false" "array-table update does not append monitoring App Group under array table"
 
 array_mode="$(file_mode "$array_config")"
 if [ "$array_mode" != "600" ]; then
@@ -525,7 +560,10 @@ assert_contains "$signers_config" "name@company.com ssh-ed25519 AAAA_COMPANY_PUB
 assert_data_key_once_with_value "$signers_config" "enableEditorStack" "true" "documented signer array update writes Editor Stack in data"
 assert_data_key_once_with_value "$signers_config" "enableAiCliTools" "true" "documented signer array update writes AI Tool Stack in data"
 assert_data_key_once_with_value "$signers_config" "enableDevelopmentWorkspace" "true" "documented signer array update writes Development Workspace in data"
-assert_data_key_once_with_value "$signers_config" "enableMacosDesktopApps" "false" "documented signer array update writes macOS desktop-app boundary in data"
+assert_data_key_once_with_value "$signers_config" "enableMacosAppGroupTerminalApps" "false" "documented signer array update writes terminal-apps App Group in data"
+assert_data_key_once_with_value "$signers_config" "enableMacosAppGroupAutomation" "false" "documented signer array update writes automation App Group in data"
+assert_data_key_once_with_value "$signers_config" "enableMacosAppGroupLauncher" "false" "documented signer array update writes launcher App Group in data"
+assert_data_key_once_with_value "$signers_config" "enableMacosAppGroupMonitoring" "false" "documented signer array update writes monitoring App Group in data"
 assert_contains "$signers_config" "branch = \"main\"" "documented signer array update preserves later sections"
 
 multiline_array_home="$tmp_dir/multiline-array-home"


### PR DESCRIPTION
## Summary

- Adds profile-aware Terrapod preset visibility so `workstation` is available on the macOS Terminal Profile and rejected for the VPS Shell Profile.
- Replaces the legacy all-in macOS desktop app toggle with purpose-based App Group data keys and grouped cask rendering.
- Updates README guidance and shell tests for preset expansion, group-to-cask rendering, default disabled behavior, and stale key removal.

## Impact

This keeps macOS desktop app installation grouped by purpose without introducing individual app toggles. Existing `enableMacosDesktopApps` values are treated as stale managed config keys; users should run `terrapod configure workstation` or set the new App Group keys to opt into the grouped stack.

Closes #34.

## Validation

- `sh tests/terrapod_config_test.sh`
- `sh tests/terrapod_command_test.sh`
- `sh tests/chezmoiignore_test.sh`
- `sh tests/readme_optional_stack_profiles_test.sh`
- Full `tests/*.sh` suite plus `zsh tests/zshrc_zoxide_test.zsh`
- `git diff --check`
- Final review against `origin/main`: no blocking findings