### PR TITLE
Add Terrapod status and doctor

### DIFF
--- a/docs/superpowers/plans/2026-05-28-terrapod-status-doctor.md
+++ b/docs/superpowers/plans/2026-05-28-terrapod-status-doctor.md
@@ -1,0 +1,908 @@
+# Terrapod Status And Doctor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `terrapod status` and `terrapod doctor` commands that explain the current machine through repository domain language without running broad package upgrade commands.
+
+**Architecture:** Keep implementation inside the existing POSIX shell Terrapod entry point. Add small helpers for supported profile detection, conservative managed `[data]` reads, tool availability summaries, status rendering, and doctor validation. Extend the existing shell test file with stubbed `uname`, `chezmoi`, package-manager, and tool commands.
+
+**Tech Stack:** POSIX `sh`, `awk`, existing shell test scripts, `chezmoi` only in tests that already depend on it.
+
+---
+
+## File Structure
+
+- Modify `dot_local/bin/executable_terrapod`: add `status` and `doctor` command dispatch plus shared helper functions.
+- Modify `tests/terrapod_command_test.sh`: add command tests for help text, macOS status, Ubuntu 24.04 status, unsupported Linux status, disabled optional stacks, enabled optional stacks with missing tools, doctor validation, and broad-upgrade non-invocation.
+- Leave `tests/terrapod_config_test.sh` unchanged: config-writing behavior already covers Preset expansion and managed key persistence.
+
+## Task 1: Add failing status tests
+
+**Files:**
+- Modify: `tests/terrapod_command_test.sh`
+- Test: `tests/terrapod_command_test.sh`
+
+- [ ] **Step 1: Add status test helpers after `assert_call_args`**
+
+```sh
+write_success_stub() {
+  name="$1"
+  write_stub "$tmp_dir/bin/$name" \
+    'exit 0'
+}
+
+write_failing_command_stub() {
+  name="$1"
+  call_file="$2"
+  write_stub "$tmp_dir/bin/$name" \
+    'printf "%s\n" "$0 $*" >>"'"$call_file"'"' \
+    'exit 90'
+}
+
+write_os_release() {
+  path="$1"
+  id="$2"
+  version_id="$3"
+  pretty_name="$4"
+
+  cat >"$path" <<EOF
+ID=$id
+VERSION_ID="$version_id"
+PRETTY_NAME="$pretty_name"
+EOF
+}
+```
+
+- [ ] **Step 2: Update the help assertions**
+
+Add these assertions after the existing update help assertions:
+
+```sh
+assert_contains \
+  "$help_output" \
+  "terrapod status" \
+  "Terrapod help documents status"
+
+assert_contains \
+  "$help_output" \
+  "terrapod doctor" \
+  "Terrapod help documents doctor"
+```
+
+- [ ] **Step 3: Add macOS status test before the update tests**
+
+```sh
+status_config="$tmp_dir/status-macos.toml"
+cat >"$status_config" <<'TOML'
+[data]
+enableEditorStack = true
+enableAiCliTools = true
+enableDevelopmentWorkspace = true
+enableMacosAppGroupTerminalApps = true
+enableMacosAppGroupAutomation = false
+enableMacosAppGroupLauncher = true
+enableMacosAppGroupMonitoring = false
+TOML
+
+for tool in chezmoi git zsh mise brew nvim gemini claude codex zellij ghostty cmux op; do
+  write_success_stub "$tool"
+done
+
+macos_status_output="$(
+  TERRAPOD_PROFILE=macos-terminal TERRAPOD_CHEZMOI_CONFIG="$status_config" PATH="$tmp_dir/bin:/usr/bin:/bin" \
+    sh "$terrapod" status
+)"
+
+assert_contains "$macos_status_output" "Terrapod status" "Terrapod status prints a command heading"
+assert_contains "$macos_status_output" "Profile: macOS Terminal Profile" "Terrapod status reports macOS Terminal Profile context"
+assert_contains "$macos_status_output" "Config: $status_config (present)" "Terrapod status reports explicit config path"
+assert_contains "$macos_status_output" "Optional Editor Stack: enabled (tools available: nvim)" "Terrapod status reports enabled Optional Editor Stack tool state"
+assert_contains "$macos_status_output" "Optional AI Tool Stack: enabled (tools available: gemini, claude, codex)" "Terrapod status reports enabled Optional AI Tool Stack tool state"
+assert_contains "$macos_status_output" "Optional Development Workspace: enabled (tools available: zellij)" "Terrapod status reports enabled Optional Development Workspace tool state"
+assert_contains "$macos_status_output" "terminal-apps: enabled (Ghostty and cmux)" "Terrapod status reports enabled terminal-apps macOS App Group"
+assert_contains "$macos_status_output" "automation: disabled" "Terrapod status reports disabled automation macOS App Group"
+assert_contains "$macos_status_output" "launcher: enabled (Raycast and 1Password CLI)" "Terrapod status reports enabled launcher macOS App Group"
+assert_contains "$macos_status_output" "monitoring: disabled" "Terrapod status reports disabled monitoring macOS App Group"
+assert_contains "$macos_status_output" "chezmoi: available" "Terrapod status reports chezmoi availability"
+assert_contains "$macos_status_output" "brew: available" "Terrapod status reports macOS Bootstrap Package Manager availability"
+assert_contains "$macos_status_output" "Warnings: none" "Terrapod status reports no warnings when enabled tools are present"
+```
+
+- [ ] **Step 4: Add Ubuntu disabled-stack status test**
+
+```sh
+status_ubuntu_config="$tmp_dir/status-ubuntu.toml"
+status_ubuntu_os_release="$tmp_dir/status-ubuntu-os-release"
+cat >"$status_ubuntu_config" <<'TOML'
+[data]
+enableEditorStack = false
+enableAiCliTools = false
+enableDevelopmentWorkspace = false
+enableMacosAppGroupTerminalApps = false
+enableMacosAppGroupAutomation = false
+enableMacosAppGroupLauncher = false
+enableMacosAppGroupMonitoring = false
+TOML
+write_os_release "$status_ubuntu_os_release" ubuntu 24.04 "Ubuntu 24.04 LTS"
+write_stub "$tmp_dir/bin/uname" 'printf "%s\n" "Linux"'
+write_success_stub apt
+
+ubuntu_status_output="$(
+  TERRAPOD_OS_RELEASE_FILE="$status_ubuntu_os_release" TERRAPOD_CHEZMOI_CONFIG="$status_ubuntu_config" PATH="$tmp_dir/bin:/usr/bin:/bin" \
+    sh "$terrapod" status
+)"
+
+assert_contains "$ubuntu_status_output" "Profile: VPS Shell Profile" "Terrapod status reports VPS Shell Profile context on Ubuntu 24.04"
+assert_contains "$ubuntu_status_output" "Optional Editor Stack: disabled" "Terrapod status reports disabled Optional Editor Stack without treating nvim as missing"
+assert_contains "$ubuntu_status_output" "Optional AI Tool Stack: disabled" "Terrapod status reports disabled Optional AI Tool Stack without missing-tool warnings"
+assert_contains "$ubuntu_status_output" "Optional Development Workspace: disabled" "Terrapod status reports disabled Optional Development Workspace without missing-tool warnings"
+assert_contains "$ubuntu_status_output" "macOS App Groups: not applicable for VPS Shell Profile" "Terrapod status omits macOS App Group details on VPS Shell Profile"
+assert_contains "$ubuntu_status_output" "apt: available" "Terrapod status reports Ubuntu Bootstrap Package Manager availability"
+assert_contains "$ubuntu_status_output" "Warnings: none" "Terrapod status has no warnings for disabled optional stacks"
+assert_not_contains "$ubuntu_status_output" "missing tools: nvim" "Terrapod status distinguishes disabled Optional Editor Stack from missing tools"
+assert_not_contains "$ubuntu_status_output" "missing tools: gemini" "Terrapod status distinguishes disabled Optional AI Tool Stack from missing tools"
+```
+
+- [ ] **Step 5: Add enabled-missing-tools and unsupported-Linux status tests**
+
+```sh
+status_missing_config="$tmp_dir/status-missing.toml"
+cat >"$status_missing_config" <<'TOML'
+[data]
+enableEditorStack = true
+enableAiCliTools = true
+enableDevelopmentWorkspace = true
+TOML
+
+rm -f "$tmp_dir/bin/nvim" "$tmp_dir/bin/gemini" "$tmp_dir/bin/claude" "$tmp_dir/bin/codex" "$tmp_dir/bin/zellij"
+
+missing_status_output="$(
+  TERRAPOD_OS_RELEASE_FILE="$status_ubuntu_os_release" TERRAPOD_CHEZMOI_CONFIG="$status_missing_config" PATH="$tmp_dir/bin:/usr/bin:/bin" \
+    sh "$terrapod" status
+)"
+
+assert_contains "$missing_status_output" "Optional Editor Stack: enabled (missing tools: nvim)" "Terrapod status reports missing tools only for enabled Optional Editor Stack"
+assert_contains "$missing_status_output" "Optional AI Tool Stack: enabled (missing tools: gemini, claude, codex)" "Terrapod status reports missing tools only for enabled Optional AI Tool Stack"
+assert_contains "$missing_status_output" "Optional Development Workspace: enabled (missing tools: zellij)" "Terrapod status reports missing tools only for enabled Optional Development Workspace"
+assert_contains "$missing_status_output" "Warning: Optional AI Tool Stack is enabled but missing tools: gemini, claude, codex" "Terrapod status warns for enabled missing AI tools"
+
+status_unsupported_os_release="$tmp_dir/status-unsupported-os-release"
+write_os_release "$status_unsupported_os_release" debian 12 "Debian GNU/Linux 12"
+
+unsupported_status_output="$(
+  TERRAPOD_OS_RELEASE_FILE="$status_unsupported_os_release" TERRAPOD_CHEZMOI_CONFIG="$status_ubuntu_config" PATH="$tmp_dir/bin:/usr/bin:/bin" \
+    sh "$terrapod" status
+)"
+
+assert_contains "$unsupported_status_output" "Profile: unsupported profile" "Terrapod status reports unsupported Linux as unsupported"
+assert_contains "$unsupported_status_output" "Warning: unsupported Linux release: Debian GNU/Linux 12. Terrapod supports Ubuntu 24.04 for the VPS Shell Profile." "Terrapod status explains unsupported Linux"
+```
+
+- [ ] **Step 6: Run status tests and verify they fail**
+
+Run: `sh tests/terrapod_command_test.sh`
+
+Expected: FAIL because `status` is not yet implemented and help text does not mention it.
+
+## Task 2: Implement status command
+
+**Files:**
+- Modify: `dot_local/bin/executable_terrapod`
+- Test: `tests/terrapod_command_test.sh`
+
+- [ ] **Step 1: Add `status` and `doctor` to help text**
+
+Change the help command list to include:
+
+```sh
+  terrapod status
+  terrapod doctor
+```
+
+Change the command descriptions to include:
+
+```sh
+  status                                Explain this machine's Terrapod profile, config, stack, and tool state.
+  doctor                                Validate Terrapod prerequisites and report actionable guidance.
+```
+
+Change examples to include:
+
+```sh
+  terrapod status
+  terrapod doctor
+```
+
+- [ ] **Step 2: Add supported OS-release helpers after `chezmoi_config_file`**
+
+```sh
+os_release_file() {
+  printf '%s\n' "${TERRAPOD_OS_RELEASE_FILE:-/etc/os-release}"
+}
+
+os_release_value() {
+  key="$1"
+  file="$(os_release_file)"
+
+  if [ ! -f "$file" ]; then
+    return 1
+  fi
+
+  awk -F= -v wanted="$key" '
+    $1 == wanted {
+      value = $0
+      sub("^[^=]*=", "", value)
+      sub(/^"/, "", value)
+      sub(/"$/, "", value)
+      print value
+      found = 1
+      exit
+    }
+    END {
+      exit found ? 0 : 1
+    }
+  ' "$file"
+}
+
+is_supported_ubuntu_release() {
+  [ "$(os_release_value ID 2>/dev/null || printf unknown)" = "ubuntu" ] &&
+    [ "$(os_release_value VERSION_ID 2>/dev/null || printf unknown)" = "24.04" ]
+}
+
+unsupported_profile_reason() {
+  case "$(uname -s 2>/dev/null || printf unknown)" in
+    Linux)
+      pretty_name="$(os_release_value PRETTY_NAME 2>/dev/null || printf 'unknown Linux release')"
+      printf '%s\n' "unsupported Linux release: $pretty_name. Terrapod supports Ubuntu 24.04 for the VPS Shell Profile."
+      ;;
+    *)
+      printf '%s\n' "unsupported operating system: $(uname -s 2>/dev/null || printf unknown). Terrapod supports macOS and Ubuntu 24.04."
+      ;;
+  esac
+}
+```
+
+- [ ] **Step 3: Update `current_profile` Linux detection**
+
+Replace the Linux branch with:
+
+```sh
+    Linux)
+      if is_supported_ubuntu_release; then
+        printf '%s\n' "vps-shell"
+      else
+        printf '%s\n' "unsupported"
+      fi
+      ;;
+```
+
+- [ ] **Step 4: Add config bool and tool summary helpers after `profile_context_label`**
+
+```sh
+config_bool() {
+  key="$1"
+  config_file="$(chezmoi_config_file)"
+
+  if [ ! -f "$config_file" ]; then
+    printf '%s\n' "false"
+    return
+  fi
+
+  awk -v wanted="$key" '
+    function strip_space(value) {
+      sub(/^[[:space:]]*/, "", value)
+      sub(/[[:space:]]*$/, "", value)
+      return value
+    }
+
+    function strip_comment(value) {
+      sub(/[[:space:]]*#.*/, "", value)
+      return strip_space(value)
+    }
+
+    function unquote_key(value, quote) {
+      value = strip_space(value)
+      quote = substr(value, 1, 1)
+      if ((quote == "\"" || quote == "\047") && substr(value, length(value), 1) == quote) {
+        return substr(value, 2, length(value) - 2)
+      }
+      return value
+    }
+
+    function is_data_section(line) {
+      return line ~ "^[[:space:]]*\\[[[:space:]]*(data|\"data\"|\047data\047)[[:space:]]*\\][[:space:]]*($|#)"
+    }
+
+    function is_section(line) {
+      return line ~ /^[[:space:]]*(\[[^]]+\]|\[\[[^]]+\]\])[[:space:]]*($|#)/
+    }
+
+    function is_key_assignment(line) {
+      return line ~ "^[[:space:]]*(\"[^\"]+\"|\047[^\047]+\047|[A-Za-z0-9_-]+)[[:space:]]*="
+    }
+
+    function assignment_key_name(line, key) {
+      key = line
+      sub(/^[[:space:]]*/, "", key)
+      sub(/[[:space:]]*=.*/, "", key)
+      return unquote_key(key)
+    }
+
+    function assignment_value(line, value) {
+      value = line
+      sub(/^[^=]*=/, "", value)
+      return strip_comment(value)
+    }
+
+    function dotted_data_key_name(line, key) {
+      key = line
+      sub(/^[[:space:]]*/, "", key)
+      sub(/[[:space:]]*=.*/, "", key)
+      sub("^[[:space:]]*(data|\"data\"|\047data\047)[[:space:]]*\\.[[:space:]]*", "", key)
+      return unquote_key(key)
+    }
+
+    function is_root_dotted_data_key(line) {
+      return line ~ "^[[:space:]]*(data|\"data\"|\047data\047)[[:space:]]*\\."
+    }
+
+    BEGIN {
+      in_root = 1
+      found = "false"
+    }
+
+    {
+      if (in_root && is_root_dotted_data_key($0) && dotted_data_key_name($0) == wanted) {
+        found = assignment_value($0)
+      }
+
+      if (is_data_section($0)) {
+        in_root = 0
+        in_data = 1
+        next
+      }
+
+      if (is_section($0)) {
+        in_root = 0
+        in_data = 0
+        next
+      }
+
+      if (in_data && is_key_assignment($0) && assignment_key_name($0) == wanted) {
+        found = assignment_value($0)
+      }
+    }
+
+    END {
+      if (found == "true") {
+        print "true"
+      } else {
+        print "false"
+      }
+    }
+  ' "$config_file"
+}
+
+is_enabled() {
+  [ "$1" = "true" ]
+}
+
+effective_editor_stack_enabled() {
+  if is_enabled "$(config_bool enableEditorStack)" || is_enabled "$(config_bool enableDevelopmentWorkspace)"; then
+    printf '%s\n' "true"
+  else
+    printf '%s\n' "false"
+  fi
+}
+
+effective_ai_cli_tools_enabled() {
+  if is_enabled "$(config_bool enableAiCliTools)" || is_enabled "$(config_bool enableDevelopmentWorkspace)"; then
+    printf '%s\n' "true"
+  else
+    printf '%s\n' "false"
+  fi
+}
+
+join_tools() {
+  joined=
+  for tool do
+    if [ -z "$joined" ]; then
+      joined="$tool"
+    else
+      joined="$joined, $tool"
+    fi
+  done
+  printf '%s\n' "$joined"
+}
+
+missing_tools() {
+  missing=
+  for tool do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      if [ -z "$missing" ]; then
+        missing="$tool"
+      else
+        missing="$missing, $tool"
+      fi
+    fi
+  done
+  printf '%s\n' "$missing"
+}
+
+tool_phrase() {
+  missing="$(missing_tools "$@")"
+  if [ -n "$missing" ]; then
+    printf '%s\n' "missing tools: $missing"
+  else
+    printf '%s\n' "tools available: $(join_tools "$@")"
+  fi
+}
+
+print_stack_status() {
+  label="$1"
+  enabled="$2"
+  shift 2
+
+  if is_enabled "$enabled"; then
+    printf '  %s: enabled (%s)\n' "$label" "$(tool_phrase "$@")"
+  else
+    printf '  %s: disabled\n' "$label"
+  fi
+}
+```
+
+- [ ] **Step 5: Add status render helpers**
+
+```sh
+print_config_context() {
+  config_file="$(chezmoi_config_file)"
+  if [ -f "$config_file" ]; then
+    printf '%s\n' "Config: $config_file (present)"
+  else
+    printf '%s\n' "Config: $config_file (missing; defaults apply)"
+  fi
+}
+
+print_macos_app_group_status() {
+  profile="$1"
+
+  if [ "$profile" != "macos-terminal" ]; then
+    printf '%s\n' "macOS App Groups: not applicable for $(profile_context_label)"
+    return
+  fi
+
+  printf '%s\n' "macOS App Groups:"
+  if is_enabled "$(config_bool enableMacosAppGroupTerminalApps)"; then
+    printf '%s\n' "  terminal-apps: enabled (Ghostty and cmux)"
+  else
+    printf '%s\n' "  terminal-apps: disabled"
+  fi
+  if is_enabled "$(config_bool enableMacosAppGroupAutomation)"; then
+    printf '%s\n' "  automation: enabled (Hammerspoon and Karabiner-Elements)"
+  else
+    printf '%s\n' "  automation: disabled"
+  fi
+  if is_enabled "$(config_bool enableMacosAppGroupLauncher)"; then
+    printf '%s\n' "  launcher: enabled (Raycast and 1Password CLI)"
+  else
+    printf '%s\n' "  launcher: disabled"
+  fi
+  if is_enabled "$(config_bool enableMacosAppGroupMonitoring)"; then
+    printf '%s\n' "  monitoring: enabled (iStat Menus)"
+  else
+    printf '%s\n' "  monitoring: disabled"
+  fi
+}
+
+print_key_tool_status() {
+  profile="$1"
+
+  printf '%s\n' "Key tools:"
+  for tool in chezmoi git zsh mise; do
+    if command -v "$tool" >/dev/null 2>&1; then
+      printf '  %s: available\n' "$tool"
+    else
+      printf '  %s: missing\n' "$tool"
+    fi
+  done
+
+  case "$profile" in
+    macos-terminal)
+      if command -v brew >/dev/null 2>&1; then
+        printf '%s\n' "  brew: available"
+      else
+        printf '%s\n' "  brew: missing"
+      fi
+      ;;
+    vps-shell)
+      if command -v apt >/dev/null 2>&1; then
+        printf '%s\n' "  apt: available"
+      else
+        printf '%s\n' "  apt: missing"
+      fi
+      ;;
+  esac
+}
+
+print_status_warnings() {
+  profile="$1"
+  printed=0
+
+  if [ "$profile" = "unsupported" ]; then
+    printf '%s\n' "Warning: $(unsupported_profile_reason)"
+    printed=1
+  fi
+
+  if is_enabled "$(effective_editor_stack_enabled)"; then
+    missing="$(missing_tools nvim)"
+    if [ -n "$missing" ]; then
+      printf '%s\n' "Warning: Optional Editor Stack is enabled but missing tools: $missing"
+      printed=1
+    fi
+  fi
+
+  if is_enabled "$(effective_ai_cli_tools_enabled)"; then
+    missing="$(missing_tools gemini claude codex)"
+    if [ -n "$missing" ]; then
+      printf '%s\n' "Warning: Optional AI Tool Stack is enabled but missing tools: $missing"
+      printed=1
+    fi
+  fi
+
+  if is_enabled "$(config_bool enableDevelopmentWorkspace)"; then
+    missing="$(missing_tools zellij)"
+    if [ -n "$missing" ]; then
+      printf '%s\n' "Warning: Optional Development Workspace is enabled but missing tools: $missing"
+      printed=1
+    fi
+  fi
+
+  if [ "$printed" -eq 0 ]; then
+    printf '%s\n' "Warnings: none"
+  fi
+}
+
+run_status() {
+  if [ "$#" -ne 0 ]; then
+    fail_usage "status accepts no arguments"
+  fi
+
+  profile="$(current_profile)"
+
+  printf '%s\n' "Terrapod status"
+  printf '%s\n' "Profile: $(profile_context_label)"
+  print_config_context
+  printf '%s\n' "Optional stacks:"
+  print_stack_status "Optional Editor Stack" "$(effective_editor_stack_enabled)" nvim
+  print_stack_status "Optional AI Tool Stack" "$(effective_ai_cli_tools_enabled)" gemini claude codex
+  print_stack_status "Optional Development Workspace" "$(config_bool enableDevelopmentWorkspace)" zellij
+  print_macos_app_group_status "$profile"
+  print_key_tool_status "$profile"
+  print_status_warnings "$profile"
+}
+```
+
+- [ ] **Step 6: Dispatch `status`**
+
+Add this branch before `update)`:
+
+```sh
+  status)
+    shift
+    run_status "$@"
+    ;;
+```
+
+- [ ] **Step 7: Run status tests and verify they pass**
+
+Run: `sh tests/terrapod_command_test.sh`
+
+Expected: PASS through the new status section and existing command tests.
+
+## Task 3: Add failing doctor tests
+
+**Files:**
+- Modify: `tests/terrapod_command_test.sh`
+- Test: `tests/terrapod_command_test.sh`
+
+- [ ] **Step 1: Add doctor success test after status tests**
+
+```sh
+doctor_config="$tmp_dir/doctor-ok.toml"
+doctor_os_release="$tmp_dir/doctor-os-release"
+cat >"$doctor_config" <<'TOML'
+[data]
+enableEditorStack = false
+enableAiCliTools = false
+enableDevelopmentWorkspace = false
+TOML
+write_os_release "$doctor_os_release" ubuntu 24.04 "Ubuntu 24.04 LTS"
+
+for tool in chezmoi git zsh mise apt; do
+  write_success_stub "$tool"
+done
+
+if ! doctor_ok_output="$(
+  TERRAPOD_OS_RELEASE_FILE="$doctor_os_release" TERRAPOD_CHEZMOI_CONFIG="$doctor_config" PATH="$tmp_dir/bin:/usr/bin:/bin" \
+    sh "$terrapod" doctor
+)"; then
+  fail "Terrapod doctor succeeds when VPS prerequisites are present and optional stacks are disabled"
+fi
+
+assert_contains "$doctor_ok_output" "Terrapod doctor" "Terrapod doctor prints a command heading"
+assert_contains "$doctor_ok_output" "ok - Profile is supported: VPS Shell Profile" "Terrapod doctor validates supported Ubuntu profile"
+assert_contains "$doctor_ok_output" "ok - chezmoi is available" "Terrapod doctor validates chezmoi availability"
+assert_contains "$doctor_ok_output" "ok - apt is available" "Terrapod doctor validates Ubuntu Bootstrap Package Manager availability"
+assert_contains "$doctor_ok_output" "ok - Optional AI Tool Stack is disabled" "Terrapod doctor treats disabled Optional AI Tool Stack as valid"
+assert_contains "$doctor_ok_output" "Guidance: none" "Terrapod doctor prints no guidance when checks pass"
+```
+
+- [ ] **Step 2: Add doctor missing-tool test**
+
+```sh
+doctor_missing_config="$tmp_dir/doctor-missing.toml"
+cat >"$doctor_missing_config" <<'TOML'
+[data]
+enableEditorStack = true
+enableAiCliTools = true
+enableDevelopmentWorkspace = true
+TOML
+
+rm -f "$tmp_dir/bin/nvim" "$tmp_dir/bin/gemini" "$tmp_dir/bin/claude" "$tmp_dir/bin/codex" "$tmp_dir/bin/zellij"
+
+if TERRAPOD_OS_RELEASE_FILE="$doctor_os_release" TERRAPOD_CHEZMOI_CONFIG="$doctor_missing_config" PATH="$tmp_dir/bin:/usr/bin:/bin" \
+  sh "$terrapod" doctor >"$tmp_dir/doctor-missing.out" 2>"$tmp_dir/doctor-missing.err"; then
+  fail "Terrapod doctor fails when enabled optional stack tools are missing"
+fi
+
+doctor_missing_output="$(cat "$tmp_dir/doctor-missing.out")"
+
+assert_contains "$doctor_missing_output" "warn - Optional Editor Stack is enabled but missing tools: nvim" "Terrapod doctor warns about missing enabled editor tools"
+assert_contains "$doctor_missing_output" "warn - Optional AI Tool Stack is enabled but missing tools: gemini, claude, codex" "Terrapod doctor warns about missing enabled AI tools"
+assert_contains "$doctor_missing_output" "warn - Optional Development Workspace is enabled but missing tools: zellij" "Terrapod doctor warns about missing enabled workspace tools"
+assert_contains "$doctor_missing_output" "Run terrapod chezmoi -- apply after enabling Optional AI Tool Stack, or install/apply the configured tools before relying on them." "Terrapod doctor gives actionable missing optional-stack guidance"
+```
+
+- [ ] **Step 3: Add doctor unsupported Linux and broad-upgrade tests**
+
+```sh
+doctor_unsupported_os_release="$tmp_dir/doctor-unsupported-os-release"
+write_os_release "$doctor_unsupported_os_release" debian 12 "Debian GNU/Linux 12"
+
+if TERRAPOD_OS_RELEASE_FILE="$doctor_unsupported_os_release" TERRAPOD_CHEZMOI_CONFIG="$doctor_config" PATH="$tmp_dir/bin:/usr/bin:/bin" \
+  sh "$terrapod" doctor >"$tmp_dir/doctor-unsupported.out" 2>"$tmp_dir/doctor-unsupported.err"; then
+  fail "Terrapod doctor fails on unsupported Linux"
+fi
+
+doctor_unsupported_output="$(cat "$tmp_dir/doctor-unsupported.out")"
+assert_contains "$doctor_unsupported_output" "warn - unsupported Linux release: Debian GNU/Linux 12. Terrapod supports Ubuntu 24.04 for the VPS Shell Profile." "Terrapod doctor explains unsupported Linux"
+
+doctor_broad_upgrade_calls="$tmp_dir/doctor-broad-upgrade.calls"
+rm -f "$doctor_broad_upgrade_calls"
+for command_name in brew apt sudo mise npm; do
+  write_failing_command_stub "$command_name" "$doctor_broad_upgrade_calls"
+done
+
+TERRAPOD_PROFILE=macos-terminal TERRAPOD_CHEZMOI_CONFIG="$doctor_config" PATH="$tmp_dir/bin:/usr/bin:/bin" \
+  sh "$terrapod" status >/dev/null
+
+if TERRAPOD_PROFILE=macos-terminal TERRAPOD_CHEZMOI_CONFIG="$doctor_config" PATH="$tmp_dir/bin:/usr/bin:/bin" \
+  sh "$terrapod" doctor >/dev/null; then
+  :
+fi
+
+if [ -e "$doctor_broad_upgrade_calls" ]; then
+  printf '%s\n' "unexpected broad upgrade command calls from status/doctor:" >&2
+  sed 's/^/  /' "$doctor_broad_upgrade_calls" >&2
+  fail "Terrapod status and doctor do not call brew, apt, sudo, mise, or npm upgrade flows"
+fi
+
+pass "Terrapod status and doctor do not call brew, apt, sudo, mise, or npm upgrade flows"
+```
+
+- [ ] **Step 4: Run doctor tests and verify they fail**
+
+Run: `sh tests/terrapod_command_test.sh`
+
+Expected: FAIL because `doctor` is not yet implemented.
+
+## Task 4: Implement doctor command
+
+**Files:**
+- Modify: `dot_local/bin/executable_terrapod`
+- Test: `tests/terrapod_command_test.sh`
+
+- [ ] **Step 1: Add doctor output helpers after `run_status`**
+
+```sh
+doctor_failed=0
+doctor_guidance_printed=0
+
+doctor_ok() {
+  printf '  ok - %s\n' "$1"
+}
+
+doctor_warn() {
+  printf '  warn - %s\n' "$1"
+  doctor_failed=1
+}
+
+doctor_guidance() {
+  if [ "$doctor_guidance_printed" -eq 0 ]; then
+    printf '%s\n' "Guidance:"
+    doctor_guidance_printed=1
+  fi
+  printf '  - %s\n' "$1"
+}
+
+doctor_check_command() {
+  tool="$1"
+  if command -v "$tool" >/dev/null 2>&1; then
+    doctor_ok "$tool is available"
+  else
+    doctor_warn "$tool is missing"
+    doctor_guidance "Install or apply the configured Core Shell Stack so '$tool' is available on PATH."
+  fi
+}
+
+doctor_check_optional_stack() {
+  label="$1"
+  enabled="$2"
+  guidance="$3"
+  shift 3
+
+  if ! is_enabled "$enabled"; then
+    doctor_ok "$label is disabled"
+    return
+  fi
+
+  missing="$(missing_tools "$@")"
+  if [ -n "$missing" ]; then
+    doctor_warn "$label is enabled but missing tools: $missing"
+    doctor_guidance "$guidance"
+  else
+    doctor_ok "$label is enabled and tools are available: $(join_tools "$@")"
+  fi
+}
+```
+
+- [ ] **Step 2: Add `run_doctor` after the doctor helpers**
+
+```sh
+run_doctor() {
+  if [ "$#" -ne 0 ]; then
+    fail_usage "doctor accepts no arguments"
+  fi
+
+  doctor_failed=0
+  doctor_guidance_printed=0
+  profile="$(current_profile)"
+
+  printf '%s\n' "Terrapod doctor"
+  printf '%s\n' "Profile: $(profile_context_label)"
+  print_config_context
+  printf '%s\n' "Checks:"
+
+  if [ "$profile" = "unsupported" ]; then
+    doctor_warn "$(unsupported_profile_reason)"
+    doctor_guidance "Run Terrapod on macOS or Ubuntu 24.04, or use 'terrapod chezmoi -- <args>' as an advanced escape hatch on unsupported systems."
+  else
+    doctor_ok "Profile is supported: $(profile_context_label)"
+  fi
+
+  for tool in chezmoi git zsh mise; do
+    doctor_check_command "$tool"
+  done
+
+  case "$profile" in
+    macos-terminal)
+      doctor_check_command brew
+      ;;
+    vps-shell)
+      doctor_check_command apt
+      ;;
+  esac
+
+  doctor_check_optional_stack \
+    "Optional Editor Stack" \
+    "$(effective_editor_stack_enabled)" \
+    "Run terrapod chezmoi -- apply after enabling Optional Editor Stack, or install/apply the configured editor tools before relying on them." \
+    nvim
+
+  doctor_check_optional_stack \
+    "Optional AI Tool Stack" \
+    "$(effective_ai_cli_tools_enabled)" \
+    "Run terrapod chezmoi -- apply after enabling Optional AI Tool Stack, or install/apply the configured tools before relying on them." \
+    gemini claude codex
+
+  doctor_check_optional_stack \
+    "Optional Development Workspace" \
+    "$(config_bool enableDevelopmentWorkspace)" \
+    "Run terrapod chezmoi -- apply after enabling Optional Development Workspace, or install/apply the configured workspace tools before relying on them." \
+    zellij
+
+  if [ "$doctor_guidance_printed" -eq 0 ]; then
+    printf '%s\n' "Guidance: none"
+  fi
+
+  if [ "$doctor_failed" -ne 0 ]; then
+    return 1
+  fi
+}
+```
+
+- [ ] **Step 3: Dispatch `doctor`**
+
+Add this branch before `update)`:
+
+```sh
+  doctor)
+    shift
+    run_doctor "$@"
+    ;;
+```
+
+- [ ] **Step 4: Run command tests and verify they pass**
+
+Run: `sh tests/terrapod_command_test.sh`
+
+Expected: PASS.
+
+## Task 5: Full verification and final commit
+
+**Files:**
+- Verify: all `tests/*.sh` and `tests/*.zsh`
+
+- [ ] **Step 1: Run syntax check**
+
+Run: `sh -n dot_local/bin/executable_terrapod`
+
+Expected: PASS with no output.
+
+- [ ] **Step 2: Run focused tests**
+
+Run: `sh tests/terrapod_command_test.sh`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run full shell test suite**
+
+Run:
+
+```sh
+for test_script in tests/*.sh; do
+  [ -f "$test_script" ] || continue
+  sh "$test_script"
+done
+for test_script in tests/*.zsh; do
+  [ -f "$test_script" ] || continue
+  zsh "$test_script"
+done
+```
+
+Expected: PASS for every script.
+
+- [ ] **Step 4: Review diff against base**
+
+Run: `git diff --stat origin/main...HEAD && git diff origin/main...HEAD -- dot_local/bin/executable_terrapod tests/terrapod_command_test.sh docs/superpowers/plans/2026-05-28-terrapod-status-doctor.md`
+
+Expected: diff includes only the Terrapod command, command tests, and this plan.
+
+- [ ] **Step 5: Commit once per the requested workflow**
+
+Run:
+
+```sh
+git add dot_local/bin/executable_terrapod tests/terrapod_command_test.sh docs/superpowers/plans/2026-05-28-terrapod-status-doctor.md
+git commit -m "Add Terrapod status and doctor"
+```
+
+Expected: commit succeeds on branch `feat/issue-36-terrapod-status-doctor`.
+
+---
+
+## Execution Notes
+
+- `origin/main` gained `terrapod diff` and `terrapod apply` while this work was in progress, so the final implementation preserves those wrappers and adds `status`/`doctor` alongside them.
+- The final status/doctor implementation uses the existing config-aware helpers (`config_data_bool "$config_file" ...` and `show_config_context`) rather than the standalone sketch names shown in the planning snippets.
+- Doctor guidance points users at `terrapod chezmoi -- apply` so the command stays informational and avoids broad package upgrade flows.

