### PR TITLE
Bootstrap gum for VPS Shell Profile

### DIFF
--- a/.chezmoiscripts/run_onchange_before_00-bootstrap-ubuntu.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_00-bootstrap-ubuntu.sh.tmpl
@@ -46,7 +46,18 @@ $sudo_cmd apt-get install -y \
 $sudo_cmd install -dm 755 /etc/apt/keyrings
 curl -fSs https://mise.en.dev/gpg-key.pub | $sudo_cmd tee /etc/apt/keyrings/mise-archive-keyring.asc >/dev/null
 printf '%s\n' "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.asc] https://mise.en.dev/deb stable main" | $sudo_cmd tee /etc/apt/sources.list.d/mise.list >/dev/null
-curl -fsSL https://repo.charm.sh/apt/gpg.key | $sudo_cmd gpg --dearmor --yes -o /etc/apt/keyrings/charm.gpg
+charm_key_file="$(mktemp "${TMPDIR:-/tmp}/terrapod-charm-key.XXXXXX")"
+if ! curl -fsSL https://repo.charm.sh/apt/gpg.key -o "$charm_key_file"; then
+  echo "Failed to fetch the Charm APT signing key for gum. Check network access to https://repo.charm.sh/apt/gpg.key and rerun Terrapod apply." >&2
+  rm -f "$charm_key_file"
+  exit 1
+fi
+if ! $sudo_cmd gpg --dearmor --yes -o /etc/apt/keyrings/charm.gpg "$charm_key_file"; then
+  echo "Failed to install the Charm APT signing key for gum. Check APT keyring permissions and rerun Terrapod apply." >&2
+  rm -f "$charm_key_file"
+  exit 1
+fi
+rm -f "$charm_key_file"
 printf '%s\n' "deb [signed-by=/etc/apt/keyrings/charm.gpg] https://repo.charm.sh/apt/ * *" | $sudo_cmd tee /etc/apt/sources.list.d/charm.list >/dev/null
 
 $sudo_cmd apt-get update -y

--- a/.chezmoiscripts/run_onchange_before_00-bootstrap-ubuntu.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_00-bootstrap-ubuntu.sh.tmpl
@@ -46,9 +46,12 @@ $sudo_cmd apt-get install -y \
 $sudo_cmd install -dm 755 /etc/apt/keyrings
 curl -fSs https://mise.en.dev/gpg-key.pub | $sudo_cmd tee /etc/apt/keyrings/mise-archive-keyring.asc >/dev/null
 printf '%s\n' "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.asc] https://mise.en.dev/deb stable main" | $sudo_cmd tee /etc/apt/sources.list.d/mise.list >/dev/null
+curl -fsSL https://repo.charm.sh/apt/gpg.key | $sudo_cmd gpg --dearmor --yes -o /etc/apt/keyrings/charm.gpg
+printf '%s\n' "deb [signed-by=/etc/apt/keyrings/charm.gpg] https://repo.charm.sh/apt/ * *" | $sudo_cmd tee /etc/apt/sources.list.d/charm.list >/dev/null
 
 $sudo_cmd apt-get update -y
 $sudo_cmd apt-get install -y mise
+$sudo_cmd apt-get install -y gum
 
 target_user="$(id -un)"
 zsh_path="/usr/bin/zsh"

--- a/install.sh
+++ b/install.sh
@@ -137,7 +137,7 @@ vps_sudo_cmd() {
   elif command -v sudo >/dev/null 2>&1; then
     printf '%s\n' "sudo"
   else
-    fatal "git and gum are required before Terrapod Setup. Install git and gum manually, or install sudo so Terrapod can prepare them with apt-get."
+    fatal "Ubuntu bootstrap prerequisites are required before Terrapod Setup. Install sudo so Terrapod can prepare git and gum with apt-get, or install git and gum manually before rerunning the installer."
   fi
 }
 
