### PR TITLE
Align Terrapod README verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotfiles
 
-Personal dotfiles managed with chezmoi.
+Personal dotfiles managed with Terrapod, a chezmoi-backed dotfiles management tool.
 
 ## Setup
 
@@ -8,6 +8,10 @@ The Terrapod first-run installer is the primary entry point for a new machine.
 It installs `chezmoi` into `~/.local/bin`, asks for a Preset, writes
 Terrapod-managed config values, initializes
 `https://github.com/juty9026/dotfiles.git`, and runs the initial apply.
+
+You do not need to install `chezmoi` manually before running this installer.
+The installer installs its own user-local `chezmoi` binary when needed, then
+uses Terrapod to configure the machine before the first apply.
 
 ### macOS
 
@@ -40,12 +44,6 @@ installs that rendered bundle:
 - `monitoring`: iStat Menus.
 
 Machine-specific Homebrew packages should live outside the tracked `Brewfile`.
-
-To edit an existing checkout, move to the chezmoi source directory.
-
-```sh
-chezmoi cd
-```
 
 ### Ubuntu 24.04 VPS
 
@@ -83,16 +81,42 @@ first apply and reconnect.
 chsh -s "$(command -v zsh)"
 ```
 
-Direct `chezmoi` commands are mainly for maintenance after bootstrap, such as
-reviewing changes with `chezmoi diff`, applying later changes with
-`chezmoi apply`, or using `chezmoi cd` to edit the source checkout. For an
-unusual recovery path, install `chezmoi` manually and initialize
+Terrapod handles normal management after bootstrap. For an unusual recovery
+path, install `chezmoi` manually and initialize
 `https://github.com/juty9026/dotfiles.git` directly, then review and apply the
 result.
 
+## Management
+
+Use `terrapod` as the primary management command after bootstrap.
+`tpod` is the short alias for the same command.
+
+```sh
+terrapod status
+terrapod doctor
+terrapod diff
+terrapod apply
+terrapod update
+tpod status
+```
+
+`terrapod update` refreshes this dotfiles source and delegates to `chezmoi update --exclude scripts`.
+It does not update OS packages or mise-managed tools.
+
+Direct chezmoi use remains an advanced escape hatch.
+
+```sh
+terrapod chezmoi -- cd
+terrapod chezmoi -- status
+```
+
 ## Updates
 
-Update OS-managed packages with the OS package manager.
+Terrapod does not run broad Bootstrap Package Manager or Modern CLI Provider upgrades.
+Homebrew and APT are Bootstrap Package Managers here: they prepare a machine for the declared shell state.
+mise is the Modern CLI Provider for shared command-line tools and development runtimes.
+
+Use OS package managers directly only when intentionally updating OS-managed packages.
 
 ```sh
 # macOS
@@ -104,7 +128,7 @@ sudo apt update
 sudo apt upgrade
 ```
 
-Update modern CLI tools and development runtimes with mise.
+Use mise directly when intentionally updating modern CLI tools or development runtimes.
 
 ```sh
 mise outdated
@@ -206,7 +230,7 @@ gitAllowedSigners = [
 Then apply the dotfiles.
 
 ```sh