--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -388,6 +388,18 @@ print_stack_status() {
   fi
 }
 
+print_optional_setting_status() {
+  label="$1"
+  enabled="$2"
+  detail="$3"
+
+  if is_enabled "$enabled"; then
+    printf '  %s: enabled (%s)\n' "$label" "$detail"
+  else
+    printf '  %s: disabled\n' "$label"
+  fi
+}
+
 print_macos_app_group_status() {
   config_file="$1"
   profile="$2"
@@ -424,7 +436,7 @@ print_key_tool_status() {
   profile="$1"
 
   printf '%s\n' "Key tools:"
-  for tool in chezmoi git zsh mise; do
+  for tool in chezmoi git zsh mise nvim zellij; do
     if command -v "$tool" >/dev/null 2>&1; then
       printf '  %s: available\n' "$tool"
     else
@@ -452,7 +464,7 @@ print_key_tool_status() {
 
 status_key_tool_warnings() {
   profile="$1"
-  missing="$(missing_tools chezmoi git zsh mise)"
+  missing="$(missing_tools chezmoi git zsh mise nvim zellij)"
 
   case "$profile" in
     macos-terminal)
@@ -496,26 +508,10 @@ print_status_warnings() {
     printed=1
   fi
 
-  if is_enabled "$(effective_editor_stack_enabled "$config_file")"; then
-    missing="$(missing_tools nvim)"
-    if [ -n "$missing" ]; then
-      printf '%s\n' "Warning: Optional Editor Stack is enabled but missing tools: $missing"
-      printed=1
-    fi
-  fi
-
   if is_enabled "$(effective_ai_cli_tools_enabled "$config_file")"; then
     missing="$(missing_tools gemini claude codex)"
     if [ -n "$missing" ]; then
       printf '%s\n' "Warning: Optional AI Tool Stack is enabled but missing tools: $missing"
-      printed=1
-    fi
-  fi
-
-  if is_enabled "$(config_data_bool "$config_file" enableDevelopmentWorkspace)"; then
-    missing="$(missing_tools zellij)"
-    if [ -n "$missing" ]; then
-      printf '%s\n' "Warning: Optional Development Workspace is enabled but missing tools: $missing"
       printed=1
     fi
   fi
@@ -537,9 +533,9 @@ run_status() {
   printf '%s\n' "Profile: $(profile_context_label)"
   show_config_context "$config_file"
   printf '%s\n' "Optional stacks:"
-  print_stack_status "Optional Editor Stack" "$(effective_editor_stack_enabled "$config_file")" nvim
+  print_optional_setting_status "Optional Editor Stack" "$(effective_editor_stack_enabled "$config_file")" "rich Neovim configuration"
   print_stack_status "Optional AI Tool Stack" "$(effective_ai_cli_tools_enabled "$config_file")" gemini claude codex
-  print_stack_status "Optional Development Workspace" "$(config_data_bool "$config_file" enableDevelopmentWorkspace)" zellij
+  print_optional_setting_status "Optional Development Workspace" "$(config_data_bool "$config_file" enableDevelopmentWorkspace)" "development Zellij layouts"
   print_macos_app_group_status "$config_file" "$profile"
   print_key_tool_status "$profile"
   print_status_warnings "$config_file" "$profile"
@@ -748,6 +744,18 @@ doctor_check_optional_stack() {
   fi
 }
 
+doctor_check_optional_setting() {
+  label="$1"
+  enabled="$2"
+  detail="$3"
+
+  if is_enabled "$enabled"; then
+    doctor_ok "$label is enabled ($detail)"
+  else
+    doctor_ok "$label is disabled"
+  fi
+}
+
 run_doctor() {
   if [ "$#" -ne 0 ]; then
     fail_usage "doctor accepts no arguments"
@@ -770,7 +778,7 @@ run_doctor() {
     doctor_ok "Profile is supported: $(profile_context_label)"
   fi
 
-  for tool in chezmoi git zsh mise; do
+  for tool in chezmoi git zsh mise nvim zellij; do
     doctor_check_command "$tool"
   done
 
@@ -783,11 +791,10 @@ run_doctor() {
       ;;
   esac
 
-  doctor_check_optional_stack \
+  doctor_check_optional_setting \
     "Optional Editor Stack" \
     "$(effective_editor_stack_enabled "$config_file")" \
-    "Run terrapod chezmoi -- apply after enabling Optional Editor Stack, or install/apply the configured editor tools before relying on them." \
-    nvim
+    "rich Neovim configuration"
 
   doctor_check_optional_stack \
     "Optional AI Tool Stack" \
@@ -795,11 +802,10 @@ run_doctor() {
     "Run terrapod chezmoi -- apply after enabling Optional AI Tool Stack, or install/apply the configured tools before relying on them." \
     gemini claude codex
 
-  doctor_check_optional_stack \
+  doctor_check_optional_setting \
     "Optional Development Workspace" \
     "$(config_data_bool "$config_file" enableDevelopmentWorkspace)" \
-    "Run terrapod chezmoi -- apply after enabling Optional Development Workspace, or install/apply the configured workspace tools before relying on them." \
-    zellij
+    "development Zellij layouts"
 
   if [ "$doctor_guidance_printed" -eq 0 ]; then
     printf '%s\n' "Guidance: none"

--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -10,6 +10,8 @@ Terrapod - Dotfiles Management Tool
 Usage:
   terrapod [help|--help|-h]
   terrapod configure <$preset_args>
+  terrapod status
+  terrapod doctor
   terrapod diff
   terrapod apply
   terrapod update
@@ -19,6 +21,8 @@ Commands:
   help                                  Show this help.
   configure <$preset_args>
                                         Expand a Preset into concrete chezmoi data values.
+  status                                Explain this machine's Terrapod profile, config, stack, and tool state.
+  doctor                                Validate Terrapod prerequisites and report actionable guidance.
   diff                                  Run chezmoi diff with Terrapod profile and stack context.
   apply                                 Run preflight checks, chezmoi apply, and post-apply validation.
   update                                Run chezmoi update with Terrapod profile and config context.
@@ -26,6 +30,8 @@ Commands:
 
 Examples:
   terrapod configure development
+  terrapod status
+  terrapod doctor
   terrapod diff
   terrapod apply
   terrapod update
@@ -69,6 +75,52 @@ chezmoi_config_file() {
   printf '%s\n' "$HOME/.config/chezmoi/chezmoi.toml"
 }
 
+os_release_file() {
+  printf '%s\n' "${TERRAPOD_OS_RELEASE_FILE:-/etc/os-release}"
+}
+
+os_release_value() {
+  key="$1"
+  file="$(os_release_file)"
+
+  if [ ! -f "$file" ]; then
+    return 1
+  fi
+
+  awk -F= -v wanted="$key" '
+    $1 == wanted {
+      value = $0
+      sub("^[^=]*=", "", value)
+      sub(/^"/, "", value)
+      sub(/"$/, "", value)
+      print value
+      found = 1
+      exit
+    }
+
+    END {
+      exit found ? 0 : 1
+    }
+  ' "$file"
+}
+
+is_supported_ubuntu_release() {
+  [ "$(os_release_value ID 2>/dev/null || printf unknown)" = "ubuntu" ] &&
+    [ "$(os_release_value VERSION_ID 2>/dev/null || printf unknown)" = "24.04" ]
+}
+
+unsupported_profile_reason() {
+  case "$(uname -s 2>/dev/null || printf unknown)" in
+    Linux)
+      pretty_name="$(os_release_value PRETTY_NAME 2>/dev/null || printf 'unknown Linux release')"
+      printf '%s\n' "unsupported Linux release: $pretty_name. Terrapod supports Ubuntu 24.04 for the VPS Shell Profile."
+      ;;
+    *)
+      printf '%s\n' "unsupported operating system: $(uname -s 2>/dev/null || printf unknown). Terrapod supports macOS and Ubuntu 24.04."
+      ;;
+  esac
+}
+
 current_profile() {
   case "${TERRAPOD_PROFILE:-}" in
     macos-terminal|vps-shell)
@@ -82,7 +134,11 @@ current_profile() {
       printf '%s\n' "macos-terminal"
       ;;
     Linux)
-      printf '%s\n' "vps-shell"
+      if is_supported_ubuntu_release; then
+        printf '%s\n' "vps-shell"
+      else
+        printf '%s\n' "unsupported"
+      fi
       ;;
     *)
       printf '%s\n' "unsupported"
@@ -259,6 +315,236 @@ effective_optional_stack_state_label() {
   fi
 }
 
+is_enabled() {
+  [ "$1" = "true" ]
+}
+
+effective_editor_stack_enabled() {
+  config_file="$1"
+
+  if [ "$(config_data_bool "$config_file" enableEditorStack)" = "true" ] ||
+    [ "$(config_data_bool "$config_file" enableDevelopmentWorkspace)" = "true" ]; then
+    printf '%s\n' "true"
+  else
+    printf '%s\n' "false"
+  fi
+}
+
+effective_ai_cli_tools_enabled() {
+  config_file="$1"
+
+  if [ "$(config_data_bool "$config_file" enableAiCliTools)" = "true" ] ||
+    [ "$(config_data_bool "$config_file" enableDevelopmentWorkspace)" = "true" ]; then
+    printf '%s\n' "true"
+  else
+    printf '%s\n' "false"
+  fi
+}
+
+join_tools() {
+  joined=
+  for tool do
+    if [ -z "$joined" ]; then
+      joined="$tool"
+    else
+      joined="$joined, $tool"
+    fi
+  done
+  printf '%s\n' "$joined"
+}
+
+missing_tools() {
+  missing=
+  for tool do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      if [ -z "$missing" ]; then
+        missing="$tool"
+      else
+        missing="$missing, $tool"
+      fi
+    fi
+  done
+  printf '%s\n' "$missing"
+}
+
+tool_phrase() {
+  missing="$(missing_tools "$@")"
+  if [ -n "$missing" ]; then
+    printf '%s\n' "missing tools: $missing"
+  else
+    printf '%s\n' "tools available: $(join_tools "$@")"
+  fi
+}
+
+print_stack_status() {
+  label="$1"
+  enabled="$2"
+  shift 2
+
+  if is_enabled "$enabled"; then
+    printf '  %s: enabled (%s)\n' "$label" "$(tool_phrase "$@")"
+  else
+    printf '  %s: disabled\n' "$label"
+  fi
+}
+
+print_macos_app_group_status() {
+  config_file="$1"
+  profile="$2"
+
+  if [ "$profile" != "macos-terminal" ]; then
+    printf '%s\n' "macOS App Groups: not applicable for $(profile_context_label)"
+    return
+  fi
+
+  printf '%s\n' "macOS App Groups:"
+  if is_enabled "$(config_data_bool "$config_file" enableMacosAppGroupTerminalApps)"; then
+    printf '%s\n' "  terminal-apps: enabled (Ghostty and cmux)"
+  else
+    printf '%s\n' "  terminal-apps: disabled"
+  fi
+  if is_enabled "$(config_data_bool "$config_file" enableMacosAppGroupAutomation)"; then
+    printf '%s\n' "  automation: enabled (Hammerspoon and Karabiner-Elements)"
+  else
+    printf '%s\n' "  automation: disabled"
+  fi
+  if is_enabled "$(config_data_bool "$config_file" enableMacosAppGroupLauncher)"; then
+    printf '%s\n' "  launcher: enabled (Raycast and 1Password CLI)"
+  else
+    printf '%s\n' "  launcher: disabled"
+  fi
+  if is_enabled "$(config_data_bool "$config_file" enableMacosAppGroupMonitoring)"; then
+    printf '%s\n' "  monitoring: enabled (iStat Menus)"
+  else
+    printf '%s\n' "  monitoring: disabled"
+  fi
+}
+
+print_key_tool_status() {
+  profile="$1"
+
+  printf '%s\n' "Key tools:"
+  for tool in chezmoi git zsh mise; do
+    if command -v "$tool" >/dev/null 2>&1; then
+      printf '  %s: available\n' "$tool"
+    else
+      printf '  %s: missing\n' "$tool"
+    fi
+  done
+
+  case "$profile" in
+    macos-terminal)
+      if command -v brew >/dev/null 2>&1; then
+        printf '%s\n' "  brew: available"
+      else
+        printf '%s\n' "  brew: missing"
+      fi
+      ;;
+    vps-shell)
+      if command -v apt >/dev/null 2>&1; then
+        printf '%s\n' "  apt: available"
+      else
+        printf '%s\n' "  apt: missing"
+      fi
+      ;;
+  esac
+}
+
+status_key_tool_warnings() {
+  profile="$1"
+  missing="$(missing_tools chezmoi git zsh mise)"
+
+  case "$profile" in
+    macos-terminal)
+      platform_missing="$(missing_tools brew)"
+      ;;
+    vps-shell)
+      platform_missing="$(missing_tools apt)"
+      ;;
+    *)
+      platform_missing=
+      ;;
+  esac
+
+  if [ -n "$platform_missing" ]; then
+    if [ -n "$missing" ]; then
+      missing="$missing, $platform_missing"
+    else
+      missing="$platform_missing"
+    fi
+  fi
+
+  if [ -n "$missing" ]; then
+    printf '%s\n' "Warning: missing key tools: $missing"
+    return 0
+  fi
+
+  return 1
+}
+
+print_status_warnings() {
+  config_file="$1"
+  profile="$2"
+  printed=0
+
+  if [ "$profile" = "unsupported" ]; then
+    printf '%s\n' "Warning: $(unsupported_profile_reason)"
+    printed=1
+  fi
+
+  if status_key_tool_warnings "$profile"; then
+    printed=1
+  fi
+
+  if is_enabled "$(effective_editor_stack_enabled "$config_file")"; then
+    missing="$(missing_tools nvim)"
+    if [ -n "$missing" ]; then
+      printf '%s\n' "Warning: Optional Editor Stack is enabled but missing tools: $missing"
+      printed=1
+    fi
+  fi
+
+  if is_enabled "$(effective_ai_cli_tools_enabled "$config_file")"; then
+    missing="$(missing_tools gemini claude codex)"
+    if [ -n "$missing" ]; then
+      printf '%s\n' "Warning: Optional AI Tool Stack is enabled but missing tools: $missing"
+      printed=1
+    fi
+  fi
+
+  if is_enabled "$(config_data_bool "$config_file" enableDevelopmentWorkspace)"; then
+    missing="$(missing_tools zellij)"
+    if [ -n "$missing" ]; then
+      printf '%s\n' "Warning: Optional Development Workspace is enabled but missing tools: $missing"
+      printed=1
+    fi
+  fi
+
+  if [ "$printed" -eq 0 ]; then
+    printf '%s\n' "Warnings: none"
+  fi
+}
+
+run_status() {
+  if [ "$#" -ne 0 ]; then
+    fail_usage "status accepts no arguments"
+  fi
+
+  config_file="$(chezmoi_config_file)"
+  profile="$(current_profile)"
+
+  printf '%s\n' "Terrapod status"
+  printf '%s\n' "Profile: $(profile_context_label)"
+  show_config_context "$config_file"
+  printf '%s\n' "Optional stacks:"
+  print_stack_status "Optional Editor Stack" "$(effective_editor_stack_enabled "$config_file")" nvim
+  print_stack_status "Optional AI Tool Stack" "$(effective_ai_cli_tools_enabled "$config_file")" gemini claude codex
+  print_stack_status "Optional Development Workspace" "$(config_data_bool "$config_file" enableDevelopmentWorkspace)" zellij
+  print_macos_app_group_status "$config_file" "$profile"
+  print_key_tool_status "$profile"
+  print_status_warnings "$config_file" "$profile"
+}
+
 show_config_context() {
   config_file="$1"
 
@@ -409,6 +695,119 @@ run_apply() {
   fi
 
   run_post_apply_validation
+}
+
+doctor_failed=0
+doctor_guidance_printed=0
+
+doctor_ok() {
+  printf '  ok - %s\n' "$1"
+}
+
+doctor_warn() {
+  printf '  warn - %s\n' "$1"
+  doctor_failed=1
+}
+
+doctor_guidance() {
+  if [ "$doctor_guidance_printed" -eq 0 ]; then
+    printf '%s\n' "Guidance:"
+    doctor_guidance_printed=1
+  fi
+  printf '  - %s\n' "$1"
+}
+
+doctor_check_command() {
+  tool="$1"
+
+  if command -v "$tool" >/dev/null 2>&1; then
+    doctor_ok "$tool is available"
+  else
+    doctor_warn "$tool is missing"
+    doctor_guidance "Install or apply the configured Core Shell Stack so '$tool' is available on PATH."
+  fi
+}
+
+doctor_check_optional_stack() {
+  label="$1"
+  enabled="$2"
+  guidance="$3"
+  shift 3
+
+  if ! is_enabled "$enabled"; then
+    doctor_ok "$label is disabled"
+    return
+  fi
+
+  missing="$(missing_tools "$@")"
+  if [ -n "$missing" ]; then
+    doctor_warn "$label is enabled but missing tools: $missing"
+    doctor_guidance "$guidance"
+  else
+    doctor_ok "$label is enabled and tools are available: $(join_tools "$@")"
+  fi
+}
+
+run_doctor() {
+  if [ "$#" -ne 0 ]; then
+    fail_usage "doctor accepts no arguments"
+  fi
+
+  doctor_failed=0
+  doctor_guidance_printed=0
+  config_file="$(chezmoi_config_file)"
+  profile="$(current_profile)"
+
+  printf '%s\n' "Terrapod doctor"
+  printf '%s\n' "Profile: $(profile_context_label)"
+  show_config_context "$config_file"
+  printf '%s\n' "Checks:"
+
+  if [ "$profile" = "unsupported" ]; then
+    doctor_warn "$(unsupported_profile_reason)"
+    doctor_guidance "Run Terrapod on macOS or Ubuntu 24.04, or use 'terrapod chezmoi -- <args>' as an advanced escape hatch on unsupported systems."
+  else
+    doctor_ok "Profile is supported: $(profile_context_label)"
+  fi
+
+  for tool in chezmoi git zsh mise; do
+    doctor_check_command "$tool"
+  done
+
+  case "$profile" in
+    macos-terminal)
+      doctor_check_command brew
+      ;;
+    vps-shell)
+      doctor_check_command apt
+      ;;
+  esac
+
+  doctor_check_optional_stack \
+    "Optional Editor Stack" \
+    "$(effective_editor_stack_enabled "$config_file")" \
+    "Run terrapod chezmoi -- apply after enabling Optional Editor Stack, or install/apply the configured editor tools before relying on them." \
+    nvim
+
+  doctor_check_optional_stack \
+    "Optional AI Tool Stack" \
+    "$(effective_ai_cli_tools_enabled "$config_file")" \
+    "Run terrapod chezmoi -- apply after enabling Optional AI Tool Stack, or install/apply the configured tools before relying on them." \
+    gemini claude codex
+
+  doctor_check_optional_stack \
+    "Optional Development Workspace" \
+    "$(config_data_bool "$config_file" enableDevelopmentWorkspace)" \
+    "Run terrapod chezmoi -- apply after enabling Optional Development Workspace, or install/apply the configured workspace tools before relying on them." \
+    zellij
+
+  if [ "$doctor_guidance_printed" -eq 0 ]; then
+    printf '%s\n' "Guidance: none"
+  fi
+
+  if [ "$doctor_failed" -ne 0 ]; then
+    return 1
+  fi
 }
 
 show_update_context() {
@@ -945,6 +1344,14 @@ case "$command_name" in
     confirm_existing_config_update "$config_file"
     write_managed_config "$config_file" "$preset"
     printf '%s\n' "Configured Terrapod Preset '$preset' in $config_file"
+    ;;
+  status)
+    shift
+    run_status "$@"
+    ;;
+  doctor)
+    shift
+    run_doctor "$@"
     ;;
   diff)
     shift

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -435,9 +435,9 @@ macos_status_output="$(
 assert_contains "$macos_status_output" "Terrapod status" "Terrapod status prints a command heading"
 assert_contains "$macos_status_output" "Profile: macOS Terminal Profile" "Terrapod status reports macOS Terminal Profile context"
 assert_contains "$macos_status_output" "Config: $status_config (present)" "Terrapod status reports explicit config path"
