### PR TITLE
Add Korean README

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -1,4 +1,5 @@
 README.md
+README.ko.md
 Brewfile
 Brewfile.macos-desktop-apps
 AGENTS.md

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -72,6 +72,14 @@ _Avoid_: separate tool, primary brand name
 A first-run setup choice that expands into concrete optional stack and app-group settings for a machine.
 _Avoid_: machine preset, permanent mode, dynamic policy
 
+**Canonical README**:
+The English `README.md` that defines the authoritative Terrapod README content.
+_Avoid_: primary docs, source README
+
+**Korean README**:
+The Korean-language README that follows the **Canonical README** for Korean readers.
+_Avoid_: separate Korean introduction, independent README, self-labeled translation
+
 ## Relationships
 
 - The **Dotfiles Management Tool** is the user-facing entry point for first install, configuration changes, and routine dotfiles maintenance.
@@ -147,6 +155,16 @@ _Avoid_: machine preset, permanent mode, dynamic policy
 - README section naming should support the product-first quick-start shape, using names such as Quick Start, What Terrapod Carries, Choose a Preset, What Terrapod Leaves Alone, Daily Commands, Platform Details, Local Overrides, Manual Restore, and Repository Conventions.
 - README section titles and command examples use canonical domain terms such as **Preset**, while product metaphor stays in supporting explanatory copy.
 - README should explain **Preset** choices by the kind of machine they suit before listing the concrete optional stack and app-group settings they expand into.