-chezmoi apply
+terrapod apply
 ```
 
 ## Conventions

--- a/tests/readme_optional_stack_profiles_test.sh
+++ b/tests/readme_optional_stack_profiles_test.sh
@@ -136,6 +136,18 @@ assert_contains 'separate from `enableDevelopmentWorkspace`' \
   "README documents macOS Desktop App Stack separation from enableDevelopmentWorkspace"
 assert_contains 'casks can affect shared applications' \
   "README documents why macOS Desktop App Stack remains separate"
+assert_contains '`terrapod update` refreshes this dotfiles source and delegates to `chezmoi update --exclude scripts`.' \
+  "README documents Terrapod update as dotfiles-source maintenance"
+assert_contains 'Terrapod does not run broad Bootstrap Package Manager or Modern CLI Provider upgrades.' \
+  "README states Terrapod does not run broad package or tool upgrades"
+assert_contains 'Homebrew and APT are Bootstrap Package Managers here: they prepare a machine for the declared shell state.' \
+  "README preserves Bootstrap Package Manager boundary"
+assert_contains 'mise is the Modern CLI Provider for shared command-line tools and development runtimes.' \
+  "README preserves Modern CLI Provider boundary"
+assert_contains 'Use OS package managers directly only when intentionally updating OS-managed packages.' \
+  "README keeps OS package upgrades outside Terrapod"
+assert_contains 'Use mise directly when intentionally updating modern CLI tools or development runtimes.' \
+  "README keeps Modern CLI Provider upgrades outside Terrapod"
 assert_raycast_restore_contains '`enableMacosAppGroupLauncher`' \
   "README Raycast restore procedure mentions launcher App Group"
 assert_contains 'Opting out of an optional stack excludes its files from chezmoi management; it does not remove files already present on a machine.' \

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -972,6 +972,14 @@ assert_contains \
   "stub diff output" \
   "Terrapod diff includes delegated chezmoi diff output"
 
+if [ -e "$BROAD_UPGRADE_CALL_FILE" ]; then
+  printf '%s\n' "unexpected broad upgrade command calls during diff:" >&2
+  sed 's/^/  /' "$BROAD_UPGRADE_CALL_FILE" >&2
+  fail "Terrapod diff does not call brew, apt, sudo, mise, or npm upgrade flows"
+fi
+
+pass "Terrapod diff does not call brew, apt, sudo, mise, or npm upgrade flows"
+
 rm -f "$CHEZMOI_CALL_FILE" "$CHEZMOI_INVOKED_FILE"
 
 if HOME="$diff_home" XDG_CONFIG_HOME="$diff_xdg" TERRAPOD_CHEZMOI_CONFIG="$diff_config" PATH="$tmp_dir/bin:/usr/bin:/bin" \
@@ -1052,6 +1060,7 @@ write_stub "$tmp_dir/bin/chezmoi" \
   'exit 91'
 
 rm -f "$CHEZMOI_APPLY_ARGS_FILE" "$CHEZMOI_APPLY_INVOKED_FILE" "$CHEZMOI_MANAGED_ARGS_FILE"
+rm -f "$BROAD_UPGRADE_CALL_FILE"
 
 if ! HOME="$diff_home" XDG_CONFIG_HOME="$diff_xdg" PATH="$tmp_dir/bin:/usr/bin:/bin" \
   sh "$terrapod" apply >"$tmp_dir/apply.out" 2>"$tmp_dir/apply.err"; then
@@ -1158,6 +1167,14 @@ assert_contains \
   "$apply_output" \
   "Post-apply validation: tpod alias is managed" \
   "Terrapod apply validates the tpod alias managed target"
+
+if [ -e "$BROAD_UPGRADE_CALL_FILE" ]; then
+  printf '%s\n' "unexpected broad upgrade command calls during apply:" >&2
+  sed 's/^/  /' "$BROAD_UPGRADE_CALL_FILE" >&2
+  fail "Terrapod apply does not call brew, apt, sudo, mise, or npm upgrade flows"
+fi
+
+pass "Terrapod apply does not call brew, apt, sudo, mise, or npm upgrade flows"
 
 rm -f "$CHEZMOI_APPLY_ARGS_FILE" "$CHEZMOI_APPLY_INVOKED_FILE" "$CHEZMOI_MANAGED_ARGS_FILE"
 

--- a/tests/terrapod_installer_test.sh
+++ b/tests/terrapod_installer_test.sh
@@ -37,6 +37,18 @@ assert_contains() {
   pass "$message"
 }
 
+assert_not_contains() {
+  haystack="$1"
+  needle="$2"
+  message="$3"
+
+  if printf '%s\n' "$haystack" | grep -F -e "$needle" >/dev/null; then
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
 assert_line() {
   haystack="$1"
   expected_line="$2"
@@ -114,6 +126,14 @@ readme_text="$(cat "$readme_file")"
 assert_contains "$readme_text" "Terrapod first-run installer" "README documents the Terrapod first-run installer"
 assert_contains "$readme_text" 'sh -c "$(curl -fsLS https://raw.githubusercontent.com/juty9026/dotfiles/main/install.sh)"' "README documents the full installer command"
 assert_contains "$readme_text" "https://github.com/juty9026/dotfiles.git" "README documents the HTTPS source repository"
+assert_contains "$readme_text" "You do not need to install \`chezmoi\` manually before running this installer." "README states chezmoi is not a first-run prerequisite"
+assert_contains "$readme_text" "Use \`terrapod\` as the primary management command after bootstrap." "README documents Terrapod as the primary management command"
+assert_contains "$readme_text" "\`tpod\` is the short alias for the same command." "README documents tpod as the short Terrapod alias"
+assert_contains "$readme_text" "terrapod chezmoi -- status" "README documents raw chezmoi access through Terrapod"
+assert_contains "$readme_text" "Direct chezmoi use remains an advanced escape hatch." "README keeps direct chezmoi as an advanced escape hatch"
+assert_not_contains "$readme_text" "--non-interactive" "README keeps non-interactive installer options out of scope"
+assert_not_contains "$readme_text" "repository rename" "README keeps repository renaming out of scope"
+assert_not_contains "$readme_text" "log-output" "README keeps broader log-output design out of scope"
 
 chezmoiignore_file="$repo_root/.chezmoiignore"
 if [ ! -f "$chezmoiignore_file" ]; then


### PR DESCRIPTION
## Summary

Closes #39.

- Document Terrapod as the first-run entry point and primary post-bootstrap management command, with `tpod` as the short alias.
- Keep direct `chezmoi` usage as an advanced escape hatch and clarify that Terrapod update does not own OS package or mise-managed tool upgrades.
- Extend existing shell tests for README contracts and maintenance wrappers, including broad-upgrade guards for `terrapod diff` and `terrapod apply`.

## Validation

- `sh tests/terrapod_installer_test.sh`
- `sh tests/readme_optional_stack_profiles_test.sh`
- `sh tests/terrapod_command_test.sh`
- `for test_file in tests/*.sh tests/*.zsh; do case "$test_file" in tests/*.sh) sh "$test_file" ;; tests/*.zsh) zsh "$test_file" ;; esac; done`
- Final review against `origin/main`: no findings, Ready for Review.