-assert_contains "$macos_status_output" "Optional Editor Stack: enabled (tools available: nvim)" "Terrapod status reports enabled Optional Editor Stack tool state"
+assert_contains "$macos_status_output" "Optional Editor Stack: enabled (rich Neovim configuration)" "Terrapod status reports enabled Optional Editor Stack state"
 assert_contains "$macos_status_output" "Optional AI Tool Stack: enabled (tools available: gemini, claude, codex)" "Terrapod status reports enabled Optional AI Tool Stack tool state"
-assert_contains "$macos_status_output" "Optional Development Workspace: enabled (tools available: zellij)" "Terrapod status reports enabled Optional Development Workspace tool state"
+assert_contains "$macos_status_output" "Optional Development Workspace: enabled (development Zellij layouts)" "Terrapod status reports enabled Optional Development Workspace state"
 assert_contains "$macos_status_output" "terminal-apps: enabled (Ghostty and cmux)" "Terrapod status reports enabled terminal-apps macOS App Group"
 assert_contains "$macos_status_output" "automation: disabled" "Terrapod status reports disabled automation macOS App Group"
 assert_contains "$macos_status_output" "launcher: enabled (Raycast and 1Password CLI)" "Terrapod status reports enabled launcher macOS App Group"
@@ -462,7 +462,7 @@ dotted_status_output="$(
     /bin/sh "$terrapod" status
 )"
 
