### PR TITLE
Polish Terrapod README and command output

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -122,6 +122,8 @@ _Avoid_: machine preset, permanent mode, dynamic policy
 - **Terrapod** applies this repository's declared dotfiles state; it does not act as the package manager for OS packages or mise-managed tool upgrades.
 - **Terrapod** may install declared dependencies needed to reach the target state, but it does not run broad version upgrade commands such as `brew upgrade`, `apt upgrade`, or `mise upgrade`.
 - `terrapod update` delegates repository update semantics to `chezmoi update` and adds Terrapod-specific context and validation around it.
+- README and command output describe `terrapod update` as a source update so it is not confused with Homebrew, APT, or mise upgrades.
+- README and command output describe `terrapod diff` and `terrapod apply` as declared-state operations delegated to chezmoi.
 - The **macOS Desktop App Stack** is opt-in because Homebrew casks can install shared applications and desktop support assets outside a single user's home directory.
 - The **macOS Desktop App Stack** excludes Homebrew itself, shared CLI formulae such as mise and btop, and terminal font casks.
 - Terminal font casks belong to the macOS Terminal Profile core bootstrap because the managed terminal configuration depends on them and they are not desktop applications.
@@ -135,7 +137,22 @@ _Avoid_: machine preset, permanent mode, dynamic policy
 - Individual macOS app toggles are excluded from the current **Terrapod** setup scope.
 - Repository renaming makes `juty9026/terrapod` the canonical slug for the **Terrapod Source Repository** without adding legacy URL fallback behavior.
 - Non-interactive setup options are deferred outside the current **Terrapod** installer and management command work.
-- README and command output should use the **Terrapod** name where needed for consistency; broader branding and log-output design are deferred.
+- README presentation should make **Terrapod** feel like a small product with a clear identity and a quick-start guide, not primarily like an operations manual.
+- README still pairs the evocative **Terrapod** product promise with visible chezmoi and package-manager boundaries.
+- README treats chezmoi as visible underlying machinery, not as the main story or default workflow.
+- README should lead with a lightweight quick start that shows the first-run installer and a few normal management commands before platform details.
+- README should show Terrapod's non-goals near the top as product boundaries, especially broad OS package upgrades, mise-managed upgrades, machine-local secrets, and untracked overrides.
+- README should summarize what **Terrapod** carries near the top using domain concepts: machine profiles, **Preset** choices, optional stacks, and **macOS App Groups**.
+- README should move deeper platform, Preset, optional stack, app-group, and update-boundary details below the product introduction and quick start.
+- README section naming should support the product-first quick-start shape, using names such as Quick Start, What Terrapod Carries, Choose a Preset, What Terrapod Leaves Alone, Daily Commands, Platform Details, Local Overrides, Manual Restore, and Repository Conventions.
+- README section titles and command examples use canonical domain terms such as **Preset**, while product metaphor stays in supporting explanatory copy.
+- README should explain **Preset** choices by the kind of machine they suit before listing the concrete optional stack and app-group settings they expand into.
+- `terrapod help` may carry a concise product introduction, but routine command output stays operational and scan-friendly.
+- `terrapod help` introduces **Terrapod** as a small landing pod for dotfiles and immediately states that chezmoi remains underneath while package-manager upgrades stay outside scope.
+- Routine command output uses stable labels such as Profile, Config, Preflight, Delegating, Post-apply validation, and Guidance instead of brand metaphors.
+- Routine command stage labels may be lightly polished when the result stays concise, stable, and clear in copied logs.
+- The current command-output pass stays simple and does not add emoji or terminal color behavior.
+- Error output avoids product metaphor and states the failed condition plus the next useful action.
 
 ## Example Dialogue
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,91 @@
 # Terrapod
 
-Personal dotfiles managed with Terrapod, a chezmoi-backed dotfiles management tool.
+Terrapod is a small landing pod for your machines: it brings your familiar
+shell, editor, runtime, and desktop habits to a fresh Mac or Ubuntu 24.04 VPS.
 
-## Setup
+Under the hood, Terrapod uses chezmoi as the apply engine and keeps package-manager upgrades outside its scope.
 