+- The **Canonical README** is the source of truth for README content.
+- The **Korean README** follows the **Canonical README**, but it does not need to label itself as a translation.
+- The **Korean README** lives at `README.ko.md`.
+- The **Korean README** keeps canonical domain terms such as **Terrapod**, **Preset**, optional stack names, and **macOS App Group** in English while explaining them in natural Korean.
+- The **Korean README** keeps section headings in English to mirror the **Canonical README** heading structure directly.
+- The **Korean README** translates body copy, table headers, and list explanations into natural Korean while preserving command names, config keys, file names, literal values, and canonical domain terms in English.
+- The **Canonical README** and **Korean README** use a compact globe-marked language switcher directly below the `# Terrapod` heading, with the current language bolded and the other README linked.
+- Changes to the **Canonical README** should make heading-structure drift in the **Korean README** visible during maintenance.
+- README drift checks compare corresponding section headings only; they do not enforce paragraph, table, or code block parity.
+- README drift checks compare all Markdown heading lines from `README.md` and `README.ko.md` for exact text and order.
 - `terrapod help` may carry a concise product introduction, but routine command output stays operational and scan-friendly.
 - `terrapod help` introduces **Terrapod** as a small landing pod for dotfiles and immediately states that chezmoi remains underneath while package-manager upgrades stay outside scope.
 - Routine command output uses stable labels such as Profile, Config, Preflight, Delegating, Post-apply validation, and Guidance instead of brand metaphors.

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,267 @@
+# Terrapod
+
+🌐 언어: [English](README.md) | **한국어**
+
+Terrapod은 익숙한 shell, editor, runtime, desktop 습관을 새 Mac이나 Ubuntu 24.04 VPS로 가져오는 작은 landing pod입니다.
+
+내부적으로 Terrapod은 chezmoi를 apply engine으로 사용하며, package-manager upgrade는 범위 밖에 둡니다.
+
+## Quick Start
+
+지원되는 machine에서 Terrapod first-run installer를 실행합니다.
+
+```sh
+sh -c "$(curl -fsLS https://raw.githubusercontent.com/juty9026/terrapod/main/install.sh)"
+```
+
+installer는 필요할 때 `chezmoi`를 `~/.local/bin`에 설치하고, Preset을 물어본 뒤, Terrapod이 관리하는 machine-local config 값을 쓰고, `https://github.com/juty9026/terrapod.git`을 초기화한 다음 initial declared-state apply를 실행합니다.
+
+이 installer를 실행하기 전에 `chezmoi`를 직접 설치할 필요는 없습니다.
+
+bootstrap 이후에는 일반 점검과 source update에 Terrapod을 사용합니다.
+
+```sh
+terrapod status
+terrapod doctor
+terrapod update
+```
+
+## What Terrapod Carries
+
+- macOS terminal workstation과 Ubuntu 24.04 VPS를 위한 machine profile.
+- 구체적인 machine-local setting으로 펼쳐지는 Preset.
+- 풍부한 editor configuration, AI CLI tools, development workspace surface를 위한 optional stack.
+- 선택한 desktop tool을 묶는 macOS App Group.
+
+## Choose a Preset
+
+Preset은 first-run setup 중 Terrapod이 machine에 펼쳐 놓을 형태입니다.
+
+| Preset | 적합한 용도 | 구성 |
+| --- | --- | --- |
+| `minimal` | 작은 VPS, 깨끗한 shell, recovery install | Core shell과 runtime baseline만 |
+| `development` | active coding에 쓰는 machine | Optional Editor Stack, Optional AI Tool Stack, Optional Development Workspace |
+| `workstation` | 개인 macOS workstation | Development setup에 모든 macOS App Group 추가 |
+
+Preset은 구체적인 machine-local setting을 씁니다. 영구적인 mode가 아니므로, 나중에 Preset 정의가 바뀌어도 이미 설정된 machine이 조용히 다시 바뀌지는 않습니다.
+
+`workstation` Preset은 macOS Terminal Profile에서만 사용할 수 있습니다.
+
+## What Terrapod Leaves Alone
+
+Terrapod은 이 저장소의 declared dotfiles state를 적용합니다. 전체 운영체제를 소유하지는 않습니다.
+
+- 광범위한 Homebrew 또는 APT upgrade
+- mise-managed tool과 runtime upgrade
+- Machine-local secret
+- 추적하지 않는 개인 override
+
+Terrapod은 광범위한 Homebrew, APT, mise upgrade를 실행하지 않습니다.
+
+## Daily Commands
+
+bootstrap 이후의 기본 관리 명령은 `terrapod`입니다. `tpod`는 같은 명령의 짧은 alias입니다.
+
+```sh
+terrapod status
+terrapod doctor
+terrapod diff
+terrapod apply
+terrapod update
+tpod status
+```
+
+`terrapod update`는 `chezmoi update --exclude scripts`를 통해 Terrapod Source Repository를 새로고침합니다. Homebrew, APT, mise upgrade는 실행하지 않습니다.
+
+직접 chezmoi를 사용하는 길은 advanced escape hatch로 남아 있습니다.
+
+```sh
+terrapod chezmoi -- cd
+terrapod chezmoi -- status
+```
+
+## Platform Details
+
+### macOS
+
+macOS에서 installer를 실행합니다.
+
+```sh
+sh -c "$(curl -fsLS https://raw.githubusercontent.com/juty9026/terrapod/main/install.sh)"
+```
+
+macOS에서는 initial apply가 초기 terminal environment를 위해 `.chezmoiscripts` 아래 setup script도 실행합니다.
+
+- Homebrew bootstrap과 macOS `Brewfile` bundle
+- mise
+- mise를 통한 ripgrep, neovim, zellij, lazygit, GitHub CLI (`gh`), starship 같은 CLI tool
+- btop. mise-managed release asset이 macOS arm64를 지원하지 않기 때문에 Homebrew로 설치합니다.
+- Terminal font cask
+- Oh My Zsh, zinit, SCM Breeze
+- `~/.config/mise/config.toml`을 통한 Bun, Python, uv/uvx, Node.js
+- Node.js Corepack을 통한 pnpm
+
+macOS desktop application은 machine-local data key로 제어되는 opt-in App Group으로 나뉩니다. Homebrew bootstrap 중 chezmoi는 선택한 group을 `Brewfile.macos-desktop-apps.tmpl`에서 temporary Brewfile로 render하고, 그 rendered bundle을 설치합니다.
+
+- `terminal-apps`: Ghostty와 cmux.
+- `automation`: Hammerspoon과 Karabiner-Elements.
+- `launcher`: Raycast와 1Password CLI.
+- `monitoring`: iStat Menus.
+
+Machine-specific Homebrew package는 tracked `Brewfile` 밖에 둬야 합니다.
+
+### Ubuntu 24.04 VPS
+
+Ubuntu support는 24.04 LTS만 대상으로 합니다. VPS profile은 기본적으로 read-only이므로 initial setup에 GitHub authentication이 필요하지 않습니다. installer를 실행합니다.
+
+```sh
+sh -c "$(curl -fsLS https://raw.githubusercontent.com/juty9026/terrapod/main/install.sh)"
+```
+
+installer는 bootstrap process 동안 `~/.local/bin`을 `PATH`에 추가합니다. first apply 이후에는 managed zsh session이 `~/.local/bin`을 `PATH`에 유지하므로, reconnect 후에도 `chezmoi` 같은 user-local binary를 사용할 수 있습니다.
+
+Ubuntu에서는 initial apply가 VPS shell profile을 위한 setup script를 실행합니다.
+
+- APT bootstrap package: zsh, git, curl, ca-certificates, gpg, unzip, build-essential
+- mise-managed Python runtime에 필요한 Python build dependency
+- official mise APT repository에서 설치하는 mise
+- Oh My Zsh, zinit, SCM Breeze
+- mise를 통한 ripgrep, neovim, zellij, lazygit, GitHub CLI (`gh`), starship 같은 CLI tool
+- mise를 통한 Bun, Python, uv/uvx, Node.js
+- Node.js Corepack을 통한 pnpm
+- login shell을 zsh로 전환
+
+VPS에서 write access가 나중에 필요할 때만 GitHub authentication을 설정하세요. 첫 mise install이 aqua tool을 resolve하는 동안 GitHub API rate limit에 걸리면, 임시 `GITHUB_TOKEN`을 export하고 `chezmoi apply`를 다시 실행합니다.
+
+login shell이 자동으로 바뀌지 않았다면 first apply 이후 직접 전환하고 다시 접속합니다.
+
+```sh
+chsh -s "$(command -v zsh)"
+```
+
+bootstrap 이후의 일반 관리는 Terrapod이 처리합니다. 특이한 recovery path에서는 `chezmoi`를 직접 설치하고 `https://github.com/juty9026/terrapod.git`을 initialize한 뒤, 결과를 검토하고 apply합니다.
+
+### Intentional Upgrades
+
+여기서 Homebrew와 APT는 Bootstrap Package Manager입니다. declared shell state를 위해 machine을 준비하는 역할입니다. mise는 supported machine profile 전반의 shared command-line tool과 development runtime을 위한 Modern CLI Provider입니다.
+
+OS-managed package를 의도적으로 업데이트할 때만 OS package manager를 직접 사용합니다.
+
+```sh
+# macOS
+brew update
+brew upgrade
+
+# Ubuntu
+sudo apt update
+sudo apt upgrade
+```
+
+modern CLI tool이나 development runtime을 의도적으로 업데이트할 때는 mise를 직접 사용합니다.
+
+```sh
+mise outdated
+mise upgrade
+```
+
+configured major/minor range를 넘어설 때만 `--bump`를 사용합니다. 예를 들어 Node.js를 현재 `24` line에서 더 새 major로 옮기는 경우입니다.
+
+```sh
+mise outdated --bump
+mise upgrade --bump
+```
+
+## Manual Restore
+
+### Raycast
+
+Raycast Store extension과 app state는 이 repo에서 직접 추적하지 않고, 1Password에 저장한 `.rayconfig` backup에서 수동으로 복원합니다.
+
+1. `enableMacosAppGroupLauncher`로 launcher macOS App Group을 enable/install하거나, 다른 방식으로 Raycast가 설치되어 있는지 확인합니다.
+2. Raycast settings export가 들어 있는 1Password item을 엽니다.
+3. 최신 `.rayconfig` file을 다운로드합니다.
+4. Raycast에서 `Import Settings & Data`를 실행합니다.
+5. 같은 1Password item에 있는 Raycast export passphrase를 입력합니다.
+6. 가져올 category를 선택합니다. 보통 Store extension, settings, alias, hotkey, quicklink, snippet을 선택합니다.
+
+Raycast 변경사항을 workstation 간에 공유해야 할 때는 primary workstation에서 새 `.rayconfig`를 export하고 1Password item을 업데이트합니다.
+
+## Local Overrides
+
+Machine-local option은 이 repo 밖에서 `chezmoi edit-config`로 설정합니다. 여기에는 option name, default, example만 둡니다. workstation-specific value는 commit하지 않습니다.
+
+Optional stack profile과 macOS App Group setting은 기본적으로 disabled입니다.
+
+| 설정 키 | 기본값 | 목적 |
+| --- | --- | --- |
+| `enableEditorStack` | `false` | rich Neovim configuration을 관리하는 Optional Editor Stack을 활성화합니다. Plain Neovim은 어느 쪽이든 Core Shell Stack에 남아 있습니다. |
+| `enableAiCliTools` | `false` | mise-managed Node.js runtime을 통해 npm으로 Gemini CLI, Claude Code, Codex를 설치합니다. |
+| `enableDevelopmentWorkspace` | `false` | Optional Editor Stack, Optional AI Tool Stack, development-specific Zellij workspace surface를 포함하는 Optional Development Workspace preset을 활성화합니다. |
+| `enableMacosAppGroupTerminalApps` | `false` | terminal-apps macOS App Group인 Ghostty와 cmux를 설치합니다. |
+| `enableMacosAppGroupAutomation` | `false` | automation macOS App Group인 Hammerspoon과 Karabiner-Elements를 설치합니다. |
+| `enableMacosAppGroupLauncher` | `false` | launcher macOS App Group인 Raycast와 1Password CLI를 설치합니다. |
+| `enableMacosAppGroupMonitoring` | `false` | monitoring macOS App Group인 iStat Menus를 설치합니다. |
+| `gitAllowedSigners` | `[]` | workstation-specific SSH signing identity를 `~/.ssh/allowed_signers`에 추가합니다. |
+
+`enableDevelopmentWorkspace`가 `true`이면 `enableEditorStack`이나 `enableAiCliTools`가 false이거나 생략되어도 Optional Editor Stack과 Optional AI Tool Stack이 함께 활성화됩니다.
+
+macOS Desktop App Stack installation은 `enableDevelopmentWorkspace`와 분리되어 있습니다. desktop cask가 한 사용자의 home directory 밖에 있는 shared application에 영향을 줄 수 있기 때문입니다.
+
+optional stack에서 opt out하면 해당 file은 chezmoi management에서 제외됩니다. 이미 machine에 존재하는 file을 제거하지는 않습니다.
+
+### Optional stack profile examples
+
+Minimal VPS:
+
+```toml
+[data]
+```
+
+Editor-only machine:
+
+```toml
+[data]
+enableEditorStack = true
+```
+
+AI-only machine:
+
+```toml
+[data]
+enableAiCliTools = true
+```
+
+Full development workspace machine:
+
+```toml
+[data]
+enableEditorStack = false
+enableAiCliTools = false
+enableDevelopmentWorkspace = true
+```
+
+Git signing identity는 어느 profile과도 함께 설정할 수 있습니다.
+
+```toml
+[data]
+gitAllowedSigners = [
+  "name@company.com ssh-ed25519 AAAA_COMPANY_PUBLIC_KEY company",
+]
+```
+
+그 다음 dotfiles를 apply합니다.
+
+```sh
+terrapod apply
+```
+
+## Repository Conventions
+
+- `dot_`: home directory의 dotfile
+- `private_`: private permission이 필요한 file
+- `executable_`: executable bit가 필요한 file
+- `.tmpl`: machine-specific value나 secret injection을 위한 template
+
+static configuration에는 template을 사용하지 않습니다.
+
+secret, token, private key를 commit하지 마세요.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Terrapod
 