-assert_contains "$dotted_status_output" "Optional Editor Stack: enabled (tools available: nvim)" "Terrapod status reads root dotted data keys for effective editor stack state"
+assert_contains "$dotted_status_output" "Optional Editor Stack: enabled (rich Neovim configuration)" "Terrapod status reads root dotted data keys for effective editor stack state"
 assert_contains "$dotted_status_output" "Optional AI Tool Stack: enabled (tools available: gemini, claude, codex)" "Terrapod status reads root dotted data keys for effective AI stack state"
 assert_contains "$dotted_status_output" "terminal-apps: enabled (Ghostty and cmux)" "Terrapod status reads root dotted data keys for macOS App Groups"
 assert_contains "$dotted_status_output" "Warnings: none" "Terrapod status has no warnings for root dotted data keys when tools are present"
@@ -481,7 +481,7 @@ enableMacosAppGroupMonitoring = false
 TOML
 write_os_release "$status_ubuntu_os_release" ubuntu 24.04 "Ubuntu 24.04 LTS"
 
-ubuntu_status_path="$(status_doctor_path ubuntu chezmoi git zsh mise apt)"
+ubuntu_status_path="$(status_doctor_path ubuntu chezmoi git zsh mise nvim zellij apt)"
 write_stub "$ubuntu_status_path/uname" 'printf "%s\n" "Linux"'
 
 ubuntu_status_output="$(
