### PR TITLE
Add Terrapod diff and apply wrappers

### DIFF
--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -10,6 +10,8 @@ Terrapod - Dotfiles Management Tool
 Usage:
   terrapod [help|--help|-h]
   terrapod configure <$preset_args>
+  terrapod diff
+  terrapod apply
   terrapod update
   terrapod chezmoi -- <args...>
 
@@ -17,11 +19,15 @@ Commands:
   help                                  Show this help.
   configure <$preset_args>
                                         Expand a Preset into concrete chezmoi data values.
+  diff                                  Run chezmoi diff with Terrapod profile and stack context.
+  apply                                 Run preflight checks, chezmoi apply, and post-apply validation.
   update                                Run chezmoi update with Terrapod profile and config context.
   chezmoi -- <args...>                  Run raw chezmoi for advanced maintenance.
 
 Examples:
   terrapod configure development
+  terrapod diff
+  terrapod apply
   terrapod update
   terrapod chezmoi -- status
 EOF
@@ -109,23 +115,309 @@ profile_context_label() {
   esac
 }
 
-show_update_context() {
-  config_file="$(chezmoi_config_file)"
+config_data_bool() {
+  config_file="$1"
+  key="$2"
 
-  printf '%s\n' "Terrapod update"
-  printf '%s\n' "Profile: $(profile_context_label)"
+  if [ ! -f "$config_file" ]; then
+    printf '%s\n' "false"
+    return
+  fi
+
+  awk -v wanted_key="$key" '
+    function strip_space(value) {
+      sub(/^[[:space:]]*/, "", value)
+      sub(/[[:space:]]*$/, "", value)
+      return value
+    }
+
+    function strip_comment(value) {
+      sub(/[[:space:]]*#.*/, "", value)
+      return value
+    }
+
+    function unquote_key(value, quote) {
+      value = strip_space(value)
+      quote = substr(value, 1, 1)
+
+      if ((quote == "\"" || quote == "\047") && substr(value, length(value), 1) == quote) {
+        return substr(value, 2, length(value) - 2)
+      }
+
+      return value
+    }
+
+    function is_comment(line) {
+      return line ~ "^[[:space:]]*#"
+    }
+
+    function is_data_section(line) {
+      return line ~ "^[[:space:]]*\\[[[:space:]]*(data|\"data\"|\047data\047)[[:space:]]*\\][[:space:]]*($|#)"
+    }
+
+    function is_section(line) {
+      return line ~ /^[[:space:]]*(\[[^]]+\]|\[\[[^]]+\]\])[[:space:]]*($|#)/
+    }
+
+    function is_key_assignment(line) {
+      return line ~ "^[[:space:]]*(\"[^\"]+\"|\047[^\047]+\047|[A-Za-z0-9_-]+)[[:space:]]*="
+    }
+
+    function is_root_dotted_data_key(line) {
+      return line ~ "^[[:space:]]*(data|\"data\"|\047data\047)[[:space:]]*\\."
+    }
+
+    function assignment_key_name(line, key) {
+      key = line
+      sub(/^[[:space:]]*/, "", key)
+      sub(/[[:space:]]*=.*/, "", key)
+      return unquote_key(key)
+    }
+
+    function dotted_data_key_name(line, key) {
+      key = line
+      sub(/^[[:space:]]*/, "", key)
+      sub(/[[:space:]]*=.*/, "", key)
+      sub("^[[:space:]]*(data|\"data\"|\047data\047)[[:space:]]*\\.[[:space:]]*", "", key)
+      return unquote_key(key)
+    }
+
+    function assignment_value(line, value) {
+      value = line
+      sub(/^[^=]*=/, "", value)
+      return strip_space(strip_comment(value))
+    }
+
+    BEGIN {
+      in_root = 1
+      result = "false"
+    }
+
+    {
+      if (is_comment($0)) {
+        next
+      }
+
+      if (in_root && is_root_dotted_data_key($0)) {
+        if (dotted_data_key_name($0) == wanted_key) {
+          result = assignment_value($0)
+        }
+        next
+      }
+
+      if (is_data_section($0)) {
+        in_root = 0
+        in_data = 1
+        next
+      }
+
+      if (is_section($0)) {
+        in_root = 0
+        in_data = 0
+        next
+      }
+
+      if (in_data && is_key_assignment($0) && assignment_key_name($0) == wanted_key) {
+        result = assignment_value($0)
+      }
+    }
+
+    END {
+      if (result == "true") {
+        print "true"
+      } else {
+        print "false"
+      }
+    }
+  ' "$config_file"
+}
+
+bool_state_label() {
+  case "$1" in
+    true)
+      printf '%s\n' "enabled"
+      ;;
+    *)
+      printf '%s\n' "disabled"
+      ;;
+  esac
+}
+
+config_bool_state_label() {
+  bool_state_label "$(config_data_bool "$1" "$2")"
+}
+
+effective_optional_stack_state_label() {
+  config_file="$1"
+  key="$2"
+
+  if [ "$(config_data_bool "$config_file" "$key")" = "true" ] ||
+    [ "$(config_data_bool "$config_file" enableDevelopmentWorkspace)" = "true" ]; then
+    bool_state_label true
+  else
+    bool_state_label false
+  fi
+}
+
+show_config_context() {
+  config_file="$1"
 
   if [ -f "$config_file" ]; then
     printf '%s\n' "Config: $config_file (present)"
   else
     printf '%s\n' "Config: $config_file (missing; chezmoi defaults apply)"
   fi
+}
+
+show_stack_context() {
+  config_file="$1"
+
+  printf '%s\n' "Optional stacks:"
+  printf '%s\n' "Optional Editor Stack: $(effective_optional_stack_state_label "$config_file" enableEditorStack)"
+  printf '%s\n' "Optional AI Tool Stack: $(effective_optional_stack_state_label "$config_file" enableAiCliTools)"
+  printf '%s\n' "Optional Development Workspace: $(config_bool_state_label "$config_file" enableDevelopmentWorkspace)"
+  printf '%s\n' "macOS App Groups:"
+  printf '%s\n' "terminal-apps: $(config_bool_state_label "$config_file" enableMacosAppGroupTerminalApps)"
+  printf '%s\n' "automation: $(config_bool_state_label "$config_file" enableMacosAppGroupAutomation)"
+  printf '%s\n' "launcher: $(config_bool_state_label "$config_file" enableMacosAppGroupLauncher)"
+  printf '%s\n' "monitoring: $(config_bool_state_label "$config_file" enableMacosAppGroupMonitoring)"
+}
+
+render_chezmoi_command() {
+  printf '%s' "chezmoi"
 
   if [ -n "${TERRAPOD_CHEZMOI_CONFIG:-}" ]; then
-    printf '%s\n' "Delegating repository update to: chezmoi --config $TERRAPOD_CHEZMOI_CONFIG update --exclude scripts"
-  else
-    printf '%s\n' "Delegating repository update to: chezmoi update --exclude scripts"
+    printf ' --config %s' "$TERRAPOD_CHEZMOI_CONFIG"
   fi
+
+  for arg do
+    printf ' %s' "$arg"
+  done
+
+  printf '\n'
+}
+
+run_chezmoi_command() {
+  if [ -n "${TERRAPOD_CHEZMOI_CONFIG:-}" ]; then
+    chezmoi --config "$TERRAPOD_CHEZMOI_CONFIG" "$@"
+  else
+    chezmoi "$@"
+  fi
+}
+
+show_diff_context() {
+  config_file="$(chezmoi_config_file)"
+
+  printf '%s\n' "Terrapod diff"
+  printf '%s\n' "Profile: $(profile_context_label)"
+  show_config_context "$config_file"
+  show_stack_context "$config_file"
+  printf '%s\n' "Delegating target-state diff to: $(render_chezmoi_command diff)"
+}
+
+run_diff() {
+  if [ "$#" -ne 0 ]; then
+    fail_usage "diff accepts no arguments"
+  fi
+
+  show_diff_context
+  run_chezmoi_command diff
+}
+
+run_apply_preflight() {
+  config_file="$1"
+
+  if ! command -v chezmoi >/dev/null 2>&1; then
+    fatal "chezmoi is required before apply; install it or run the Terrapod installer, then rerun 'terrapod apply'"
+  fi
+
+  printf '%s\n' "Preflight: chezmoi is available"
+
+  if [ -e "$config_file" ] || [ -L "$config_file" ]; then
+    if [ ! -f "$config_file" ] || [ ! -r "$config_file" ]; then
+      fatal "config path is not a readable file: $config_file"
+    fi
+
+    printf '%s\n' "Preflight: config file is readable"
+  else
+    printf '%s\n' "Preflight: config file is missing; chezmoi defaults will apply"
+  fi
+}
+
+validate_managed_target() {
+  managed_output="$1"
+  target="$2"
+  label="$3"
+
+  if printf '%s\n' "$managed_output" | grep -Fx "$target" >/dev/null; then
+    printf '%s\n' "Post-apply validation: $label is managed"
+    return 0
+  fi
+
+  printf '%s\n' "terrapod: post-apply validation failed: $label is not managed ($target missing)" >&2
+  print_post_apply_validation_guidance
+  return 1
+}
+
+print_post_apply_validation_guidance() {
+  if [ -n "${TERRAPOD_CHEZMOI_CONFIG:-}" ]; then
+    printf '%s\n' "Run 'terrapod chezmoi -- --config $TERRAPOD_CHEZMOI_CONFIG managed' to inspect managed targets, then rerun 'terrapod apply'." >&2
+  else
+    printf '%s\n' "Run 'terrapod chezmoi -- managed' to inspect managed targets, then rerun 'terrapod apply'." >&2
+  fi
+}
+
+run_post_apply_validation() {
+  validation_status=0
+
+  if ! managed_output="$(run_chezmoi_command managed)"; then
+    printf '%s\n' "terrapod: post-apply validation failed: unable to inspect managed targets" >&2
+    print_post_apply_validation_guidance
+    return 1
+  fi
+
+  validate_managed_target "$managed_output" ".local/bin/terrapod" "Terrapod command" ||
+    validation_status=1
+  validate_managed_target "$managed_output" ".local/bin/tpod" "tpod alias" ||
+    validation_status=1
+
+  return "$validation_status"
+}
+
+show_apply_context() {
+  config_file="$1"
+
+  printf '%s\n' "Terrapod apply"
+  printf '%s\n' "Profile: $(profile_context_label)"
+  show_config_context "$config_file"
+  show_stack_context "$config_file"
+  printf '%s\n' "Delegating target-state apply to: $(render_chezmoi_command apply)"
+}
+
+run_apply() {
+  if [ "$#" -ne 0 ]; then
+    fail_usage "apply accepts no arguments"
+  fi
+
+  config_file="$(chezmoi_config_file)"
+  show_apply_context "$config_file"
+  run_apply_preflight "$config_file"
+
+  if ! run_chezmoi_command apply; then
+    printf '%s\n' "terrapod: chezmoi apply failed; fix the error above, then rerun 'terrapod apply'." >&2
+    return 1
+  fi
+
+  run_post_apply_validation
+}
+
+show_update_context() {
+  config_file="$(chezmoi_config_file)"
+
+  printf '%s\n' "Terrapod update"
+  printf '%s\n' "Profile: $(profile_context_label)"
+  show_config_context "$config_file"
+  printf '%s\n' "Delegating repository update to: $(render_chezmoi_command update --exclude scripts)"
 }
 
 run_update() {
@@ -134,11 +426,7 @@ run_update() {
   fi
 
   show_update_context
-  if [ -n "${TERRAPOD_CHEZMOI_CONFIG:-}" ]; then
-    chezmoi --config "$TERRAPOD_CHEZMOI_CONFIG" update --exclude scripts
-  else
-    chezmoi update --exclude scripts
-  fi
+  run_chezmoi_command update --exclude scripts
 }
 
 render_preset_data() {
@@ -657,6 +945,14 @@ case "$command_name" in
     confirm_existing_config_update "$config_file"
     write_managed_config "$config_file" "$preset"
     printf '%s\n' "Configured Terrapod Preset '$preset' in $config_file"
+    ;;
+  diff)
+    shift
+    run_diff "$@"
+    ;;
+  apply)
+    shift
+    run_apply "$@"
     ;;
   update)
     shift

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -519,3 +519,457 @@ if [ -e "$BROAD_UPGRADE_CALL_FILE" ]; then
 fi
 
 pass "Terrapod update rejects extra arguments before broad upgrade flows"