+🌐 Language: **English** | [한국어](README.ko.md)
+
 Terrapod is a small landing pod for your machines: it brings your familiar
 shell, editor, runtime, and desktop habits to a fresh Mac or Ubuntu 24.04 VPS.
 

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -139,6 +139,21 @@ fi
 
 pass "development tests are ignored by chezmoi"
 
+managed_repository_docs="$(
+  chezmoi \
+    --config "$chezmoi_config" \
+    --source "$repo_root" \
+    managed \
+    --path-style source-relative |
+    grep -E '^(README(\.ko)?\.md|AGENTS\.md|CONTEXT\.md|docs/)' || true
+)"
+
+if [ -n "$managed_repository_docs" ]; then
+  fail "repository documentation should not be managed by chezmoi: $managed_repository_docs"
+fi
+
+pass "repository documentation is ignored by chezmoi"
+
 ubuntu_data='{"chezmoi":{"os":"linux","osRelease":{"id":"ubuntu","versionID":"24.04"}},"enableEditorStack":false,"enableAiCliTools":false,"enableDevelopmentWorkspace":false}'
 ubuntu_managed="$(managed_source_paths "$ubuntu_data")"
 macos_data='{"chezmoi":{"os":"darwin"},"enableEditorStack":false,"enableAiCliTools":false,"enableDevelopmentWorkspace":false}'