@@ -500,6 +500,20 @@ assert_not_contains "$ubuntu_status_output" "Warning:" "Terrapod status emits no
 assert_not_contains "$ubuntu_status_output" "missing tools: nvim" "Terrapod status distinguishes disabled Optional Editor Stack from missing tools"
 assert_not_contains "$ubuntu_status_output" "missing tools: gemini" "Terrapod status distinguishes disabled Optional AI Tool Stack from missing tools"
 
+core_missing_status_path="$(status_doctor_path core-missing-status chezmoi git zsh mise apt)"
+write_stub "$core_missing_status_path/uname" 'printf "%s\n" "Linux"'
+
+core_missing_status_output="$(
+  TERRAPOD_OS_RELEASE_FILE="$status_ubuntu_os_release" TERRAPOD_CHEZMOI_CONFIG="$status_ubuntu_config" PATH="$core_missing_status_path" \
+    /bin/sh "$terrapod" status
+)"
+
+assert_contains "$core_missing_status_output" "Optional Editor Stack: disabled" "Terrapod status keeps disabled Optional Editor Stack separate from missing core Neovim"
+assert_contains "$core_missing_status_output" "Optional Development Workspace: disabled" "Terrapod status keeps disabled Optional Development Workspace separate from missing core Zellij"
+assert_contains "$core_missing_status_output" "nvim: missing" "Terrapod status reports missing plain Neovim as a key tool"
+assert_contains "$core_missing_status_output" "zellij: missing" "Terrapod status reports missing Zellij as a key tool"
+assert_contains "$core_missing_status_output" "Warning: missing key tools: nvim, zellij" "Terrapod status warns about missing core Neovim and Zellij even when optional stacks are disabled"
+
 status_missing_config="$tmp_dir/status-missing.toml"
 cat >"$status_missing_config" <<'TOML'
 [data]