@@ -148,9 +148,20 @@ ensure_charm_apt_repository() {
     fatal "failed to create the APT keyring directory for the Charm repository. Check sudo permissions and rerun the Terrapod installer before Terrapod Setup."
   fi
 
-  if ! curl -fsSL https://repo.charm.sh/apt/gpg.key | $sudo_cmd gpg --dearmor --yes -o /etc/apt/keyrings/charm.gpg; then
-    fatal "failed to install the Charm APT signing key for gum. Check network access to https://repo.charm.sh/apt/gpg.key and rerun the Terrapod installer before Terrapod Setup."
+  if ! charm_key_file="$(mktemp "${TMPDIR:-/tmp}/terrapod-charm-key.XXXXXX")"; then
+    fatal "failed to create a temporary file for the Charm APT signing key. Check temporary directory permissions and rerun the Terrapod installer before Terrapod Setup."
   fi
+
+  if ! curl -fsSL https://repo.charm.sh/apt/gpg.key -o "$charm_key_file"; then
+    rm -f "$charm_key_file"
+    fatal "failed to fetch the Charm APT signing key for gum. Check network access to https://repo.charm.sh/apt/gpg.key and rerun the Terrapod installer before Terrapod Setup."
+  fi
+
+  if ! $sudo_cmd gpg --dearmor --yes -o /etc/apt/keyrings/charm.gpg "$charm_key_file"; then
+    rm -f "$charm_key_file"
+    fatal "failed to install the Charm APT signing key for gum. Check APT keyring permissions and rerun the Terrapod installer before Terrapod Setup."
+  fi
+  rm -f "$charm_key_file"
 
   if ! printf '%s\n' "deb [signed-by=/etc/apt/keyrings/charm.gpg] https://repo.charm.sh/apt/ * *" | $sudo_cmd tee /etc/apt/sources.list.d/charm.list >/dev/null; then
     fatal "failed to write the Charm APT repository for gum. Check sudo permissions and rerun the Terrapod installer before Terrapod Setup."

--- a/install.sh
+++ b/install.sh
@@ -131,6 +131,36 @@ install_chezmoi_if_needed() {
   printf '%s\n' "$chezmoi_path"
 }
 
+vps_sudo_cmd() {
+  if [ "$(id -u)" -eq 0 ]; then
+    printf '%s\n' ""
+  elif command -v sudo >/dev/null 2>&1; then
+    printf '%s\n' "sudo"
+  else
+    fatal "git and gum are required before Terrapod Setup. Install git and gum manually, or install sudo so Terrapod can prepare them with apt-get."
+  fi
+}
+
+ensure_charm_apt_repository() {
+  sudo_cmd="$1"
+
+  if ! $sudo_cmd install -dm 755 /etc/apt/keyrings; then
+    fatal "failed to create the APT keyring directory for the Charm repository. Check sudo permissions and rerun the Terrapod installer before Terrapod Setup."
+  fi
+
+  if ! curl -fsSL https://repo.charm.sh/apt/gpg.key | $sudo_cmd gpg --dearmor --yes -o /etc/apt/keyrings/charm.gpg; then
+    fatal "failed to install the Charm APT signing key for gum. Check network access to https://repo.charm.sh/apt/gpg.key and rerun the Terrapod installer before Terrapod Setup."
+  fi
+
+  if ! printf '%s\n' "deb [signed-by=/etc/apt/keyrings/charm.gpg] https://repo.charm.sh/apt/ * *" | $sudo_cmd tee /etc/apt/sources.list.d/charm.list >/dev/null; then
+    fatal "failed to write the Charm APT repository for gum. Check sudo permissions and rerun the Terrapod installer before Terrapod Setup."
+  fi
+
+  if ! $sudo_cmd apt-get update -y; then
+    fatal "failed to update APT metadata after adding the Charm APT repository for gum. Check APT connectivity and rerun the Terrapod installer before Terrapod Setup."
+  fi
+}
+
 ensure_source_repo_prerequisites() {
   profile="$1"
 
@@ -138,24 +168,33 @@ ensure_source_repo_prerequisites() {
     return 0
   fi
 
-  if command -v git >/dev/null 2>&1; then
+  if command -v git >/dev/null 2>&1 && command -v gum >/dev/null 2>&1; then
     return 0
   fi
 
-  if [ "$(id -u)" -eq 0 ]; then
-    sudo_cmd=""
-  elif command -v sudo >/dev/null 2>&1; then
-    sudo_cmd="sudo"
-  else
-    fatal "git is required before chezmoi can initialize the source repository. Install git, or install sudo so Terrapod can install git with apt-get."
+  sudo_cmd="$(vps_sudo_cmd)"
+  bootstrap_packages="ca-certificates curl"
+  if ! command -v git >/dev/null 2>&1; then
+    bootstrap_packages="$bootstrap_packages git"
   fi
+  bootstrap_packages="$bootstrap_packages gpg"
 
   if ! $sudo_cmd apt-get update -y; then
-    fatal "failed to update APT metadata before installing git"
+    fatal "failed to update APT metadata before installing Ubuntu bootstrap prerequisites"
   fi
 
-  if ! $sudo_cmd apt-get install -y ca-certificates git; then
-    fatal "failed to install git before initializing the source repository"
+  if ! $sudo_cmd apt-get install -y $bootstrap_packages; then
+    fatal "failed to install Ubuntu bootstrap prerequisites before Terrapod Setup. Install ca-certificates, curl, git, and gpg, then rerun the Terrapod installer."
+  fi
+
+  if command -v gum >/dev/null 2>&1; then
+    return 0
+  fi
+
+  ensure_charm_apt_repository "$sudo_cmd"
+
+  if ! $sudo_cmd apt-get install -y gum; then
+    fatal "failed to install gum from the Charm APT repository. Check APT output, fix repository/package access, and rerun the Terrapod installer before Terrapod Setup."
   fi
 }
 

--- a/tests/bootstrap_ubuntu_test.sh
+++ b/tests/bootstrap_ubuntu_test.sh
@@ -30,6 +30,18 @@ assert_contains() {
   pass "$message"
 }
 
+assert_not_contains() {
+  haystack="$1"
+  needle="$2"
+  message="$3"
+
+  if printf '%s\n' "$haystack" | grep -F -e "$needle" >/dev/null; then
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
 assert_first_occurrence_before() {
   haystack="$1"
   first="$2"
@@ -90,7 +102,28 @@ write_stub "$tmp_dir/bin/curl" \
   'printf "%s\n" "curl args:$*" >>"$BOOTSTRAP_TEST_LOG"' \
   'case "$*" in' \
   '  *mise.en.dev*) printf "%s\n" mise-key ;;' \
-  '  *repo.charm.sh*) printf "%s\n" charm-key ;;' \
+  '  *repo.charm.sh*)' \
+  '    if [ "${BOOTSTRAP_CHARM_KEY_CURL_STATUS:-0}" != "0" ]; then' \
+  '      exit "$BOOTSTRAP_CHARM_KEY_CURL_STATUS"' \
+  '    fi' \
+  '    output_file=""' \
+  '    want_output_file="no"' \
+  '    for arg do' \
+  '      if [ "$want_output_file" = "yes" ]; then' \
+  '        output_file="$arg"' \
+  '        want_output_file="no"' \
+  '        continue' \
+  '      fi' \
+  '      if [ "$arg" = "-o" ]; then' \
+  '        want_output_file="yes"' \
+  '      fi' \
+  '    done' \
+  '    if [ -n "$output_file" ]; then' \
+  '      printf "%s\n" charm-key >"$output_file"' \
+  '    else' \
+  '      printf "%s\n" charm-key' \
+  '    fi' \
+  '    ;;' \
   '  *) exit 64 ;;' \
   'esac'
 
@@ -137,9 +170,23 @@ pass "Ubuntu bootstrap sets the login shell to zsh"
 bootstrap_log="$(cat "$BOOTSTRAP_TEST_LOG")"
 assert_contains "$bootstrap_log" "install args:-dm 755 /etc/apt/keyrings" "Ubuntu bootstrap creates an APT keyring directory"
 assert_contains "$bootstrap_log" "curl args:-fSs https://mise.en.dev/gpg-key.pub" "Ubuntu bootstrap still fetches the mise APT signing key"
-assert_contains "$bootstrap_log" "curl args:-fsSL https://repo.charm.sh/apt/gpg.key" "Ubuntu bootstrap fetches the Charm APT signing key"
-assert_contains "$bootstrap_log" "gpg args:--dearmor --yes -o /etc/apt/keyrings/charm.gpg" "Ubuntu bootstrap dearmors the Charm APT signing key"
+assert_contains "$bootstrap_log" "curl args:-fsSL https://repo.charm.sh/apt/gpg.key -o " "Ubuntu bootstrap fetches the Charm APT signing key"
+assert_contains "$bootstrap_log" "gpg args:--dearmor --yes -o /etc/apt/keyrings/charm.gpg " "Ubuntu bootstrap dearmors the Charm APT signing key"
 assert_contains "$bootstrap_log" "tee stdin:deb [signed-by=/etc/apt/keyrings/charm.gpg] https://repo.charm.sh/apt/ * *" "Ubuntu bootstrap pins the Charm repository to its keyring"
 assert_contains "$bootstrap_log" "apt-get args:install -y gum" "Ubuntu bootstrap installs gum through APT"
 assert_contains "$bootstrap_log" "apt-get args:install -y mise" "Ubuntu bootstrap still installs mise through APT"
 assert_first_occurrence_before "$bootstrap_log" "tee stdin:deb [signed-by=/etc/apt/keyrings/charm.gpg] https://repo.charm.sh/apt/ * *" "apt-get args:install -y gum" "Ubuntu bootstrap adds the Charm repository before installing gum"
+
+: >"$BOOTSTRAP_TEST_LOG"
+BOOTSTRAP_CHARM_KEY_CURL_STATUS=17
+export BOOTSTRAP_CHARM_KEY_CURL_STATUS
+if sh "$rendered" >"$tmp_dir/bootstrap-curl-failure.out" 2>"$tmp_dir/bootstrap-curl-failure.err"; then
+  unset BOOTSTRAP_CHARM_KEY_CURL_STATUS
+  fail "Ubuntu bootstrap should fail when the Charm signing key download fails"
+fi
+unset BOOTSTRAP_CHARM_KEY_CURL_STATUS
+
+bootstrap_curl_failure_log="$(cat "$BOOTSTRAP_TEST_LOG")"
+assert_contains "$bootstrap_curl_failure_log" "curl args:-fsSL https://repo.charm.sh/apt/gpg.key -o " "Ubuntu bootstrap Charm key failure attempts to fetch the signing key"
+assert_not_contains "$bootstrap_curl_failure_log" "apt-get args:install -y gum" "Ubuntu bootstrap Charm key failure stops before installing gum"
+pass "Ubuntu bootstrap fails when the Charm signing key download fails"

--- a/tests/bootstrap_ubuntu_test.sh
+++ b/tests/bootstrap_ubuntu_test.sh
@@ -18,6 +18,35 @@ pass() {
   printf '%s\n' "ok - $1"
 }
 
+assert_contains() {
+  haystack="$1"
+  needle="$2"
+  message="$3"
+
+  if ! printf '%s\n' "$haystack" | grep -F "$needle" >/dev/null; then
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
+assert_first_occurrence_before() {
+  haystack="$1"
+  first="$2"
+  second="$3"
+  message="$4"
+
+  if ! printf '%s\n' "$haystack" | awk -v first="$first" -v second="$second" '
+    first_line == 0 && index($0, first) { first_line = NR }
+    second_line == 0 && index($0, second) { second_line = NR }
+    END { exit !(first_line > 0 && second_line > 0 && first_line < second_line) }
+  '; then
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
 write_stub() {
   path="$1"
   shift
@@ -50,17 +79,30 @@ write_stub "$tmp_dir/bin/sudo" \
   'exec "$@"'
 
 write_stub "$tmp_dir/bin/apt-get" \
+  'printf "%s\n" "apt-get args:$*" >>"$BOOTSTRAP_TEST_LOG"' \
   'exit 0'
 
 write_stub "$tmp_dir/bin/install" \
+  'printf "%s\n" "install args:$*" >>"$BOOTSTRAP_TEST_LOG"' \
   'exit 0'
 
 write_stub "$tmp_dir/bin/curl" \
-  'printf "%s\n" mise-key'
+  'printf "%s\n" "curl args:$*" >>"$BOOTSTRAP_TEST_LOG"' \
+  'case "$*" in' \
+  '  *mise.en.dev*) printf "%s\n" mise-key ;;' \
+  '  *repo.charm.sh*) printf "%s\n" charm-key ;;' \
+  '  *) exit 64 ;;' \
+  'esac'
+
+write_stub "$tmp_dir/bin/gpg" \
+  'printf "%s\n" "gpg args:$*" >>"$BOOTSTRAP_TEST_LOG"' \
+  'cat >/dev/null'
 
 write_stub "$tmp_dir/bin/tee" \
-  'cat >/dev/null' \
-  'exit 0'
+  'printf "%s\n" "tee args:$*" >>"$BOOTSTRAP_TEST_LOG"' \
+  'while IFS= read -r line || [ -n "$line" ]; do' \
+  '  printf "%s\n" "tee stdin:$line" >>"$BOOTSTRAP_TEST_LOG"' \
+  'done'
 
 write_stub "$tmp_dir/bin/getent" \
   'if [ "$1" = passwd ] && [ "$2" = testuser ]; then' \
@@ -79,6 +121,7 @@ write_stub "$tmp_dir/bin/chsh" \
 export PATH="$tmp_dir/bin:/usr/bin:/bin"
 export HOME="$tmp_dir/home"
 export CHSH_TEST_LOG="$tmp_dir/chsh.log"
+export BOOTSTRAP_TEST_LOG="$tmp_dir/bootstrap.log"
 
 sh "$rendered" >"$tmp_dir/bootstrap.out" 2>"$tmp_dir/bootstrap.err"
 
@@ -90,3 +133,13 @@ if [ "$actual" != "$expected" ]; then
 fi
 
 pass "Ubuntu bootstrap sets the login shell to zsh"
+
+bootstrap_log="$(cat "$BOOTSTRAP_TEST_LOG")"
+assert_contains "$bootstrap_log" "install args:-dm 755 /etc/apt/keyrings" "Ubuntu bootstrap creates an APT keyring directory"
+assert_contains "$bootstrap_log" "curl args:-fSs https://mise.en.dev/gpg-key.pub" "Ubuntu bootstrap still fetches the mise APT signing key"
+assert_contains "$bootstrap_log" "curl args:-fsSL https://repo.charm.sh/apt/gpg.key" "Ubuntu bootstrap fetches the Charm APT signing key"
+assert_contains "$bootstrap_log" "gpg args:--dearmor --yes -o /etc/apt/keyrings/charm.gpg" "Ubuntu bootstrap dearmors the Charm APT signing key"
+assert_contains "$bootstrap_log" "tee stdin:deb [signed-by=/etc/apt/keyrings/charm.gpg] https://repo.charm.sh/apt/ * *" "Ubuntu bootstrap pins the Charm repository to its keyring"
+assert_contains "$bootstrap_log" "apt-get args:install -y gum" "Ubuntu bootstrap installs gum through APT"
+assert_contains "$bootstrap_log" "apt-get args:install -y mise" "Ubuntu bootstrap still installs mise through APT"
+assert_first_occurrence_before "$bootstrap_log" "tee stdin:deb [signed-by=/etc/apt/keyrings/charm.gpg] https://repo.charm.sh/apt/ * *" "apt-get args:install -y gum" "Ubuntu bootstrap adds the Charm repository before installing gum"

--- a/tests/terrapod_installer_test.sh
+++ b/tests/terrapod_installer_test.sh
@@ -293,6 +293,9 @@ set -eu
 printf '%s\n' "apt-get args:$*" >>"${TERRAPOD_STUB_CALL_LOG:?}"
 case "${1-}" in
   update|install)
+    if [ "$*" = "install -y gum" ] && [ "${TERRAPOD_APT_FAIL_INSTALL_GUM:-0}" = "1" ]; then
+      exit 17
+    fi
     exit 0
     ;;
   *)
@@ -301,6 +304,60 @@ case "${1-}" in
 esac
 EOF
   chmod +x "$case_dir/bin/apt-get"
+
+  cat >"$case_dir/bin/install" <<'EOF'
+#!/bin/sh
+set -eu
+
+printf '%s\n' "install args:$*" >>"${TERRAPOD_STUB_CALL_LOG:?}"
+exit 0
+EOF
+  chmod +x "$case_dir/bin/install"
+
+  cat >"$case_dir/bin/curl" <<'EOF'
+#!/bin/sh
+set -eu
+
+printf '%s\n' "curl args:$*" >>"${TERRAPOD_STUB_CALL_LOG:?}"
+case "$*" in
+  *https://repo.charm.sh/apt/gpg.key*)
+    if [ "${TERRAPOD_CHARM_KEY_STUB_STATUS:-0}" != "0" ]; then
+      exit "$TERRAPOD_CHARM_KEY_STUB_STATUS"
+    fi
+    printf '%s\n' "fake charm key"
+    ;;
+  *)
+    printf '%s\n' "unexpected curl args:$*" >>"${TERRAPOD_STUB_CALL_LOG:?}"
+    exit 64
+    ;;
+esac
+EOF
+  chmod +x "$case_dir/bin/curl"
+
+  cat >"$case_dir/bin/gpg" <<'EOF'
+#!/bin/sh
+set -eu
+
+printf '%s\n' "gpg args:$*" >>"${TERRAPOD_STUB_CALL_LOG:?}"
+cat >/dev/null
+if [ "${TERRAPOD_GPG_STUB_STATUS:-0}" != "0" ]; then
+  exit "$TERRAPOD_GPG_STUB_STATUS"
+fi
+exit 0
+EOF
+  chmod +x "$case_dir/bin/gpg"
+
+  cat >"$case_dir/bin/tee" <<'EOF'
+#!/bin/sh
+set -eu
+
+printf '%s\n' "tee args:$*" >>"${TERRAPOD_STUB_CALL_LOG:?}"
+while IFS= read -r line || [ -n "$line" ]; do
+  printf '%s\n' "tee stdin:$line" >>"${TERRAPOD_STUB_CALL_LOG:?}"
+done
+exit 0
+EOF
+  chmod +x "$case_dir/bin/tee"
 }
 
 write_chezmoi_flow_stub() {
@@ -492,7 +549,7 @@ pass "Darwin installer creates user local bin directory"
 ubuntu_case="$(make_case_dir ubuntu-profile)"
 write_uname_stub "$ubuntu_case" "Linux"
 ubuntu_os_release="$(write_os_release "$ubuntu_case" "ID=ubuntu" 'VERSION_ID="24.04"')"
-write_command_call_stubs "$ubuntu_case" "curl" "wget" "git" "sh"
+write_command_call_stubs "$ubuntu_case" "curl" "wget" "git" "gum" "sh"
 mkdir -p "$ubuntu_case/home/.local/bin"
 write_chezmoi_flow_stub "$ubuntu_case/home/.local/bin/chezmoi"
 TERRAPOD_OS_RELEASE_FILE="$ubuntu_os_release"
@@ -529,8 +586,72 @@ unset TERRAPOD_STUB_CALL_LOG
 assert_status "$installer_status" 0 "Ubuntu installer installs source prerequisites when git is missing"
 ubuntu_missing_git_log_text="$(cat "$ubuntu_missing_git_log")"
 assert_contains "$ubuntu_missing_git_log_text" "apt-get args:update -y" "Ubuntu missing git case updates package metadata"
-assert_contains "$ubuntu_missing_git_log_text" "apt-get args:install -y ca-certificates git" "Ubuntu missing git case installs git before init"
-assert_first_occurrence_before "$ubuntu_missing_git_log_text" "apt-get args:install -y ca-certificates git" "chezmoi args:init https://github.com/juty9026/terrapod.git" "Ubuntu missing git case installs git before chezmoi init"
+assert_contains "$ubuntu_missing_git_log_text" "apt-get args:install -y ca-certificates curl git gpg" "Ubuntu missing git case installs source and bootstrap UI dependencies"
+assert_contains "$ubuntu_missing_git_log_text" "install args:-dm 755 /etc/apt/keyrings" "Ubuntu missing git case creates an APT keyring directory"
+assert_contains "$ubuntu_missing_git_log_text" "curl args:-fsSL https://repo.charm.sh/apt/gpg.key" "Ubuntu missing git case fetches the Charm APT signing key"
+assert_contains "$ubuntu_missing_git_log_text" "gpg args:--dearmor --yes -o /etc/apt/keyrings/charm.gpg" "Ubuntu missing git case dearmors the Charm APT signing key"
+assert_contains "$ubuntu_missing_git_log_text" "tee args:/etc/apt/sources.list.d/charm.list" "Ubuntu missing git case writes the Charm APT source list"
+assert_contains "$ubuntu_missing_git_log_text" "tee stdin:deb [signed-by=/etc/apt/keyrings/charm.gpg] https://repo.charm.sh/apt/ * *" "Ubuntu missing git case pins the Charm repository to its keyring"
+assert_contains "$ubuntu_missing_git_log_text" "apt-get args:install -y gum" "Ubuntu missing git case installs gum through APT"
+assert_first_occurrence_before "$ubuntu_missing_git_log_text" "apt-get args:install -y ca-certificates curl git gpg" "chezmoi args:init https://github.com/juty9026/terrapod.git" "Ubuntu missing git case installs git before chezmoi init"
+assert_first_occurrence_before "$ubuntu_missing_git_log_text" "tee args:/etc/apt/sources.list.d/charm.list" "apt-get args:install -y gum" "Ubuntu missing git case adds the Charm repository before installing gum"
+assert_first_occurrence_before "$ubuntu_missing_git_log_text" "apt-get args:install -y gum" "terrapod args:setup" "Ubuntu missing git case installs gum before Terrapod Setup"
+assert_first_occurrence_before "$ubuntu_missing_git_log_text" "apt-get args:install -y gum" "chezmoi args:apply" "Ubuntu missing git case installs gum before initial apply"
+
+ubuntu_charm_repo_failure_case="$(make_case_dir ubuntu-charm-repo-failure)"
+write_uname_stub "$ubuntu_charm_repo_failure_case" "Linux"
+ubuntu_charm_repo_failure_os_release="$(write_os_release "$ubuntu_charm_repo_failure_case" "ID=ubuntu" 'VERSION_ID="24.04"')"
+write_command_call_stubs "$ubuntu_charm_repo_failure_case" "wget" "git" "sh"
+write_ubuntu_package_stubs "$ubuntu_charm_repo_failure_case"
+mkdir -p "$ubuntu_charm_repo_failure_case/home/.local/bin"
+write_chezmoi_flow_stub "$ubuntu_charm_repo_failure_case/home/.local/bin/chezmoi"
+ubuntu_charm_repo_failure_log="$ubuntu_charm_repo_failure_case/command-calls"
+TERRAPOD_OS_RELEASE_FILE="$ubuntu_charm_repo_failure_os_release"
+TERRAPOD_STUB_CALL_LOG="$ubuntu_charm_repo_failure_log"
+TERRAPOD_GPG_STUB_STATUS=17
+export TERRAPOD_OS_RELEASE_FILE
+export TERRAPOD_STUB_CALL_LOG
+export TERRAPOD_GPG_STUB_STATUS
+run_installer_case "$ubuntu_charm_repo_failure_case" 'development
+'
+unset TERRAPOD_OS_RELEASE_FILE
+unset TERRAPOD_STUB_CALL_LOG
+unset TERRAPOD_GPG_STUB_STATUS
+assert_failure "$installer_status" "Ubuntu Charm repository failure makes installer exit unsuccessfully"
+ubuntu_charm_repo_failure_stderr="$(cat "$ubuntu_charm_repo_failure_case/stderr")"
+ubuntu_charm_repo_failure_log_text="$(cat "$ubuntu_charm_repo_failure_log")"
+assert_contains "$ubuntu_charm_repo_failure_stderr" "failed to install the Charm APT signing key" "Ubuntu Charm repository failure explains the failed trust boundary"
+assert_contains "$ubuntu_charm_repo_failure_stderr" "rerun the Terrapod installer before Terrapod Setup" "Ubuntu Charm repository failure gives setup recovery guidance"
+assert_not_contains "$ubuntu_charm_repo_failure_log_text" "terrapod args:setup" "Ubuntu Charm repository failure stops before Terrapod Setup"
+assert_not_contains "$ubuntu_charm_repo_failure_log_text" "chezmoi args:apply" "Ubuntu Charm repository failure stops before initial apply"
+
+ubuntu_gum_failure_case="$(make_case_dir ubuntu-gum-failure)"
+write_uname_stub "$ubuntu_gum_failure_case" "Linux"
+ubuntu_gum_failure_os_release="$(write_os_release "$ubuntu_gum_failure_case" "ID=ubuntu" 'VERSION_ID="24.04"')"
+write_command_call_stubs "$ubuntu_gum_failure_case" "wget" "git" "sh"
+write_ubuntu_package_stubs "$ubuntu_gum_failure_case"
+mkdir -p "$ubuntu_gum_failure_case/home/.local/bin"
+write_chezmoi_flow_stub "$ubuntu_gum_failure_case/home/.local/bin/chezmoi"
+ubuntu_gum_failure_log="$ubuntu_gum_failure_case/command-calls"
+TERRAPOD_OS_RELEASE_FILE="$ubuntu_gum_failure_os_release"
+TERRAPOD_STUB_CALL_LOG="$ubuntu_gum_failure_log"
+TERRAPOD_APT_FAIL_INSTALL_GUM=1
+export TERRAPOD_OS_RELEASE_FILE
+export TERRAPOD_STUB_CALL_LOG
+export TERRAPOD_APT_FAIL_INSTALL_GUM
+run_installer_case "$ubuntu_gum_failure_case" 'development
+'
+unset TERRAPOD_OS_RELEASE_FILE
+unset TERRAPOD_STUB_CALL_LOG
+unset TERRAPOD_APT_FAIL_INSTALL_GUM
+assert_failure "$installer_status" "Ubuntu gum install failure makes installer exit unsuccessfully"
+ubuntu_gum_failure_stderr="$(cat "$ubuntu_gum_failure_case/stderr")"
+ubuntu_gum_failure_log_text="$(cat "$ubuntu_gum_failure_log")"
+assert_contains "$ubuntu_gum_failure_stderr" "failed to install gum from the Charm APT repository" "Ubuntu gum install failure explains the failed package install"
+assert_contains "$ubuntu_gum_failure_stderr" "rerun the Terrapod installer before Terrapod Setup" "Ubuntu gum install failure gives setup recovery guidance"
+assert_contains "$ubuntu_gum_failure_log_text" "apt-get args:install -y gum" "Ubuntu gum install failure attempts to install gum"
+assert_not_contains "$ubuntu_gum_failure_log_text" "terrapod args:setup" "Ubuntu gum install failure stops before Terrapod Setup"
+assert_not_contains "$ubuntu_gum_failure_log_text" "chezmoi args:apply" "Ubuntu gum install failure stops before initial apply"
 
 first_run_case="$(make_case_dir first-run-macos)"
 write_uname_stub "$first_run_case" "Darwin"

--- a/tests/terrapod_installer_test.sh
+++ b/tests/terrapod_installer_test.sh
@@ -20,7 +20,7 @@ pass() {
 }
 
 mkdir -p "$safe_path_dir"
-for command_name in cat chmod cp mkdir; do
+for command_name in cat chmod cp mkdir mktemp rm; do
   command_path="$(command -v "$command_name")"
   ln -s "$command_path" "$safe_path_dir/$command_name"
 done
@@ -324,7 +324,23 @@ case "$*" in
     if [ "${TERRAPOD_CHARM_KEY_STUB_STATUS:-0}" != "0" ]; then
       exit "$TERRAPOD_CHARM_KEY_STUB_STATUS"
     fi
-    printf '%s\n' "fake charm key"
+    output_file=""
+    want_output_file="no"
+    for arg do
+      if [ "$want_output_file" = "yes" ]; then
+        output_file="$arg"
+        want_output_file="no"
+        continue
+      fi
+      if [ "$arg" = "-o" ]; then
+        want_output_file="yes"
+      fi
+    done
+    if [ -n "$output_file" ]; then
+      printf '%s\n' "fake charm key" >"$output_file"
+    else
+      printf '%s\n' "fake charm key"
+    fi
     ;;
   *)
     printf '%s\n' "unexpected curl args:$*" >>"${TERRAPOD_STUB_CALL_LOG:?}"
@@ -588,8 +604,8 @@ ubuntu_missing_git_log_text="$(cat "$ubuntu_missing_git_log")"
 assert_contains "$ubuntu_missing_git_log_text" "apt-get args:update -y" "Ubuntu missing git case updates package metadata"
 assert_contains "$ubuntu_missing_git_log_text" "apt-get args:install -y ca-certificates curl git gpg" "Ubuntu missing git case installs source and bootstrap UI dependencies"
 assert_contains "$ubuntu_missing_git_log_text" "install args:-dm 755 /etc/apt/keyrings" "Ubuntu missing git case creates an APT keyring directory"
-assert_contains "$ubuntu_missing_git_log_text" "curl args:-fsSL https://repo.charm.sh/apt/gpg.key" "Ubuntu missing git case fetches the Charm APT signing key"
-assert_contains "$ubuntu_missing_git_log_text" "gpg args:--dearmor --yes -o /etc/apt/keyrings/charm.gpg" "Ubuntu missing git case dearmors the Charm APT signing key"
+assert_contains "$ubuntu_missing_git_log_text" "curl args:-fsSL https://repo.charm.sh/apt/gpg.key -o " "Ubuntu missing git case fetches the Charm APT signing key"
+assert_contains "$ubuntu_missing_git_log_text" "gpg args:--dearmor --yes -o /etc/apt/keyrings/charm.gpg " "Ubuntu missing git case dearmors the Charm APT signing key"
 assert_contains "$ubuntu_missing_git_log_text" "tee args:/etc/apt/sources.list.d/charm.list" "Ubuntu missing git case writes the Charm APT source list"
 assert_contains "$ubuntu_missing_git_log_text" "tee stdin:deb [signed-by=/etc/apt/keyrings/charm.gpg] https://repo.charm.sh/apt/ * *" "Ubuntu missing git case pins the Charm repository to its keyring"
 assert_contains "$ubuntu_missing_git_log_text" "apt-get args:install -y gum" "Ubuntu missing git case installs gum through APT"
@@ -624,6 +640,35 @@ assert_contains "$ubuntu_charm_repo_failure_stderr" "failed to install the Charm
 assert_contains "$ubuntu_charm_repo_failure_stderr" "rerun the Terrapod installer before Terrapod Setup" "Ubuntu Charm repository failure gives setup recovery guidance"
 assert_not_contains "$ubuntu_charm_repo_failure_log_text" "terrapod args:setup" "Ubuntu Charm repository failure stops before Terrapod Setup"
 assert_not_contains "$ubuntu_charm_repo_failure_log_text" "chezmoi args:apply" "Ubuntu Charm repository failure stops before initial apply"
+
+ubuntu_charm_key_fetch_failure_case="$(make_case_dir ubuntu-charm-key-fetch-failure)"
+write_uname_stub "$ubuntu_charm_key_fetch_failure_case" "Linux"
+ubuntu_charm_key_fetch_failure_os_release="$(write_os_release "$ubuntu_charm_key_fetch_failure_case" "ID=ubuntu" 'VERSION_ID="24.04"')"
+write_command_call_stubs "$ubuntu_charm_key_fetch_failure_case" "wget" "git" "sh"
+write_ubuntu_package_stubs "$ubuntu_charm_key_fetch_failure_case"
+mkdir -p "$ubuntu_charm_key_fetch_failure_case/home/.local/bin"
+write_chezmoi_flow_stub "$ubuntu_charm_key_fetch_failure_case/home/.local/bin/chezmoi"
+ubuntu_charm_key_fetch_failure_log="$ubuntu_charm_key_fetch_failure_case/command-calls"
+TERRAPOD_OS_RELEASE_FILE="$ubuntu_charm_key_fetch_failure_os_release"
+TERRAPOD_STUB_CALL_LOG="$ubuntu_charm_key_fetch_failure_log"
+TERRAPOD_CHARM_KEY_STUB_STATUS=17
+export TERRAPOD_OS_RELEASE_FILE
+export TERRAPOD_STUB_CALL_LOG
+export TERRAPOD_CHARM_KEY_STUB_STATUS
+run_installer_case "$ubuntu_charm_key_fetch_failure_case" 'development
+'
+unset TERRAPOD_OS_RELEASE_FILE
+unset TERRAPOD_STUB_CALL_LOG
+unset TERRAPOD_CHARM_KEY_STUB_STATUS
+assert_failure "$installer_status" "Ubuntu Charm key fetch failure makes installer exit unsuccessfully"
+ubuntu_charm_key_fetch_failure_stderr="$(cat "$ubuntu_charm_key_fetch_failure_case/stderr")"
+ubuntu_charm_key_fetch_failure_log_text="$(cat "$ubuntu_charm_key_fetch_failure_log")"
+assert_contains "$ubuntu_charm_key_fetch_failure_stderr" "failed to fetch the Charm APT signing key" "Ubuntu Charm key fetch failure explains the failed download"
+assert_contains "$ubuntu_charm_key_fetch_failure_stderr" "rerun the Terrapod installer before Terrapod Setup" "Ubuntu Charm key fetch failure gives setup recovery guidance"
+assert_contains "$ubuntu_charm_key_fetch_failure_log_text" "curl args:-fsSL https://repo.charm.sh/apt/gpg.key -o " "Ubuntu Charm key fetch failure attempts to fetch the signing key"
+assert_not_contains "$ubuntu_charm_key_fetch_failure_log_text" "apt-get args:install -y gum" "Ubuntu Charm key fetch failure does not install gum"
+assert_not_contains "$ubuntu_charm_key_fetch_failure_log_text" "terrapod args:setup" "Ubuntu Charm key fetch failure stops before Terrapod Setup"
+assert_not_contains "$ubuntu_charm_key_fetch_failure_log_text" "chezmoi args:apply" "Ubuntu Charm key fetch failure stops before initial apply"
 
 ubuntu_gum_failure_case="$(make_case_dir ubuntu-gum-failure)"
 write_uname_stub "$ubuntu_gum_failure_case" "Linux"


### PR DESCRIPTION
## Summary
- VPS Shell Profile first-run installer가 `Terrapod Setup` 전에 Charm APT repository를 추가하고 `gum`을 APT로 설치하도록 했습니다.
- Declared Ubuntu bootstrap에도 Charm repository와 `gum` install을 추가해 first-run side effect에만 의존하지 않게 했습니다.
- Charm signing key fetch 실패가 POSIX `sh` pipeline status에 가려지지 않도록 `curl` fetch와 `gpg --dearmor`를 분리하고 regression coverage를 추가했습니다.

## Why
Issue #69 requires `gum` to be prepared as the Bootstrap UI Dependency before setup runs on Ubuntu 24.04 VPS installs, with actionable failure guidance when Charm repository or `gum` setup fails.

Closes #69

## Validation
- `for test_file in tests/*_test.sh; do bash "$test_file" || exit 1; done; zsh tests/zshrc_zoxide_test.zsh`
- Spec compliance review: passed
- Code quality re-review: Ready to merge