--- a/tests/readme_korean_test.sh
+++ b/tests/readme_korean_test.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+readme="$repo_root/README.md"
+korean_readme="$repo_root/README.ko.md"
+tmp_dir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT INT TERM
+
+fail() {
+  printf '%s\n' "not ok - $1" >&2
+  exit 1
+}
+
+pass() {
+  printf '%s\n' "ok - $1"
+}
+
+assert_file_exists() {
+  file="$1"
+  message="$2"
+
+  if [ ! -f "$file" ]; then
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
+assert_contains() {
+  file="$1"
+  needle="$2"
+  message="$3"
+
+  if ! grep -F "$needle" "$file" >/dev/null; then
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
+assert_not_contains() {
+  file="$1"
+  needle="$2"
+  message="$3"
+
+  if grep -F "$needle" "$file" >/dev/null; then
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
+extract_headings() {
+  file="$1"
+
+  grep -E '^#{1,6} ' "$file" || true
+}
+
+assert_file_exists "$readme" "README.md exists"
+assert_file_exists "$korean_readme" "README.ko.md exists"
+
+assert_contains "$readme" '🌐 Language: **English** | [한국어](README.ko.md)' \
+  "README.md has the agreed language switcher"
+assert_contains "$korean_readme" '🌐 언어: [English](README.md) | **한국어**' \
+  "README.ko.md has the agreed language switcher"
+assert_not_contains "$korean_readme" '번역본' \
+  "README.ko.md does not label itself as a translation"
+
+extract_headings "$readme" >"$tmp_dir/readme.headings"
+extract_headings "$korean_readme" >"$tmp_dir/readme-ko.headings"
+
+if ! cmp -s "$tmp_dir/readme.headings" "$tmp_dir/readme-ko.headings"; then
+  printf '%s\n' "README heading mismatch:" >&2
+  printf '%s\n' "--- README.md" >&2
+  sed 's/^/  /' "$tmp_dir/readme.headings" >&2
+  printf '%s\n' "--- README.ko.md" >&2
+  sed 's/^/  /' "$tmp_dir/readme-ko.headings" >&2
+  fail "README.ko.md mirrors README.md heading text and order"
+fi
+
+pass "README.ko.md mirrors README.md heading text and order"

--- a/tests/readme_korean_test.sh
+++ b/tests/readme_korean_test.sh
@@ -58,8 +58,45 @@ assert_not_contains() {
 extract_headings() {
   file="$1"
 
-  grep -E '^#{1,6} ' "$file" || true
+  awk '
+    /^```/ {
+      in_fence = !in_fence
+      next
+    }
+
+    !in_fence && /^#{1,6} / {
+      print
+    }
+  ' "$file" || true
 }
+
+assert_headings_ignore_fenced_code() {
+  fixture="$tmp_dir/fenced-headings.md"
+  actual="$tmp_dir/fenced-headings.actual"
+  expected="$tmp_dir/fenced-headings.expected"
+
+  cat >"$fixture" <<'EOF'
+# Visible heading
+```sh
+# Ignored shell comment
+```
+## Second visible heading
+EOF
+
+  extract_headings "$fixture" >"$actual"
+  {
+    printf '%s\n' "# Visible heading"
+    printf '%s\n' "## Second visible heading"
+  } >"$expected"
+
+  if ! cmp -s "$expected" "$actual"; then
+    fail "heading extraction ignores fenced code blocks"
+  fi
+
+  pass "heading extraction ignores fenced code blocks"
+}
+
+assert_headings_ignore_fenced_code
 
 assert_file_exists "$readme" "README.md exists"
 assert_file_exists "$korean_readme" "README.ko.md exists"


### PR DESCRIPTION
## Summary

- Add `README.ko.md` with Korean body copy while preserving canonical Terrapod domain terms and the English heading structure.
- Add compact language switchers between `README.md` and `README.ko.md`.
- Add a README parity test that checks language switchers, prevents a user-facing translation label, and compares real Markdown headings while ignoring fenced code blocks.
- Document the canonical README and Korean README maintenance rules in `CONTEXT.md`.

## Impact

Korean readers get a first-class README while `README.md` remains the canonical source. Future README structure drift is surfaced by the focused shell test.

## Validation

- `tests/readme_korean_test.sh`
- `sh tests/readme_optional_stack_profiles_test.sh`
- `tests/terrapod_installer_test.sh`
- `sh -n tests/readme_korean_test.sh`
- `git diff --check 11f57cd4b533cebf8d910449e869e7542b1ad440`