@@ -508,7 +522,7 @@ enableAiCliTools = true
 enableDevelopmentWorkspace = true
 TOML
 
-missing_status_path="$(status_doctor_path missing chezmoi git zsh mise apt)"
+missing_status_path="$(status_doctor_path missing chezmoi git zsh mise nvim zellij apt)"
 write_stub "$missing_status_path/uname" 'printf "%s\n" "Linux"'
 
 missing_status_output="$(
@@ -516,9 +530,9 @@ missing_status_output="$(
     /bin/sh "$terrapod" status
 )"
 
-assert_contains "$missing_status_output" "Optional Editor Stack: enabled (missing tools: nvim)" "Terrapod status reports missing tools only for enabled Optional Editor Stack"
+assert_contains "$missing_status_output" "Optional Editor Stack: enabled (rich Neovim configuration)" "Terrapod status reports enabled Optional Editor Stack as rich config state"
 assert_contains "$missing_status_output" "Optional AI Tool Stack: enabled (missing tools: gemini, claude, codex)" "Terrapod status reports missing tools only for enabled Optional AI Tool Stack"
-assert_contains "$missing_status_output" "Optional Development Workspace: enabled (missing tools: zellij)" "Terrapod status reports missing tools only for enabled Optional Development Workspace"
+assert_contains "$missing_status_output" "Optional Development Workspace: enabled (development Zellij layouts)" "Terrapod status reports enabled Optional Development Workspace as layout state"
 assert_contains "$missing_status_output" "Warning: Optional AI Tool Stack is enabled but missing tools: gemini, claude, codex" "Terrapod status warns for enabled missing AI tools"
 
 status_workspace_bundle_config="$tmp_dir/status-workspace-bundle.toml"
@@ -529,7 +543,7 @@ enableAiCliTools = false
 enableDevelopmentWorkspace = true
 TOML
 
-workspace_bundle_status_path="$(status_doctor_path workspace-bundle chezmoi git zsh mise apt)"
+workspace_bundle_status_path="$(status_doctor_path workspace-bundle chezmoi git zsh mise nvim zellij apt)"
 write_stub "$workspace_bundle_status_path/uname" 'printf "%s\n" "Linux"'
 
 workspace_bundle_status_output="$(
@@ -537,10 +551,9 @@ workspace_bundle_status_output="$(
     /bin/sh "$terrapod" status
 )"
 
-assert_contains "$workspace_bundle_status_output" "Optional Editor Stack: enabled (missing tools: nvim)" "Terrapod status treats Optional Development Workspace as enabling Optional Editor Stack"
+assert_contains "$workspace_bundle_status_output" "Optional Editor Stack: enabled (rich Neovim configuration)" "Terrapod status treats Optional Development Workspace as enabling Optional Editor Stack"
 assert_contains "$workspace_bundle_status_output" "Optional AI Tool Stack: enabled (missing tools: gemini, claude, codex)" "Terrapod status treats Optional Development Workspace as enabling Optional AI Tool Stack"
-assert_contains "$workspace_bundle_status_output" "Optional Development Workspace: enabled (missing tools: zellij)" "Terrapod status reports missing Optional Development Workspace tools"
-assert_contains "$workspace_bundle_status_output" "Warning: Optional Editor Stack is enabled but missing tools: nvim" "Terrapod status warns when workspace-enabled Optional Editor Stack tools are missing"
+assert_contains "$workspace_bundle_status_output" "Optional Development Workspace: enabled (development Zellij layouts)" "Terrapod status reports enabled Optional Development Workspace"
 assert_contains "$workspace_bundle_status_output" "Warning: Optional AI Tool Stack is enabled but missing tools: gemini, claude, codex" "Terrapod status warns when workspace-enabled Optional AI Tool Stack tools are missing"
 
 status_unsupported_os_release="$tmp_dir/status-unsupported-os-release"
@@ -564,7 +577,7 @@ enableDevelopmentWorkspace = false
 TOML
 write_os_release "$doctor_os_release" ubuntu 24.04 "Ubuntu 24.04 LTS"
 
-doctor_ok_path="$(status_doctor_path doctor-ok chezmoi git zsh mise apt)"
+doctor_ok_path="$(status_doctor_path doctor-ok chezmoi git zsh mise nvim zellij apt)"
 write_stub "$doctor_ok_path/uname" 'printf "%s\n" "Linux"'
 
 if ! doctor_ok_output="$(
@@ -577,13 +590,15 @@ fi
 assert_contains "$doctor_ok_output" "Terrapod doctor" "Terrapod doctor prints a command heading"
 assert_contains "$doctor_ok_output" "ok - Profile is supported: VPS Shell Profile" "Terrapod doctor validates supported Ubuntu profile"
 assert_contains "$doctor_ok_output" "ok - chezmoi is available" "Terrapod doctor validates chezmoi availability"
+assert_contains "$doctor_ok_output" "ok - nvim is available" "Terrapod doctor validates plain Neovim as a Core Shell Stack tool"
+assert_contains "$doctor_ok_output" "ok - zellij is available" "Terrapod doctor validates Zellij as a Core Shell Stack tool"
 assert_contains "$doctor_ok_output" "ok - apt is available" "Terrapod doctor validates Ubuntu Bootstrap Package Manager availability"
 assert_contains "$doctor_ok_output" "ok - Optional Editor Stack is disabled" "Terrapod doctor treats disabled Optional Editor Stack as valid"
 assert_contains "$doctor_ok_output" "ok - Optional AI Tool Stack is disabled" "Terrapod doctor treats disabled Optional AI Tool Stack as valid"
 assert_contains "$doctor_ok_output" "ok - Optional Development Workspace is disabled" "Terrapod doctor treats disabled Optional Development Workspace as valid"
 assert_contains "$doctor_ok_output" "Guidance: none" "Terrapod doctor prints no guidance when checks pass"
 
-doctor_missing_key_path="$(status_doctor_path doctor-missing-key git zsh mise apt)"
+doctor_missing_key_path="$(status_doctor_path doctor-missing-key git zsh mise nvim zellij apt)"
 write_stub "$doctor_missing_key_path/uname" 'printf "%s\n" "Linux"'
 
 if TERRAPOD_OS_RELEASE_FILE="$doctor_os_release" TERRAPOD_CHEZMOI_CONFIG="$doctor_config" PATH="$doctor_missing_key_path" \
@@ -596,6 +611,21 @@ doctor_missing_key_output="$(cat "$tmp_dir/doctor-missing-key.out")"
 assert_contains "$doctor_missing_key_output" "warn - chezmoi is missing" "Terrapod doctor warns when required chezmoi is missing"
 assert_contains "$doctor_missing_key_output" "Install or apply the configured Core Shell Stack so 'chezmoi' is available on PATH." "Terrapod doctor gives actionable guidance for missing key tools"
 
+doctor_missing_core_path="$(status_doctor_path doctor-missing-core chezmoi git zsh mise apt)"
+write_stub "$doctor_missing_core_path/uname" 'printf "%s\n" "Linux"'
+
+if TERRAPOD_OS_RELEASE_FILE="$doctor_os_release" TERRAPOD_CHEZMOI_CONFIG="$doctor_config" PATH="$doctor_missing_core_path" \
+  /bin/sh "$terrapod" doctor >"$tmp_dir/doctor-missing-core.out" 2>"$tmp_dir/doctor-missing-core.err"; then
+  fail "Terrapod doctor fails when Core Shell Stack Neovim or Zellij is missing"
+fi
+
+doctor_missing_core_output="$(cat "$tmp_dir/doctor-missing-core.out")"
+
+assert_contains "$doctor_missing_core_output" "warn - nvim is missing" "Terrapod doctor warns when plain Neovim is missing even if Optional Editor Stack is disabled"
+assert_contains "$doctor_missing_core_output" "warn - zellij is missing" "Terrapod doctor warns when Zellij is missing even if Optional Development Workspace is disabled"
+assert_contains "$doctor_missing_core_output" "ok - Optional Editor Stack is disabled" "Terrapod doctor keeps disabled Optional Editor Stack separate from missing core Neovim"
+assert_contains "$doctor_missing_core_output" "ok - Optional Development Workspace is disabled" "Terrapod doctor keeps disabled Optional Development Workspace separate from missing core Zellij"
+
 doctor_missing_config="$tmp_dir/doctor-missing.toml"
 cat >"$doctor_missing_config" <<'TOML'
 [data]
@@ -604,7 +634,7 @@ enableAiCliTools = true
 enableDevelopmentWorkspace = true
 TOML
 
-doctor_missing_path="$(status_doctor_path doctor-missing chezmoi git zsh mise apt)"
+doctor_missing_path="$(status_doctor_path doctor-missing chezmoi git zsh mise nvim zellij apt)"
 write_stub "$doctor_missing_path/uname" 'printf "%s\n" "Linux"'
 
 if TERRAPOD_OS_RELEASE_FILE="$doctor_os_release" TERRAPOD_CHEZMOI_CONFIG="$doctor_missing_config" PATH="$doctor_missing_path" \
@@ -614,15 +644,15 @@ fi
 
 doctor_missing_output="$(cat "$tmp_dir/doctor-missing.out")"
 