-The Terrapod first-run installer is the primary entry point for a new machine.
-It installs `chezmoi` into `~/.local/bin`, asks for a Preset, writes
-Terrapod-managed config values, initializes
-`https://github.com/juty9026/terrapod.git`, and runs the initial apply.
+## Quick Start
+
+Run the Terrapod first-run installer on a supported machine.
+
+```sh
+sh -c "$(curl -fsLS https://raw.githubusercontent.com/juty9026/terrapod/main/install.sh)"
+```
+
+The installer installs `chezmoi` into `~/.local/bin` when needed, asks for a
+Preset, writes Terrapod-managed machine-local config values, initializes
+`https://github.com/juty9026/terrapod.git`, and runs the initial
+declared-state apply.
 
 You do not need to install `chezmoi` manually before running this installer.
-The installer installs its own user-local `chezmoi` binary when needed, then
-uses Terrapod to configure the machine before the first apply.
+
+After bootstrap, use Terrapod for normal checks and source updates.
+
+```sh
+terrapod status
+terrapod doctor
+terrapod update
+```
+
+## What Terrapod Carries
+
+- Machine profiles for a macOS terminal workstation and an Ubuntu 24.04 VPS.
+- Presets that unfold into concrete machine-local settings.
+- Optional stacks for rich editor configuration, AI CLI tools, and development workspace surfaces.
+- macOS App Groups for selected desktop tools.
+
+## Choose a Preset
+
+A Preset is the shape Terrapod unfolds on a machine during first-run setup.
+
+| Preset | Best for | Shape |
+| --- | --- | --- |
+| `minimal` | Small VPSs, clean shells, and recovery installs | Core shell and runtime baseline only |
+| `development` | Machines used for active coding | Optional Editor Stack, Optional AI Tool Stack, and Optional Development Workspace |
+| `workstation` | Personal macOS workstations | Development setup plus every macOS App Group |
+
+Presets write concrete machine-local settings. They are not a permanent mode,
+so future Preset changes do not silently reshape an already configured machine.
+
+The `workstation` Preset is available only for the macOS Terminal Profile.
+
+## What Terrapod Leaves Alone
+
+Terrapod applies this repository's declared dotfiles state. It does not own the whole operating system.
+
+- Broad Homebrew or APT upgrades
+- mise-managed tool and runtime upgrades
+- Machine-local secrets
+- Untracked personal overrides
+
+Terrapod does not run broad Homebrew, APT, or mise upgrades.
+
+## Daily Commands
+
+Use `terrapod` as the primary management command after bootstrap.
+`tpod` is the short alias for the same command.
+
+```sh
+terrapod status
+terrapod doctor
+terrapod diff
+terrapod apply
+terrapod update
+tpod status
+```
+
+`terrapod update` refreshes the Terrapod Source Repository through `chezmoi update --exclude scripts`.
+It does not run Homebrew, APT, or mise upgrades.
+
+Direct chezmoi use remains an advanced escape hatch.
+
+```sh
+terrapod chezmoi -- cd
+terrapod chezmoi -- status
+```
+
+## Platform Details
 
 ### macOS
 
@@ -21,8 +95,7 @@ Run the installer on macOS.
 sh -c "$(curl -fsLS https://raw.githubusercontent.com/juty9026/terrapod/main/install.sh)"
 ```
 
-On macOS, the initial apply also runs setup scripts under `.chezmoiscripts` for
-the initial terminal environment:
+On macOS, the initial apply also runs setup scripts under `.chezmoiscripts` for the initial terminal environment:
 
 - Homebrew bootstrap and the macOS `Brewfile` bundle
 - mise
@@ -74,8 +147,7 @@ Only configure GitHub authentication on a VPS if write access is needed later.
 If the first mise install hits GitHub API rate limits while resolving aqua
 tools, export a temporary `GITHUB_TOKEN` and rerun `chezmoi apply`.
 
-If the login shell could not be changed automatically, switch it after the
-first apply and reconnect.
+If the login shell could not be changed automatically, switch it after the first apply and reconnect.
 
 ```sh
 chsh -s "$(command -v zsh)"
@@ -86,33 +158,8 @@ path, install `chezmoi` manually and initialize
 `https://github.com/juty9026/terrapod.git` directly, then review and apply the
 result.
 
-## Management
+### Intentional Upgrades
 
-Use `terrapod` as the primary management command after bootstrap.
-`tpod` is the short alias for the same command.
-
-```sh
-terrapod status
-terrapod doctor
-terrapod diff
-terrapod apply
-terrapod update
-tpod status
-```
-
-`terrapod update` refreshes this dotfiles source and delegates to `chezmoi update --exclude scripts`.
-It does not update OS packages or mise-managed tools.
-
-Direct chezmoi use remains an advanced escape hatch.
-
-```sh
-terrapod chezmoi -- cd
-terrapod chezmoi -- status
-```
-
-## Updates
-
-Terrapod does not run broad Bootstrap Package Manager or Modern CLI Provider upgrades.
 Homebrew and APT are Bootstrap Package Managers here: they prepare a machine for the declared shell state.
 mise is the Modern CLI Provider for shared command-line tools and development runtimes.
 