+
+export CHEZMOI_CALL_FILE="$tmp_dir/chezmoi-diff.args"
+export CHEZMOI_INVOKED_FILE="$tmp_dir/chezmoi-diff.invoked"
+
+write_stub "$tmp_dir/bin/chezmoi" \
+  'printf "%s\n" invoked >"$CHEZMOI_INVOKED_FILE"' \
+  ': >"$CHEZMOI_CALL_FILE"' \
+  'for arg do' \
+  '  printf "%s\n" "$arg" >>"$CHEZMOI_CALL_FILE"' \
+  'done' \
+  'printf "%s\n" "stub diff output"' \
+  'exit 0'
+
+write_stub "$tmp_dir/bin/uname" \
+  'printf "%s\n" "Darwin"'
+
+diff_home="$tmp_dir/diff-home"
+diff_xdg="$tmp_dir/diff-xdg"
+diff_config="$diff_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$diff_home" "$(dirname "$diff_config")"
+
+cat >"$diff_config" <<'TOML'
+[data]
+enableEditorStack = false
+enableAiCliTools = false
+enableDevelopmentWorkspace = true
+enableMacosAppGroupTerminalApps = true
+enableMacosAppGroupAutomation = false
+enableMacosAppGroupLauncher = true
+enableMacosAppGroupMonitoring = false
+TOML
+
+if ! HOME="$diff_home" XDG_CONFIG_HOME="$diff_xdg" PATH="$tmp_dir/bin:/usr/bin:/bin" \
+  sh "$terrapod" diff >"$tmp_dir/diff.out" 2>"$tmp_dir/diff.err"; then
+  printf '%s\n' "diff stdout:" >&2
+  sed 's/^/  /' "$tmp_dir/diff.out" >&2
+  printf '%s\n' "diff stderr:" >&2
+  sed 's/^/  /' "$tmp_dir/diff.err" >&2
+  fail "Terrapod diff runs successfully"
+fi
+
+diff_output="$(cat "$tmp_dir/diff.out")"
+
+assert_call_args \
+  "$CHEZMOI_CALL_FILE" \
+  "Terrapod diff delegates target-state diff behavior to chezmoi diff" \
+  diff
+
+assert_contains \
+  "$diff_output" \
+  "Terrapod diff" \
+  "Terrapod diff prints command context"
+
+assert_contains \
+  "$diff_output" \
+  "Profile: macOS Terminal Profile" \
+  "Terrapod diff prints active profile context"
+
+assert_contains \
+  "$diff_output" \
+  "Config: $diff_config (present)" \
+  "Terrapod diff prints config context"
+
+assert_contains \
+  "$diff_output" \
+  "Optional stacks:" \
+  "Terrapod diff prints optional stack section header"
+
+assert_contains \
+  "$diff_output" \
+  "Optional Editor Stack: enabled" \
+  "Terrapod diff prints effective enabled Optional Editor Stack state"
+
+assert_contains \
+  "$diff_output" \
+  "Optional AI Tool Stack: enabled" \
+  "Terrapod diff prints effective enabled Optional AI Tool Stack state"
+
+assert_contains \
+  "$diff_output" \
+  "Optional Development Workspace: enabled" \
+  "Terrapod diff prints enabled Optional Development Workspace state"
+
+assert_contains \
+  "$diff_output" \
+  "macOS App Groups:" \
+  "Terrapod diff prints macOS App Groups section header"
+
+assert_contains \
+  "$diff_output" \
+  "terminal-apps: enabled" \
+  "Terrapod diff prints enabled terminal-apps macOS App Group state"
+
+assert_contains \
+  "$diff_output" \
+  "automation: disabled" \
+  "Terrapod diff prints disabled automation macOS App Group state"
+
+assert_contains \
+  "$diff_output" \
+  "launcher: enabled" \
+  "Terrapod diff prints enabled launcher macOS App Group state"
+
+assert_contains \
+  "$diff_output" \
+  "monitoring: disabled" \
+  "Terrapod diff prints disabled monitoring macOS App Group state"
+
+assert_contains \
+  "$diff_output" \
+  "Delegating target-state diff to: chezmoi diff" \
+  "Terrapod diff explains the delegated command"
+
+assert_contains \
+  "$diff_output" \
+  "stub diff output" \
+  "Terrapod diff includes delegated chezmoi diff output"
+
+rm -f "$CHEZMOI_CALL_FILE" "$CHEZMOI_INVOKED_FILE"
+
+if HOME="$diff_home" XDG_CONFIG_HOME="$diff_xdg" TERRAPOD_CHEZMOI_CONFIG="$diff_config" PATH="$tmp_dir/bin:/usr/bin:/bin" \
+  sh "$terrapod" diff --verbose >"$tmp_dir/diff-extra.out" 2>"$tmp_dir/diff-extra.err"; then
+  fail "Terrapod diff rejects extra arguments"
+fi
+
+diff_extra_error="$(cat "$tmp_dir/diff-extra.err")"
+
+assert_contains \
+  "$diff_extra_error" \
+  "terrapod: diff accepts no arguments" \
+  "Terrapod diff explains rejected extra arguments"
+
+if [ -e "$CHEZMOI_INVOKED_FILE" ]; then
+  fail "Terrapod diff rejects extra arguments before calling chezmoi"
+fi
+
+pass "Terrapod diff rejects extra arguments before calling chezmoi"
+
+rm -f "$CHEZMOI_CALL_FILE" "$CHEZMOI_INVOKED_FILE"
+
+if ! HOME="$diff_home" XDG_CONFIG_HOME="$diff_xdg" TERRAPOD_CHEZMOI_CONFIG="$diff_config" PATH="$tmp_dir/bin:/usr/bin:/bin" \
+  sh "$terrapod" diff >"$tmp_dir/diff-override.out" 2>"$tmp_dir/diff-override.err"; then
+  printf '%s\n' "override diff stdout:" >&2
+  sed 's/^/  /' "$tmp_dir/diff-override.out" >&2
+  printf '%s\n' "override diff stderr:" >&2
+  sed 's/^/  /' "$tmp_dir/diff-override.err" >&2
+  fail "Terrapod diff runs successfully with an explicit config override"
+fi
+
+diff_override_output="$(cat "$tmp_dir/diff-override.out")"
+
+assert_call_args \
+  "$CHEZMOI_CALL_FILE" \
+  "Terrapod diff passes explicit config overrides to chezmoi diff" \
+  --config "$diff_config" diff
+
+assert_contains \
+  "$diff_override_output" \
+  "Delegating target-state diff to: chezmoi --config $diff_config diff" \
+  "Terrapod diff explains delegated explicit config command"
+
+export CHEZMOI_APPLY_ARGS_FILE="$tmp_dir/chezmoi-apply.args"
+export CHEZMOI_APPLY_INVOKED_FILE="$tmp_dir/chezmoi-apply.invoked"
+export CHEZMOI_MANAGED_ARGS_FILE="$tmp_dir/chezmoi-managed.args"
+
+write_stub "$tmp_dir/bin/chezmoi" \
+  'command_name=' \
+  'for arg do' \
+  '  case "$arg" in' \
+  '    apply|managed)' \
+  '      command_name="$arg"' \
+  '      ;;' \
+  '  esac' \
+  'done' \
+  'case "$command_name" in' \
+  '  apply)' \
+  '    printf "%s\n" invoked >"$CHEZMOI_APPLY_INVOKED_FILE"' \
+  '    : >"$CHEZMOI_APPLY_ARGS_FILE"' \
+  '    for arg do' \
+  '      printf "%s\n" "$arg" >>"$CHEZMOI_APPLY_ARGS_FILE"' \
+  '    done' \
+  '    printf "%s\n" "stub apply output"' \
+  '    exit 0' \
+  '    ;;' \
+  '  managed)' \
+  '    : >"$CHEZMOI_MANAGED_ARGS_FILE"' \
+  '    for arg do' \
+  '      printf "%s\n" "$arg" >>"$CHEZMOI_MANAGED_ARGS_FILE"' \
+  '    done' \
+  '    printf "%s\n" ".local/bin/terrapod"' \
+  '    printf "%s\n" ".local/bin/tpod"' \
+  '    exit 0' \
+  '    ;;' \
+  'esac' \
+  'printf "%s\n" "unexpected chezmoi command: $*" >&2' \
+  'exit 91'
+
+rm -f "$CHEZMOI_APPLY_ARGS_FILE" "$CHEZMOI_APPLY_INVOKED_FILE" "$CHEZMOI_MANAGED_ARGS_FILE"
+
+if ! HOME="$diff_home" XDG_CONFIG_HOME="$diff_xdg" PATH="$tmp_dir/bin:/usr/bin:/bin" \
+  sh "$terrapod" apply >"$tmp_dir/apply.out" 2>"$tmp_dir/apply.err"; then
+  printf '%s\n' "apply stdout:" >&2
+  sed 's/^/  /' "$tmp_dir/apply.out" >&2
+  printf '%s\n' "apply stderr:" >&2
+  sed 's/^/  /' "$tmp_dir/apply.err" >&2
+  fail "Terrapod apply runs successfully"
+fi
+
+apply_output="$(cat "$tmp_dir/apply.out")"
+
+assert_call_args \
+  "$CHEZMOI_APPLY_ARGS_FILE" \
+  "Terrapod apply delegates target-state apply behavior to chezmoi apply" \
+  apply
+
+assert_call_args \
+  "$CHEZMOI_MANAGED_ARGS_FILE" \
+  "Terrapod apply validates managed targets with chezmoi managed" \
+  managed
+
+assert_contains \
+  "$apply_output" \
+  "Terrapod apply" \
+  "Terrapod apply prints command context"
+
+assert_contains \
+  "$apply_output" \
+  "Profile: macOS Terminal Profile" \
+  "Terrapod apply prints active profile context"
+
+assert_contains \
+  "$apply_output" \
+  "Config: $diff_config (present)" \
+  "Terrapod apply prints config context"
+
+assert_contains \
+  "$apply_output" \
+  "Optional stacks:" \
+  "Terrapod apply prints optional stack section header"
+
+assert_contains \
+  "$apply_output" \
+  "Optional Editor Stack: enabled" \
+  "Terrapod apply prints effective enabled Optional Editor Stack state"
+
+assert_contains \
+  "$apply_output" \
+  "Optional AI Tool Stack: enabled" \
+  "Terrapod apply prints effective enabled Optional AI Tool Stack state"
+
+assert_contains \
+  "$apply_output" \
+  "Optional Development Workspace: enabled" \
+  "Terrapod apply prints enabled Optional Development Workspace state"
+
+assert_contains \
+  "$apply_output" \
+  "terminal-apps: enabled" \
+  "Terrapod apply prints enabled terminal-apps macOS App Group state"
+
+assert_contains \
+  "$apply_output" \
+  "automation: disabled" \
+  "Terrapod apply prints disabled automation macOS App Group state"
+
+assert_contains \
+  "$apply_output" \
+  "launcher: enabled" \
+  "Terrapod apply prints enabled launcher macOS App Group state"
+
+assert_contains \
+  "$apply_output" \
+  "monitoring: disabled" \
+  "Terrapod apply prints disabled monitoring macOS App Group state"
+
+assert_contains \
+  "$apply_output" \
+  "Preflight: chezmoi is available" \
+  "Terrapod apply confirms chezmoi preflight"
+
+assert_contains \
+  "$apply_output" \
+  "Preflight: config file is readable" \
+  "Terrapod apply confirms readable config preflight"
+
+assert_contains \
+  "$apply_output" \
+  "Delegating target-state apply to: chezmoi apply" \
+  "Terrapod apply explains the delegated command"
+
+assert_contains \
+  "$apply_output" \
+  "stub apply output" \
+  "Terrapod apply includes delegated chezmoi apply output"
+
+assert_contains \
+  "$apply_output" \
+  "Post-apply validation: Terrapod command is managed" \
+  "Terrapod apply validates the Terrapod command managed target"
+
+assert_contains \
+  "$apply_output" \
+  "Post-apply validation: tpod alias is managed" \
+  "Terrapod apply validates the tpod alias managed target"
+
+rm -f "$CHEZMOI_APPLY_ARGS_FILE" "$CHEZMOI_APPLY_INVOKED_FILE" "$CHEZMOI_MANAGED_ARGS_FILE"
+
+if HOME="$diff_home" XDG_CONFIG_HOME="$diff_xdg" PATH="$tmp_dir/bin:/usr/bin:/bin" \
+  sh "$terrapod" apply --dry-run >"$tmp_dir/apply-extra.out" 2>"$tmp_dir/apply-extra.err"; then
+  fail "Terrapod apply rejects extra arguments"
+fi
+
+apply_extra_error="$(cat "$tmp_dir/apply-extra.err")"
+
+assert_contains \
+  "$apply_extra_error" \
+  "terrapod: apply accepts no arguments" \
+  "Terrapod apply explains rejected extra arguments"
+
+if [ -e "$CHEZMOI_APPLY_INVOKED_FILE" ]; then
+  fail "Terrapod apply rejects extra arguments before calling chezmoi apply"
+fi
+
+pass "Terrapod apply rejects extra arguments before calling chezmoi apply"
+
+rm -f "$CHEZMOI_APPLY_ARGS_FILE" "$CHEZMOI_APPLY_INVOKED_FILE" "$CHEZMOI_MANAGED_ARGS_FILE"
+
+if ! HOME="$diff_home" XDG_CONFIG_HOME="$diff_xdg" TERRAPOD_CHEZMOI_CONFIG="$diff_config" PATH="$tmp_dir/bin:/usr/bin:/bin" \
+  sh "$terrapod" apply >"$tmp_dir/apply-override.out" 2>"$tmp_dir/apply-override.err"; then
+  printf '%s\n' "override apply stdout:" >&2
+  sed 's/^/  /' "$tmp_dir/apply-override.out" >&2
+  printf '%s\n' "override apply stderr:" >&2
+  sed 's/^/  /' "$tmp_dir/apply-override.err" >&2
+  fail "Terrapod apply runs successfully with an explicit config override"
+fi
+
+apply_override_output="$(cat "$tmp_dir/apply-override.out")"
+
+assert_call_args \
+  "$CHEZMOI_APPLY_ARGS_FILE" \
+  "Terrapod apply passes explicit config overrides to chezmoi apply" \
+  --config "$diff_config" apply
+
+assert_call_args \
+  "$CHEZMOI_MANAGED_ARGS_FILE" \
+  "Terrapod apply passes explicit config overrides to chezmoi managed" \
+  --config "$diff_config" managed
+
+assert_contains \
+  "$apply_override_output" \
+  "Delegating target-state apply to: chezmoi --config $diff_config apply" \
+  "Terrapod apply explains delegated explicit config command"
+
+symlink_config_target="$tmp_dir/symlink-target-chezmoi.toml"
+symlink_config="$tmp_dir/symlink-chezmoi.toml"
+cp "$diff_config" "$symlink_config_target"
+ln -s "$symlink_config_target" "$symlink_config"
+
+rm -f "$CHEZMOI_APPLY_ARGS_FILE" "$CHEZMOI_APPLY_INVOKED_FILE" "$CHEZMOI_MANAGED_ARGS_FILE"
+
+if ! HOME="$diff_home" XDG_CONFIG_HOME="$diff_xdg" TERRAPOD_CHEZMOI_CONFIG="$symlink_config" PATH="$tmp_dir/bin:/usr/bin:/bin" \
+  sh "$terrapod" apply >"$tmp_dir/apply-symlink.out" 2>"$tmp_dir/apply-symlink.err"; then
+  printf '%s\n' "symlink config apply stdout:" >&2
+  sed 's/^/  /' "$tmp_dir/apply-symlink.out" >&2
+  printf '%s\n' "symlink config apply stderr:" >&2
+  sed 's/^/  /' "$tmp_dir/apply-symlink.err" >&2
+  fail "Terrapod apply accepts a symlink to a regular config file"
+fi
+
+apply_symlink_output="$(cat "$tmp_dir/apply-symlink.out")"
+
+assert_call_args \
+  "$CHEZMOI_APPLY_ARGS_FILE" \
+  "Terrapod apply delegates with a symlink config path" \
+  --config "$symlink_config" apply
+
+assert_call_args \
+  "$CHEZMOI_MANAGED_ARGS_FILE" \
+  "Terrapod apply validates managed targets with a symlink config path" \
+  --config "$symlink_config" managed
+
+assert_contains \
+  "$apply_symlink_output" \
+  "Preflight: config file is readable" \
+  "Terrapod apply treats symlinked config files as readable"
+
+write_stub "$tmp_dir/bin/chezmoi" \
+  'command_name=' \
+  'for arg do' \
+  '  case "$arg" in' \
+  '    apply|managed)' \
+  '      command_name="$arg"' \
+  '      ;;' \
+  '  esac' \
+  'done' \
+  'case "$command_name" in' \
+  '  apply)' \
+  '    printf "%s\n" invoked >"$CHEZMOI_APPLY_INVOKED_FILE"' \
+  '    : >"$CHEZMOI_APPLY_ARGS_FILE"' \
+  '    for arg do' \
+  '      printf "%s\n" "$arg" >>"$CHEZMOI_APPLY_ARGS_FILE"' \
+  '    done' \
+  '    printf "%s\n" "stub apply output"' \
+  '    exit 0' \
+  '    ;;' \
+  '  managed)' \
+  '    : >"$CHEZMOI_MANAGED_ARGS_FILE"' \
+  '    for arg do' \
+  '      printf "%s\n" "$arg" >>"$CHEZMOI_MANAGED_ARGS_FILE"' \
+  '    done' \
+  '    printf "%s\n" ".local/bin/terrapod"' \
+  '    exit 0' \
+  '    ;;' \
+  'esac' \
+  'printf "%s\n" "unexpected chezmoi command: $*" >&2' \
+  'exit 91'
+
+rm -f "$CHEZMOI_APPLY_ARGS_FILE" "$CHEZMOI_APPLY_INVOKED_FILE" "$CHEZMOI_MANAGED_ARGS_FILE"
+
+if HOME="$diff_home" XDG_CONFIG_HOME="$diff_xdg" PATH="$tmp_dir/bin:/usr/bin:/bin" \
+  sh "$terrapod" apply >"$tmp_dir/apply-validation.out" 2>"$tmp_dir/apply-validation.err"; then
+  fail "Terrapod apply fails when tpod alias is not managed"
+fi
+
+apply_validation_error="$(cat "$tmp_dir/apply-validation.err")"
+
+assert_contains \
+  "$apply_validation_error" \
+  "terrapod: post-apply validation failed: tpod alias is not managed (.local/bin/tpod missing)" \
+  "Terrapod apply explains missing tpod alias managed target"
+
+assert_contains \
+  "$apply_validation_error" \
+  "Run 'terrapod chezmoi -- managed' to inspect managed targets, then rerun 'terrapod apply'." \
+  "Terrapod apply gives actionable post-apply validation guidance"
+
+rm -f "$CHEZMOI_APPLY_ARGS_FILE" "$CHEZMOI_APPLY_INVOKED_FILE" "$CHEZMOI_MANAGED_ARGS_FILE"
+
+if HOME="$diff_home" XDG_CONFIG_HOME="$diff_xdg" TERRAPOD_CHEZMOI_CONFIG="$diff_config" PATH="$tmp_dir/bin:/usr/bin:/bin" \
+  sh "$terrapod" apply >"$tmp_dir/apply-override-validation.out" 2>"$tmp_dir/apply-override-validation.err"; then
+  fail "Terrapod apply fails when tpod alias is not managed with an explicit config override"
+fi
+
+apply_override_validation_error="$(cat "$tmp_dir/apply-override-validation.err")"
+
+assert_contains \
+  "$apply_override_validation_error" \
+  "terrapod: post-apply validation failed: tpod alias is not managed (.local/bin/tpod missing)" \
+  "Terrapod apply explains missing tpod alias managed target with an explicit config override"
+
+assert_contains \
+  "$apply_override_validation_error" \
+  "Run 'terrapod chezmoi -- --config $diff_config managed' to inspect managed targets, then rerun 'terrapod apply'." \
+  "Terrapod apply gives config-aware post-apply validation guidance"


### PR DESCRIPTION
## Summary
- Add first-class `terrapod diff` and `terrapod apply` commands that print Terrapod profile, config, optional stack, and macOS App Group context before delegating to chezmoi.
- Share chezmoi command rendering/invocation helpers across diff, apply, and update while preserving update behavior.
- Add apply preflight checks and post-apply validation with actionable guidance, including explicit config override guidance.

## User impact
- Users can inspect and apply target-state changes through Terrapod without losing context about the active profile, effective optional stacks, and macOS App Groups.
- Apply failures now point users toward the managed-target inspection command needed to diagnose Terrapod/tpod installation state.

## Validation
- `sh -n dot_local/bin/executable_terrapod`
- `sh tests/terrapod_command_test.sh`
- `sh tests/terrapod_config_test.sh`
- `git diff --check origin/main...HEAD`
- Base-diff code review found no remaining findings after fixes.

Closes #37