-assert_contains "$doctor_missing_output" "warn - Optional Editor Stack is enabled but missing tools: nvim" "Terrapod doctor warns about missing enabled editor tools"
+assert_contains "$doctor_missing_output" "ok - Optional Editor Stack is enabled (rich Neovim configuration)" "Terrapod doctor reports enabled Optional Editor Stack as rich config state"
 assert_contains "$doctor_missing_output" "warn - Optional AI Tool Stack is enabled but missing tools: gemini, claude, codex" "Terrapod doctor warns about missing enabled AI tools"
-assert_contains "$doctor_missing_output" "warn - Optional Development Workspace is enabled but missing tools: zellij" "Terrapod doctor warns about missing enabled workspace tools"
+assert_contains "$doctor_missing_output" "ok - Optional Development Workspace is enabled (development Zellij layouts)" "Terrapod doctor reports enabled Optional Development Workspace as layout state"
 assert_contains "$doctor_missing_output" "Run terrapod chezmoi -- apply after enabling Optional AI Tool Stack, or install/apply the configured tools before relying on them." "Terrapod doctor gives actionable missing optional-stack guidance"
 
 doctor_unsupported_os_release="$tmp_dir/doctor-unsupported-os-release"
 write_os_release "$doctor_unsupported_os_release" debian 12 "Debian GNU/Linux 12"
 
-doctor_unsupported_path="$(status_doctor_path doctor-unsupported chezmoi git zsh mise apt)"
+doctor_unsupported_path="$(status_doctor_path doctor-unsupported chezmoi git zsh mise nvim zellij apt)"
 write_stub "$doctor_unsupported_path/uname" 'printf "%s\n" "Linux"'
 
 if TERRAPOD_OS_RELEASE_FILE="$doctor_unsupported_os_release" TERRAPOD_CHEZMOI_CONFIG="$doctor_config" PATH="$doctor_unsupported_path" \

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -87,6 +87,55 @@ assert_call_args() {
   pass "$message"
 }
 