@@ -143,7 +190,7 @@ mise outdated --bump
 mise upgrade --bump
 ```
 
-## Manual restore
+## Manual Restore
 
 ### Raycast
 
@@ -156,13 +203,12 @@ repo.
 3. Download the latest `.rayconfig` file.
 4. Run `Import Settings & Data` in Raycast.
 5. Enter the Raycast export passphrase from the same 1Password item.
-6. Select the categories to import, usually Store extensions, settings,
-   aliases, hotkeys, quicklinks, and snippets.
+6. Select the categories to import, usually Store extensions, settings, aliases, hotkeys, quicklinks, and snippets.
 
 When Raycast changes need to be shared across workstations, export a fresh
 `.rayconfig` from the primary workstation and update the 1Password item.
 
-## Local overrides
+## Local Overrides
 
 Machine-local options are configured outside this repo with
 `chezmoi edit-config`. Keep only the option names, defaults, and examples here;
@@ -181,9 +227,11 @@ Optional stack profiles and macOS App Group settings are disabled by default.
 | `enableMacosAppGroupMonitoring` | `false` | Installs the monitoring macOS App Group: iStat Menus. |
 | `gitAllowedSigners` | `[]` | Adds workstation-specific SSH signing identities to `~/.ssh/allowed_signers`. |
 
-When `enableDevelopmentWorkspace` is `true`, it enables both the Optional Editor Stack and Optional AI Tool Stack even if `enableEditorStack` or `enableAiCliTools` are false or omitted.
+When `enableDevelopmentWorkspace` is `true`, it enables both the Optional Editor Stack and Optional AI Tool Stack
+even if `enableEditorStack` or `enableAiCliTools` are false or omitted.
 
-macOS Desktop App Stack installation remains separate from `enableDevelopmentWorkspace` because desktop casks can affect shared applications outside one user's home directory.
+macOS Desktop App Stack installation remains separate from `enableDevelopmentWorkspace`
+because desktop casks can affect shared applications outside one user's home directory.
 
 Opting out of an optional stack excludes its files from chezmoi management; it does not remove files already present on a machine.
 
@@ -233,7 +281,7 @@ Then apply the dotfiles.
 terrapod apply
 ```
 
-## Conventions
+## Repository Conventions
 
 - `dot_`: dotfiles in the home directory
 - `private_`: files that need private permissions

--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -5,7 +5,8 @@ show_help() {
   preset_args="$(available_preset_args "$(current_profile)")"
 
   cat <<EOF
-Terrapod - Dotfiles Management Tool
+Terrapod - a small landing pod for your dotfiles
+Uses chezmoi underneath; keeps package-manager upgrades outside its scope.
 
 Usage:
   terrapod [help|--help|-h]
@@ -594,7 +595,7 @@ show_diff_context() {
   printf '%s\n' "Profile: $(profile_context_label)"
   show_config_context "$config_file"
   show_stack_context "$config_file"
-  printf '%s\n' "Delegating target-state diff to: $(render_chezmoi_command diff)"
+  printf '%s\n' "Delegating declared-state diff to: $(render_chezmoi_command diff)"
 }
 
 run_diff() {
@@ -673,7 +674,7 @@ show_apply_context() {
   printf '%s\n' "Profile: $(profile_context_label)"
   show_config_context "$config_file"
   show_stack_context "$config_file"
-  printf '%s\n' "Delegating target-state apply to: $(render_chezmoi_command apply)"
+  printf '%s\n' "Delegating declared-state apply to: $(render_chezmoi_command apply)"
 }
 
 run_apply() {
@@ -822,7 +823,7 @@ show_update_context() {
   printf '%s\n' "Terrapod update"
   printf '%s\n' "Profile: $(profile_context_label)"
   show_config_context "$config_file"
-  printf '%s\n' "Delegating repository update to: $(render_chezmoi_command update --exclude scripts)"
+  printf '%s\n' "Delegating source update to: $(render_chezmoi_command update --exclude scripts)"
 }
 
 run_update() {

--- a/tests/readme_optional_stack_profiles_test.sh
+++ b/tests/readme_optional_stack_profiles_test.sh
@@ -53,7 +53,7 @@ assert_ubuntu_setup_contains() {
 
   if ! awk '
     /^### Ubuntu 24.04 VPS$/ { in_ubuntu = 1; next }
-    /^## Updates$/ { in_ubuntu = 0 }
+    /^### Intentional Upgrades$/ { in_ubuntu = 0 }
     in_ubuntu { print }
   ' "$readme" | grep -F "$needle" >/dev/null; then
     fail "$message"
@@ -68,7 +68,7 @@ assert_raycast_restore_contains() {
 
   if ! awk '
     /^### Raycast$/ { in_raycast = 1; next }
-    /^## Local overrides$/ { in_raycast = 0 }
+    /^## Local Overrides$/ { in_raycast = 0 }
     in_raycast { print }
   ' "$readme" | grep -F "$needle" >/dev/null; then
     fail "$message"
@@ -124,6 +124,22 @@ assert_key_row_contains '`enableMacosAppGroupMonitoring`' 'iStat Menus' \
 
 assert_contains 'Optional stack profiles and macOS App Group settings are disabled by default.' \
   "README states optional stack profiles and App Groups are disabled by default"
+assert_contains 'Terrapod is a small landing pod for your machines' \
+  "README opens with the Terrapod product promise"
+assert_contains 'Under the hood, Terrapod uses chezmoi as the apply engine' \
+  "README keeps chezmoi visible as underlying machinery"
+assert_contains '## Quick Start' \
+  "README leads with a Quick Start section"
+assert_contains '## What Terrapod Carries' \
+  "README summarizes Terrapod's carried domain concepts"
+assert_contains '## Choose a Preset' \
+  "README uses the canonical Preset section title"
+assert_contains '## What Terrapod Leaves Alone' \
+  "README documents product boundaries near the top"
+assert_contains '## Daily Commands' \
+  "README uses a product-friendly daily command section"
+assert_contains '## Platform Details' \
+  "README moves platform inventory into platform details"
 assert_ubuntu_setup_contains 'GitHub CLI (`gh`)' \
   "README documents gh as part of the Ubuntu Core Shell Stack"
 assert_contains 'When `enableDevelopmentWorkspace` is `true`' \
@@ -136,9 +152,9 @@ assert_contains 'separate from `enableDevelopmentWorkspace`' \
   "README documents macOS Desktop App Stack separation from enableDevelopmentWorkspace"
 assert_contains 'casks can affect shared applications' \
   "README documents why macOS Desktop App Stack remains separate"
-assert_contains '`terrapod update` refreshes this dotfiles source and delegates to `chezmoi update --exclude scripts`.' \
-  "README documents Terrapod update as dotfiles-source maintenance"
-assert_contains 'Terrapod does not run broad Bootstrap Package Manager or Modern CLI Provider upgrades.' \
+assert_contains '`terrapod update` refreshes the Terrapod Source Repository through `chezmoi update --exclude scripts`.' \
+  "README documents Terrapod update as source maintenance"
+assert_contains 'Terrapod does not run broad Homebrew, APT, or mise upgrades.' \
   "README states Terrapod does not run broad package or tool upgrades"
 assert_contains 'Homebrew and APT are Bootstrap Package Managers here: they prepare a machine for the declared shell state.' \
   "README preserves Bootstrap Package Manager boundary"

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -253,8 +253,13 @@ pass "tpod shows the same help as Terrapod"
 
 assert_contains \
   "$help_output" \
-  "Terrapod - Dotfiles Management Tool" \
-  "Terrapod help names the Dotfiles Management Tool"
+  "Terrapod - a small landing pod for your dotfiles" \
+  "Terrapod help introduces the landing pod product promise"
+
+assert_contains \
+  "$help_output" \
+  "Uses chezmoi underneath; keeps package-manager upgrades outside its scope." \
+  "Terrapod help states chezmoi and package-manager boundaries"
 
 assert_contains \
   "$help_output" \
@@ -340,14 +345,14 @@ default_output="$(sh "$terrapod")"
 
 assert_contains \
   "$default_output" \
-  "Terrapod - Dotfiles Management Tool" \
+  "Terrapod - a small landing pod for your dotfiles" \
   "Terrapod with no arguments shows help"
 
 dash_help_output="$(sh "$terrapod" --help)"
 
 assert_contains \
   "$dash_help_output" \
-  "Terrapod - Dotfiles Management Tool" \
+  "Terrapod - a small landing pod for your dotfiles" \
   "Terrapod --help shows help"
 
 if sh "$terrapod" frobnicate >"$tmp_dir/unknown.out" 2>"$tmp_dir/unknown.err"; then
@@ -750,7 +755,7 @@ update_output="$(cat "$tmp_dir/update.out")"
 
 assert_call_args \
   "$CHEZMOI_CALL_FILE" \
-  "Terrapod update delegates repository update semantics to chezmoi update" \
+  "Terrapod update delegates source update semantics to chezmoi update" \
   update --exclude scripts
 
 assert_contains \
@@ -770,7 +775,7 @@ assert_contains \
 
 assert_contains \
   "$update_output" \
-  "Delegating repository update to: chezmoi update --exclude scripts" \
+  "Delegating source update to: chezmoi update --exclude scripts" \
   "Terrapod update explains the delegated command"
 
 if [ -e "$BROAD_UPGRADE_CALL_FILE" ]; then
@@ -816,7 +821,7 @@ assert_contains \
 
 assert_contains \
   "$override_update_output" \
-  "Delegating repository update to: chezmoi --config $override_config update --exclude scripts" \
+  "Delegating source update to: chezmoi --config $override_config update --exclude scripts" \
   "Terrapod update explains delegated explicit config command"
 
 if [ -e "$BROAD_UPGRADE_CALL_FILE" ]; then
@@ -899,7 +904,7 @@ diff_output="$(cat "$tmp_dir/diff.out")"
 
 assert_call_args \
   "$CHEZMOI_CALL_FILE" \
-  "Terrapod diff delegates target-state diff behavior to chezmoi diff" \
+  "Terrapod diff delegates declared-state diff behavior to chezmoi diff" \
   diff
 
 assert_contains \
@@ -964,7 +969,7 @@ assert_contains \
 
 assert_contains \
   "$diff_output" \
-  "Delegating target-state diff to: chezmoi diff" \
+  "Delegating declared-state diff to: chezmoi diff" \
   "Terrapod diff explains the delegated command"
 
 assert_contains \
@@ -1020,7 +1025,7 @@ assert_call_args \
 
 assert_contains \
   "$diff_override_output" \
-  "Delegating target-state diff to: chezmoi --config $diff_config diff" \
+  "Delegating declared-state diff to: chezmoi --config $diff_config diff" \
   "Terrapod diff explains delegated explicit config command"
 
 export CHEZMOI_APPLY_ARGS_FILE="$tmp_dir/chezmoi-apply.args"
@@ -1075,7 +1080,7 @@ apply_output="$(cat "$tmp_dir/apply.out")"
 
 assert_call_args \
   "$CHEZMOI_APPLY_ARGS_FILE" \
-  "Terrapod apply delegates target-state apply behavior to chezmoi apply" \
+  "Terrapod apply delegates declared-state apply behavior to chezmoi apply" \
   apply
 
 assert_call_args \
@@ -1150,7 +1155,7 @@ assert_contains \
 
 assert_contains \
   "$apply_output" \
-  "Delegating target-state apply to: chezmoi apply" \
+  "Delegating declared-state apply to: chezmoi apply" \
   "Terrapod apply explains the delegated command"
 
 assert_contains \
@@ -1221,7 +1226,7 @@ assert_call_args \
 
 assert_contains \
   "$apply_override_output" \
-  "Delegating target-state apply to: chezmoi --config $diff_config apply" \
+  "Delegating declared-state apply to: chezmoi --config $diff_config apply" \
   "Terrapod apply explains delegated explicit config command"
 
 symlink_config_target="$tmp_dir/symlink-target-chezmoi.toml"


### PR DESCRIPTION
## What changed

- Reworked the README into a product-first quick-start flow for Terrapod.
- Added explicit product boundaries for chezmoi, Homebrew/APT, mise, secrets, and local overrides.
- Updated `terrapod help` with the small landing pod product promise and package-manager boundary.
- Polished command-output stage labels from target/repository wording to declared-state and source-update wording.
- Captured the resolved README and output language decisions in `CONTEXT.md`.

## Why

Issue #41 called for the deferred README and command-output design pass: Terrapod should feel more like a small product without obscuring chezmoi or package-manager boundaries.

## Impact

Users get a clearer first impression, a faster setup path, and less ambiguity around what `terrapod update`, `terrapod diff`, and `terrapod apply` actually do. Routine command output stays plain and scan-friendly, with no color or emoji behavior added.

## Validation

```sh
set -e
for test_file in tests/*_test.sh; do
  sh "$test_file"
done
zsh tests/zshrc_zoxide_test.zsh
```

Closes #41