+write_success_stub() {
+  name="$1"
+  write_stub "$tmp_dir/bin/$name" \
+    'exit 0'
+}
+
+write_failing_command_stub() {
+  path="$1"
+  call_file="$2"
+  write_stub "$path" \
+    'printf "%s\n" "$0 $*" >>"'"$call_file"'"' \
+    'exit 90'
+}
+
+write_os_release() {
+  path="$1"
+  id="$2"
+  version_id="$3"
+  pretty_name="$4"
+
+  cat >"$path" <<EOF
+ID=$id
+VERSION_ID="$version_id"
+PRETTY_NAME="$pretty_name"
+EOF
+}
+
+status_doctor_path() {
+  name="$1"
+  shift
+
+  isolated_path="$tmp_dir/status-doctor-path-$name"
+  rm -rf "$isolated_path"
+  mkdir -p "$isolated_path"
+
+  awk_path="$(command -v awk 2>/dev/null || true)"
+  if [ -z "$awk_path" ]; then
+    fail "status/doctor tests require awk"
+  fi
+  ln -s "$awk_path" "$isolated_path/awk"
+
+  for command_name do
+    write_stub "$isolated_path/$command_name" \
+      'exit 0'
+  done
+
+  printf '%s\n' "$isolated_path"
+}
+
 assert_no_terrapod_artifacts_under() {
   dir="$1"
   message="$2"
@@ -227,6 +276,16 @@ assert_contains \
   "terrapod configure <minimal|development|workstation>" \
   "Terrapod help documents Preset configuration"
 
+assert_contains \
+  "$help_output" \
+  "terrapod status" \
+  "Terrapod help documents status"
+
+assert_contains \
+  "$help_output" \
+  "terrapod doctor" \
+  "Terrapod help documents doctor"
+
 macos_help_output="$(TERRAPOD_PROFILE=macos-terminal sh "$terrapod" help)"
 
 assert_contains \
@@ -353,6 +412,252 @@ assert_contains \
   "$missing_command_error" \
   "terrapod: raw chezmoi command is required" \
   "Terrapod explains missing raw chezmoi command"
+
+status_config="$tmp_dir/status-macos.toml"
+cat >"$status_config" <<'TOML'
+[data]
+enableEditorStack = true
+enableAiCliTools = true
+enableDevelopmentWorkspace = true
+enableMacosAppGroupTerminalApps = true
+enableMacosAppGroupAutomation = false
+enableMacosAppGroupLauncher = true
+enableMacosAppGroupMonitoring = false
+TOML
+
+macos_status_path="$(status_doctor_path macos chezmoi git zsh mise brew nvim gemini claude codex zellij ghostty cmux op)"
+
+macos_status_output="$(
+  TERRAPOD_PROFILE=macos-terminal TERRAPOD_CHEZMOI_CONFIG="$status_config" PATH="$macos_status_path" \
+    /bin/sh "$terrapod" status
+)"
+
+assert_contains "$macos_status_output" "Terrapod status" "Terrapod status prints a command heading"
+assert_contains "$macos_status_output" "Profile: macOS Terminal Profile" "Terrapod status reports macOS Terminal Profile context"
+assert_contains "$macos_status_output" "Config: $status_config (present)" "Terrapod status reports explicit config path"
+assert_contains "$macos_status_output" "Optional Editor Stack: enabled (tools available: nvim)" "Terrapod status reports enabled Optional Editor Stack tool state"
+assert_contains "$macos_status_output" "Optional AI Tool Stack: enabled (tools available: gemini, claude, codex)" "Terrapod status reports enabled Optional AI Tool Stack tool state"
+assert_contains "$macos_status_output" "Optional Development Workspace: enabled (tools available: zellij)" "Terrapod status reports enabled Optional Development Workspace tool state"
+assert_contains "$macos_status_output" "terminal-apps: enabled (Ghostty and cmux)" "Terrapod status reports enabled terminal-apps macOS App Group"
+assert_contains "$macos_status_output" "automation: disabled" "Terrapod status reports disabled automation macOS App Group"
+assert_contains "$macos_status_output" "launcher: enabled (Raycast and 1Password CLI)" "Terrapod status reports enabled launcher macOS App Group"
+assert_contains "$macos_status_output" "monitoring: disabled" "Terrapod status reports disabled monitoring macOS App Group"
+assert_contains "$macos_status_output" "chezmoi: available" "Terrapod status reports chezmoi availability"
+assert_contains "$macos_status_output" "brew: available" "Terrapod status reports macOS Bootstrap Package Manager availability"
+assert_contains "$macos_status_output" "Warnings: none" "Terrapod status reports no warnings when enabled tools are present"
+assert_not_contains "$macos_status_output" "Warning:" "Terrapod status emits no warning lines when enabled tools are present"
+
+status_dotted_config="$tmp_dir/status-dotted.toml"
+cat >"$status_dotted_config" <<'TOML'
+data.enableEditorStack = false
+data.enableAiCliTools = false
+data.enableDevelopmentWorkspace = true
+data.enableMacosAppGroupTerminalApps = true
+TOML
+
+dotted_status_path="$(status_doctor_path dotted chezmoi git zsh mise brew nvim gemini claude codex zellij)"
+
+dotted_status_output="$(
+  TERRAPOD_PROFILE=macos-terminal TERRAPOD_CHEZMOI_CONFIG="$status_dotted_config" PATH="$dotted_status_path" \
+    /bin/sh "$terrapod" status
+)"
+
+assert_contains "$dotted_status_output" "Optional Editor Stack: enabled (tools available: nvim)" "Terrapod status reads root dotted data keys for effective editor stack state"
+assert_contains "$dotted_status_output" "Optional AI Tool Stack: enabled (tools available: gemini, claude, codex)" "Terrapod status reads root dotted data keys for effective AI stack state"
+assert_contains "$dotted_status_output" "terminal-apps: enabled (Ghostty and cmux)" "Terrapod status reads root dotted data keys for macOS App Groups"
+assert_contains "$dotted_status_output" "Warnings: none" "Terrapod status has no warnings for root dotted data keys when tools are present"
+
+status_ubuntu_config="$tmp_dir/status-ubuntu.toml"
+status_ubuntu_os_release="$tmp_dir/status-ubuntu-os-release"
+cat >"$status_ubuntu_config" <<'TOML'
+[data]
+enableEditorStack = false
+enableAiCliTools = false
+enableDevelopmentWorkspace = false
+enableMacosAppGroupTerminalApps = false
+enableMacosAppGroupAutomation = false
+enableMacosAppGroupLauncher = false
+enableMacosAppGroupMonitoring = false
+TOML
+write_os_release "$status_ubuntu_os_release" ubuntu 24.04 "Ubuntu 24.04 LTS"
+
+ubuntu_status_path="$(status_doctor_path ubuntu chezmoi git zsh mise apt)"
+write_stub "$ubuntu_status_path/uname" 'printf "%s\n" "Linux"'
+
+ubuntu_status_output="$(
+  TERRAPOD_OS_RELEASE_FILE="$status_ubuntu_os_release" TERRAPOD_CHEZMOI_CONFIG="$status_ubuntu_config" PATH="$ubuntu_status_path" \
+    /bin/sh "$terrapod" status
+)"
+
+assert_contains "$ubuntu_status_output" "Profile: VPS Shell Profile" "Terrapod status reports VPS Shell Profile context on Ubuntu 24.04"
+assert_contains "$ubuntu_status_output" "Optional Editor Stack: disabled" "Terrapod status reports disabled Optional Editor Stack without treating nvim as missing"
+assert_contains "$ubuntu_status_output" "Optional AI Tool Stack: disabled" "Terrapod status reports disabled Optional AI Tool Stack without missing-tool warnings"
+assert_contains "$ubuntu_status_output" "Optional Development Workspace: disabled" "Terrapod status reports disabled Optional Development Workspace without missing-tool warnings"
+assert_contains "$ubuntu_status_output" "macOS App Groups: not applicable for VPS Shell Profile" "Terrapod status omits macOS App Group details on VPS Shell Profile"
+assert_contains "$ubuntu_status_output" "apt: available" "Terrapod status reports Ubuntu Bootstrap Package Manager availability"
+assert_contains "$ubuntu_status_output" "Warnings: none" "Terrapod status has no warnings for disabled optional stacks"
+assert_not_contains "$ubuntu_status_output" "Warning:" "Terrapod status emits no warning lines for disabled optional stacks"
+assert_not_contains "$ubuntu_status_output" "missing tools: nvim" "Terrapod status distinguishes disabled Optional Editor Stack from missing tools"
+assert_not_contains "$ubuntu_status_output" "missing tools: gemini" "Terrapod status distinguishes disabled Optional AI Tool Stack from missing tools"
+
+status_missing_config="$tmp_dir/status-missing.toml"
+cat >"$status_missing_config" <<'TOML'
+[data]
+enableEditorStack = true
+enableAiCliTools = true
+enableDevelopmentWorkspace = true
+TOML
+
+missing_status_path="$(status_doctor_path missing chezmoi git zsh mise apt)"
+write_stub "$missing_status_path/uname" 'printf "%s\n" "Linux"'
+
+missing_status_output="$(
+  TERRAPOD_OS_RELEASE_FILE="$status_ubuntu_os_release" TERRAPOD_CHEZMOI_CONFIG="$status_missing_config" PATH="$missing_status_path" \
+    /bin/sh "$terrapod" status
+)"
+
+assert_contains "$missing_status_output" "Optional Editor Stack: enabled (missing tools: nvim)" "Terrapod status reports missing tools only for enabled Optional Editor Stack"
+assert_contains "$missing_status_output" "Optional AI Tool Stack: enabled (missing tools: gemini, claude, codex)" "Terrapod status reports missing tools only for enabled Optional AI Tool Stack"
+assert_contains "$missing_status_output" "Optional Development Workspace: enabled (missing tools: zellij)" "Terrapod status reports missing tools only for enabled Optional Development Workspace"
+assert_contains "$missing_status_output" "Warning: Optional AI Tool Stack is enabled but missing tools: gemini, claude, codex" "Terrapod status warns for enabled missing AI tools"
+
+status_workspace_bundle_config="$tmp_dir/status-workspace-bundle.toml"
+cat >"$status_workspace_bundle_config" <<'TOML'
+[data]
+enableEditorStack = false
+enableAiCliTools = false
+enableDevelopmentWorkspace = true
+TOML
+
+workspace_bundle_status_path="$(status_doctor_path workspace-bundle chezmoi git zsh mise apt)"
+write_stub "$workspace_bundle_status_path/uname" 'printf "%s\n" "Linux"'
+
+workspace_bundle_status_output="$(
+  TERRAPOD_OS_RELEASE_FILE="$status_ubuntu_os_release" TERRAPOD_CHEZMOI_CONFIG="$status_workspace_bundle_config" PATH="$workspace_bundle_status_path" \
+    /bin/sh "$terrapod" status
+)"
+
+assert_contains "$workspace_bundle_status_output" "Optional Editor Stack: enabled (missing tools: nvim)" "Terrapod status treats Optional Development Workspace as enabling Optional Editor Stack"
+assert_contains "$workspace_bundle_status_output" "Optional AI Tool Stack: enabled (missing tools: gemini, claude, codex)" "Terrapod status treats Optional Development Workspace as enabling Optional AI Tool Stack"
+assert_contains "$workspace_bundle_status_output" "Optional Development Workspace: enabled (missing tools: zellij)" "Terrapod status reports missing Optional Development Workspace tools"
+assert_contains "$workspace_bundle_status_output" "Warning: Optional Editor Stack is enabled but missing tools: nvim" "Terrapod status warns when workspace-enabled Optional Editor Stack tools are missing"
+assert_contains "$workspace_bundle_status_output" "Warning: Optional AI Tool Stack is enabled but missing tools: gemini, claude, codex" "Terrapod status warns when workspace-enabled Optional AI Tool Stack tools are missing"
+
+status_unsupported_os_release="$tmp_dir/status-unsupported-os-release"
+write_os_release "$status_unsupported_os_release" debian 12 "Debian GNU/Linux 12"
+
+unsupported_status_output="$(
+  TERRAPOD_OS_RELEASE_FILE="$status_unsupported_os_release" TERRAPOD_CHEZMOI_CONFIG="$status_ubuntu_config" PATH="$ubuntu_status_path" \
+    /bin/sh "$terrapod" status
+)"
+
+assert_contains "$unsupported_status_output" "Profile: unsupported profile" "Terrapod status reports unsupported Linux as unsupported"
+assert_contains "$unsupported_status_output" "Warning: unsupported Linux release: Debian GNU/Linux 12. Terrapod supports Ubuntu 24.04 for the VPS Shell Profile." "Terrapod status explains unsupported Linux"
+
+doctor_config="$tmp_dir/doctor-ok.toml"
+doctor_os_release="$tmp_dir/doctor-os-release"
+cat >"$doctor_config" <<'TOML'
+[data]
+enableEditorStack = false
+enableAiCliTools = false
+enableDevelopmentWorkspace = false
+TOML
+write_os_release "$doctor_os_release" ubuntu 24.04 "Ubuntu 24.04 LTS"
+
+doctor_ok_path="$(status_doctor_path doctor-ok chezmoi git zsh mise apt)"
+write_stub "$doctor_ok_path/uname" 'printf "%s\n" "Linux"'
+
+if ! doctor_ok_output="$(
+  TERRAPOD_OS_RELEASE_FILE="$doctor_os_release" TERRAPOD_CHEZMOI_CONFIG="$doctor_config" PATH="$doctor_ok_path" \
+    /bin/sh "$terrapod" doctor
+)"; then
+  fail "Terrapod doctor succeeds when VPS prerequisites are present and optional stacks are disabled"
+fi
+
+assert_contains "$doctor_ok_output" "Terrapod doctor" "Terrapod doctor prints a command heading"
+assert_contains "$doctor_ok_output" "ok - Profile is supported: VPS Shell Profile" "Terrapod doctor validates supported Ubuntu profile"
+assert_contains "$doctor_ok_output" "ok - chezmoi is available" "Terrapod doctor validates chezmoi availability"
+assert_contains "$doctor_ok_output" "ok - apt is available" "Terrapod doctor validates Ubuntu Bootstrap Package Manager availability"
+assert_contains "$doctor_ok_output" "ok - Optional Editor Stack is disabled" "Terrapod doctor treats disabled Optional Editor Stack as valid"
+assert_contains "$doctor_ok_output" "ok - Optional AI Tool Stack is disabled" "Terrapod doctor treats disabled Optional AI Tool Stack as valid"
+assert_contains "$doctor_ok_output" "ok - Optional Development Workspace is disabled" "Terrapod doctor treats disabled Optional Development Workspace as valid"
+assert_contains "$doctor_ok_output" "Guidance: none" "Terrapod doctor prints no guidance when checks pass"
+
+doctor_missing_key_path="$(status_doctor_path doctor-missing-key git zsh mise apt)"
+write_stub "$doctor_missing_key_path/uname" 'printf "%s\n" "Linux"'
+
+if TERRAPOD_OS_RELEASE_FILE="$doctor_os_release" TERRAPOD_CHEZMOI_CONFIG="$doctor_config" PATH="$doctor_missing_key_path" \
+  /bin/sh "$terrapod" doctor >"$tmp_dir/doctor-missing-key.out" 2>"$tmp_dir/doctor-missing-key.err"; then
+  fail "Terrapod doctor fails when a required key tool is missing"
+fi
+
+doctor_missing_key_output="$(cat "$tmp_dir/doctor-missing-key.out")"
+
+assert_contains "$doctor_missing_key_output" "warn - chezmoi is missing" "Terrapod doctor warns when required chezmoi is missing"
+assert_contains "$doctor_missing_key_output" "Install or apply the configured Core Shell Stack so 'chezmoi' is available on PATH." "Terrapod doctor gives actionable guidance for missing key tools"
+
+doctor_missing_config="$tmp_dir/doctor-missing.toml"
+cat >"$doctor_missing_config" <<'TOML'
+[data]
+enableEditorStack = true
+enableAiCliTools = true
+enableDevelopmentWorkspace = true
+TOML
+
+doctor_missing_path="$(status_doctor_path doctor-missing chezmoi git zsh mise apt)"
+write_stub "$doctor_missing_path/uname" 'printf "%s\n" "Linux"'
+
+if TERRAPOD_OS_RELEASE_FILE="$doctor_os_release" TERRAPOD_CHEZMOI_CONFIG="$doctor_missing_config" PATH="$doctor_missing_path" \
+  /bin/sh "$terrapod" doctor >"$tmp_dir/doctor-missing.out" 2>"$tmp_dir/doctor-missing.err"; then
+  fail "Terrapod doctor fails when enabled optional stack tools are missing"
+fi
+
+doctor_missing_output="$(cat "$tmp_dir/doctor-missing.out")"
+
+assert_contains "$doctor_missing_output" "warn - Optional Editor Stack is enabled but missing tools: nvim" "Terrapod doctor warns about missing enabled editor tools"
+assert_contains "$doctor_missing_output" "warn - Optional AI Tool Stack is enabled but missing tools: gemini, claude, codex" "Terrapod doctor warns about missing enabled AI tools"
+assert_contains "$doctor_missing_output" "warn - Optional Development Workspace is enabled but missing tools: zellij" "Terrapod doctor warns about missing enabled workspace tools"
+assert_contains "$doctor_missing_output" "Run terrapod chezmoi -- apply after enabling Optional AI Tool Stack, or install/apply the configured tools before relying on them." "Terrapod doctor gives actionable missing optional-stack guidance"
+
+doctor_unsupported_os_release="$tmp_dir/doctor-unsupported-os-release"
+write_os_release "$doctor_unsupported_os_release" debian 12 "Debian GNU/Linux 12"
+
+doctor_unsupported_path="$(status_doctor_path doctor-unsupported chezmoi git zsh mise apt)"
+write_stub "$doctor_unsupported_path/uname" 'printf "%s\n" "Linux"'
+
+if TERRAPOD_OS_RELEASE_FILE="$doctor_unsupported_os_release" TERRAPOD_CHEZMOI_CONFIG="$doctor_config" PATH="$doctor_unsupported_path" \
+  /bin/sh "$terrapod" doctor >"$tmp_dir/doctor-unsupported.out" 2>"$tmp_dir/doctor-unsupported.err"; then
+  fail "Terrapod doctor fails on unsupported Linux"
+fi
+
+doctor_unsupported_output="$(cat "$tmp_dir/doctor-unsupported.out")"
+assert_contains "$doctor_unsupported_output" "warn - unsupported Linux release: Debian GNU/Linux 12. Terrapod supports Ubuntu 24.04 for the VPS Shell Profile." "Terrapod doctor explains unsupported Linux"
+
+doctor_broad_upgrade_calls="$tmp_dir/doctor-broad-upgrade.calls"
+rm -f "$doctor_broad_upgrade_calls"
+doctor_broad_upgrade_path="$(status_doctor_path doctor-broad-upgrade chezmoi git zsh nvim gemini claude codex zellij)"
+for command_name in brew apt sudo mise npm; do
+  write_failing_command_stub "$doctor_broad_upgrade_path/$command_name" "$doctor_broad_upgrade_calls"
+done
+write_stub "$doctor_broad_upgrade_path/uname" 'printf "%s\n" "Darwin"'
+
+if TERRAPOD_PROFILE=macos-terminal TERRAPOD_CHEZMOI_CONFIG="$doctor_config" PATH="$doctor_broad_upgrade_path" \
+  /bin/sh "$terrapod" status >/dev/null 2>/dev/null; then
+  :
+fi
+
+if TERRAPOD_PROFILE=macos-terminal TERRAPOD_CHEZMOI_CONFIG="$doctor_config" PATH="$doctor_broad_upgrade_path" \
+  /bin/sh "$terrapod" doctor >/dev/null 2>/dev/null; then
+  :
+fi
+
+if [ -e "$doctor_broad_upgrade_calls" ]; then
+  printf '%s\n' "unexpected broad upgrade command calls from status/doctor:" >&2
+  sed 's/^/  /' "$doctor_broad_upgrade_calls" >&2
+  fail "Terrapod status and doctor do not call brew, apt, sudo, mise, or npm upgrade flows"
+fi
+
+pass "Terrapod status and doctor do not call brew, apt, sudo, mise, or npm upgrade flows"
 
 export CHEZMOI_CALL_FILE="$tmp_dir/chezmoi-update.args"
 export CHEZMOI_INVOKED_FILE="$tmp_dir/chezmoi-update.invoked"


### PR DESCRIPTION
## Summary

- Add `terrapod status` for profile, config, effective optional stack, macOS App Group, key-tool, and warning reporting.
- Add `terrapod doctor` prerequisite checks with actionable guidance and no broad upgrade command execution.
- Cover macOS, Ubuntu 24.04, unsupported Linux, enabled/disabled optional stacks, missing tools, root dotted config keys, and broad-upgrade non-invocation with shell tests.

## Validation

- `sh tests/terrapod_command_test.sh`
- `for test_script in tests/*.sh; do [ -f "$test_script" ] || continue; sh "$test_script"; done; for test_script in tests/*.zsh; do [ -f "$test_script" ] || continue; zsh "$test_script"; done`
- `git diff --check`
- Codex review against `origin/main`: no findings

Closes #36