### PR TITLE
Replace Terrapod Setup with gum-backed flow

### DIFF
--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -255,7 +255,7 @@ prompt_for_setup_preset() {
   fi
 
   if [ "$status" -eq 130 ]; then
-    fatal "no Terrapod Preset selected"
+    fatal "setup cancelled"
   fi
 
   if [ "$status" -ne 0 ]; then

--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -240,12 +240,26 @@ require_gum_setup() {
   fi
 }
 
+fatal_gum_setup_failure() {
+  fatal "gum failed during Terrapod Setup; fix gum and rerun 'terrapod setup'"
+}
+
 prompt_for_setup_preset() {
   profile="$1"
 
   set -- $(available_presets_for_profile "$profile")
-  if ! preset="$(gum choose --header "Choose Terrapod Preset" "$@")"; then
+  if preset="$(gum choose --header "Choose Terrapod Preset" "$@")"; then
+    status=0
+  else
+    status="$?"
+  fi
+
+  if [ "$status" -eq 130 ]; then
     fatal "no Terrapod Preset selected"
+  fi
+
+  if [ "$status" -ne 0 ]; then
+    fatal_gum_setup_failure
   fi
 
   if [ -z "$preset" ]; then
@@ -267,11 +281,21 @@ confirm_setup_write() {
   config_file="$1"
 
   if gum confirm "Write these Terrapod settings to $config_file?" --default=false; then
+    status=0
+  else
+    status="$?"
+  fi
+
+  if [ "$status" -eq 0 ]; then
     return 0
   fi
 
-  printf '%s\n' "terrapod: setup cancelled" >&2
-  return 1
+  if [ "$status" -eq 1 ] || [ "$status" -eq 130 ]; then
+    printf '%s\n' "terrapod: setup cancelled" >&2
+    return 1
+  fi
+
+  fatal_gum_setup_failure
 }
 
 prompt_setup_bool() {
@@ -290,7 +314,11 @@ prompt_setup_bool() {
     return
   fi
 
-  fatal "setup cancelled"
+  if [ "$status" -eq 130 ]; then
+    fatal "setup cancelled"
+  fi
+
+  fatal_gum_setup_failure
 }
 
 prompt_for_setup_settings() {

--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -202,86 +202,14 @@ available_preset_args() {
   printf '%s\n' "$preset_args"
 }
 
-available_preset_at_index() {
+available_presets_for_profile() {
   profile="$1"
-  wanted_index="$2"
-  index=1
 
   for preset in $(known_presets); do
     if is_preset_available_for_profile "$preset" "$profile"; then
-      if [ "$index" -eq "$wanted_index" ]; then
-        printf '%s\n' "$preset"
-        return 0
-      fi
-      index=$((index + 1))
+      printf '%s\n' "$preset"
     fi
   done
-
-  return 1
-}
-
-available_preset_count() {
-  profile="$1"
-  count=0
-
-  for preset in $(known_presets); do
-    if is_preset_available_for_profile "$preset" "$profile"; then
-      count=$((count + 1))
-    fi
-  done
-
-  printf '%s\n' "$count"
-}
-
-rich_next_index() {
-  current="$1"
-  count="$2"
-
-  if [ "$current" -ge "$count" ]; then
-    printf '%s\n' 1
-  else
-    printf '%s\n' "$((current + 1))"
-  fi
-}
-
-rich_previous_index() {
-  current="$1"
-  count="$2"
-
-  if [ "$current" -le 1 ]; then
-    printf '%s\n' "$count"
-  else
-    printf '%s\n' "$((current - 1))"
-  fi
-}
-
-rich_preset_index_for_input() {
-  profile="$1"
-  input="$2"
-  count="$(available_preset_count "$profile")"
-
-  case "$input" in
-    1|2|3)
-      if [ "$input" -le "$count" ]; then
-        printf '%s\n' "$input"
-        return 0
-      fi
-      return 1
-      ;;
-  esac
-
-  index=1
-  for preset in $(known_presets); do
-    if is_preset_available_for_profile "$preset" "$profile"; then
-      if [ "$input" = "$preset" ]; then
-        printf '%s\n' "$index"
-        return 0
-      fi
-      index=$((index + 1))
-    fi
-  done
-
-  return 1
 }
 
 profile_context_label() {
@@ -298,66 +226,27 @@ profile_context_label() {
   esac
 }
 
-setup_rich_presentation_enabled() {
-  case "${TERRAPOD_SETUP_PRESENTATION:-auto}" in
-    rich)
-      return 0
-      ;;
-    plain)
-      return 1
-      ;;
-    auto|"")
-      ;;
-    *)
-      fatal "unsupported TERRAPOD_SETUP_PRESENTATION: ${TERRAPOD_SETUP_PRESENTATION:-}"
-      ;;
-  esac
+require_gum_setup() {
+  if ! command -v gum >/dev/null 2>&1; then
+    printf '%s\n' "terrapod: gum is required before Terrapod Setup can run" >&2
+    printf '%s\n' "Install gum, then rerun Terrapod Setup. If you are bootstrapping Terrapod, rerun the installer before apply/setup." >&2
+    exit 1
+  fi
 
-  [ -t 0 ] || return 1
-  [ -t 2 ] || return 1
-  [ -n "${TERM:-}" ] || return 1
-  [ "${TERM:-}" != "dumb" ] || return 1
-  [ -z "${CI:-}" ] || return 1
-
-  return 0
-}
-
-setup_rich_color_enabled() {
-  setup_rich_presentation_enabled || return 1
-  [ -z "${NO_COLOR:-}" ] || return 1
-  return 0
-}
-
-setup_rich_text() {
-  color_code="$1"
-  text="$2"
-
-  if setup_rich_color_enabled; then
-    printf '\033[%sm%s\033[0m' "$color_code" "$text"
-  else
-    printf '%s' "$text"
+  if [ ! -t 0 ] || [ ! -t 2 ] || [ -z "${TERM:-}" ] || [ "${TERM:-}" = "dumb" ] || [ -n "${CI:-}" ]; then
+    printf '%s\n' "terrapod: Terrapod Setup requires an interactive terminal supported by gum" >&2
+    printf '%s\n' "Run 'terrapod setup' from a real terminal with TERM set, stdin/stderr attached to a TTY, and CI unset." >&2
+    exit 1
   fi
 }
 
 prompt_for_setup_preset() {
   profile="$1"
 
-  if setup_rich_presentation_enabled; then
-    prompt_for_setup_preset_rich "$profile"
-  else
-    prompt_for_setup_preset_plain "$profile"
-  fi
-}
-
-prompt_for_setup_preset_plain() {
-  profile="$1"
-  preset_args="$(available_preset_args "$profile")"
-
-  printf 'Choose Terrapod Preset (%s): ' "$preset_args" >&2
-  if ! IFS= read -r preset; then
+  set -- $(available_presets_for_profile "$profile")
+  if ! preset="$(gum choose --header "Choose Terrapod Preset" "$@")"; then
     fatal "no Terrapod Preset selected"
   fi
-  printf '\n' >&2
 
   if [ -z "$preset" ]; then
     fatal "no Terrapod Preset selected"
@@ -365,52 +254,6 @@ prompt_for_setup_preset_plain() {
 
   validate_preset_for_profile "$preset" "$profile"
   printf '%s\n' "$preset"
-}
-
-prompt_for_setup_preset_rich() {
-  profile="$1"
-  count="$(available_preset_count "$profile")"
-  selected=1
-
-  while :; do
-    printf '%s\n' "$(setup_rich_text 36 '🌱 Terrapod Setup') Preset" >&2
-    index=1
-    for preset in $(known_presets); do
-      if is_preset_available_for_profile "$preset" "$profile"; then
-        marker=" "
-        if [ "$index" -eq "$selected" ]; then
-          marker="$(setup_rich_text 32 '▸')"
-        fi
-        printf '%s %s. %s\n' "$marker" "$index" "$preset" >&2
-        index=$((index + 1))
-      fi
-    done
-
-    printf '%s ' "$(setup_rich_text 35 'Preset [j/k, number/name, Enter]')" >&2
-    if ! IFS= read -r answer; then
-      fatal "no Terrapod Preset selected"
-    fi
-
-    case "$answer" in
-      "")
-        available_preset_at_index "$profile" "$selected"
-        return
-        ;;
-      j|J|down|Down|DOWN|"$(printf '\033[B')")
-        selected="$(rich_next_index "$selected" "$count")"
-        ;;
-      k|K|up|Up|UP|"$(printf '\033[A')")
-        selected="$(rich_previous_index "$selected" "$count")"
-        ;;
-      *)
-        if next_selected="$(rich_preset_index_for_input "$profile" "$answer")"; then
-          available_preset_at_index "$profile" "$next_selected"
-          return
-        fi
-        printf '%s\n' "terrapod: choose a Preset with j/k, number, or name" >&2
-        ;;
-    esac
-  done
 }
 
 show_setup_settings_summary() {
@@ -423,62 +266,40 @@ show_setup_settings_summary() {
 confirm_setup_write() {
   config_file="$1"
 
-  printf 'Write these Terrapod settings to %s? [y/N] ' "$config_file" >&2
-  IFS= read -r answer || answer=
+  if gum confirm "Write these Terrapod settings to $config_file?" --default=false; then
+    return 0
+  fi
 
-  case "$answer" in
-    y|Y|yes|YES)
-      return 0
-      ;;
-    *)
-      printf '%s\n' "terrapod: setup cancelled" >&2
-      return 1
-      ;;
-  esac
+  printf '%s\n' "terrapod: setup cancelled" >&2
+  return 1
 }
 
 prompt_setup_bool() {
   label="$1"
   current="$2"
 
-  printf '%s [%s]: ' "$label" "$(bool_state_label "$current")" >&2
-  IFS= read -r answer || answer=
+  if gum confirm "$label" --default="$current"; then
+    printf '%s\n' "true"
+    return
+  else
+    status="$?"
+  fi
 
-  case "$answer" in
-    "")
-      printf '%s\n' "$current"
-      ;;
-    y|Y|yes|YES|true|TRUE|on|ON|1|enabled|ENABLED)
-      printf '%s\n' "true"
-      ;;
-    n|N|no|NO|false|FALSE|off|OFF|0|disabled|DISABLED)
-      printf '%s\n' "false"
-      ;;
-    *)
-      fatal "invalid answer for $label; enter y or n"
-      ;;
-  esac
+  if [ "$status" -eq 1 ]; then
+    printf '%s\n' "false"
+    return
+  fi
+
+  fatal "setup cancelled"
 }
 
 prompt_for_setup_settings() {
   preset="$1"
   profile="$2"
 
-  if setup_rich_presentation_enabled; then
-    prompt_for_setup_settings_rich "$preset" "$profile"
-  else
-    prompt_for_setup_settings_plain "$preset" "$profile"
-  fi
-}
-
-prompt_for_setup_settings_plain() {
-  preset="$1"
-  profile="$2"
-
   load_setup_defaults "$preset"
 
   printf '%s\n' "Customize Terrapod settings." >&2
-  printf '%s\n' "Press Enter to keep the value shown in brackets." >&2
 
   setup_enableDevelopmentWorkspace="$(prompt_setup_bool "Optional Development Workspace" "$setup_enableDevelopmentWorkspace")"
 
@@ -504,172 +325,6 @@ prompt_for_setup_settings_plain() {
     setup_enableMacosAppGroupLauncher=false
     setup_enableMacosAppGroupMonitoring=false
     printf '%s\n' "macOS App Groups: not applicable for $(profile_context_label)" >&2
-  fi
-
-  render_setup_data
-}
-
-rich_setup_field_count() {
-  profile="$1"
-
-  if is_enabled "$setup_enableDevelopmentWorkspace"; then
-    if [ "$profile" = "macos-terminal" ]; then
-      printf '%s\n' 5
-    else
-      printf '%s\n' 1
-    fi
-    return
-  fi
-
-  if [ "$profile" = "macos-terminal" ]; then
-    printf '%s\n' 7
-  else
-    printf '%s\n' 3
-  fi
-}
-
-rich_setup_field_name() {
-  profile="$1"
-  index="$2"
-
-  if is_enabled "$setup_enableDevelopmentWorkspace"; then
-    case "$index" in
-      1) printf '%s\n' "enableDevelopmentWorkspace" ;;
-      2) printf '%s\n' "enableMacosAppGroupTerminalApps" ;;
-      3) printf '%s\n' "enableMacosAppGroupAutomation" ;;
-      4) printf '%s\n' "enableMacosAppGroupLauncher" ;;
-      5) printf '%s\n' "enableMacosAppGroupMonitoring" ;;
-      *) return 1 ;;
-    esac
-    return
-  fi
-
-  case "$index" in
-    1) printf '%s\n' "enableDevelopmentWorkspace" ;;
-    2) printf '%s\n' "enableEditorStack" ;;
-    3) printf '%s\n' "enableAiCliTools" ;;
-    4) printf '%s\n' "enableMacosAppGroupTerminalApps" ;;
-    5) printf '%s\n' "enableMacosAppGroupAutomation" ;;
-    6) printf '%s\n' "enableMacosAppGroupLauncher" ;;
-    7) printf '%s\n' "enableMacosAppGroupMonitoring" ;;
-    *) return 1 ;;
-  esac
-}
-
-rich_setup_field_label() {
-  case "$1" in
-    enableDevelopmentWorkspace) printf '%s\n' "Optional Development Workspace" ;;
-    enableEditorStack) printf '%s\n' "Optional Editor Stack" ;;
-    enableAiCliTools) printf '%s\n' "Optional AI Tool Stack" ;;
-    enableMacosAppGroupTerminalApps) printf '%s\n' "terminal-apps macOS App Group" ;;
-    enableMacosAppGroupAutomation) printf '%s\n' "automation macOS App Group" ;;
-    enableMacosAppGroupLauncher) printf '%s\n' "launcher macOS App Group" ;;
-    enableMacosAppGroupMonitoring) printf '%s\n' "monitoring macOS App Group" ;;
-    *) return 1 ;;
-  esac
-}
-
-rich_setup_field_value() {
-  eval "printf '%s\n' \"\$setup_$1\""
-}
-
-rich_set_setup_field_value() {
-  field="$1"
-  value="$2"
-
-  eval "setup_$field=\$value"
-
-  if [ "$field" = "enableDevelopmentWorkspace" ] && is_enabled "$value"; then
-    setup_enableEditorStack=true
-    setup_enableAiCliTools=true
-  fi
-}
-
-prompt_for_setup_settings_rich() {
-  preset="$1"
-  profile="$2"
-
-  load_setup_defaults "$preset"
-  selected=1
-
-  while :; do
-    count="$(rich_setup_field_count "$profile")"
-    if [ "$selected" -gt "$count" ]; then
-      selected="$count"
-    fi
-
-    printf '%s\n' "$(setup_rich_text 36 '✨ Setup settings')" >&2
-
-    index=1
-    while [ "$index" -le "$count" ]; do
-      field="$(rich_setup_field_name "$profile" "$index")"
-      label="$(rich_setup_field_label "$field")"
-      value="$(rich_setup_field_value "$field")"
-      marker=" "
-      if [ "$index" -eq "$selected" ]; then
-        marker="$(setup_rich_text 32 '▸')"
-      fi
-      printf '%s %s [%s]\n' "$marker" "$label" "$(bool_state_label "$value")" >&2
-      index=$((index + 1))
-    done
-
-    if is_enabled "$setup_enableDevelopmentWorkspace"; then
-      printf '%s\n' "  Optional Editor Stack: included by Optional Development Workspace" >&2
-      printf '%s\n' "  Optional AI Tool Stack: included by Optional Development Workspace" >&2
-    fi
-
-    if [ "$profile" != "macos-terminal" ]; then
-      printf '%s\n' "  macOS App Groups: not applicable for $(profile_context_label)" >&2
-    fi
-
-    printf '%s ' "$(setup_rich_text 35 'Settings [j/k, t, y/n, Enter]')" >&2
-    if ! IFS= read -r answer; then
-      break
-    fi
-
-    case "$answer" in
-      "")
-        break
-        ;;
-      j|J|down|Down|DOWN|"$(printf '\033[B')")
-        selected="$(rich_next_index "$selected" "$count")"
-        ;;
-      k|K|up|Up|UP|"$(printf '\033[A')")
-        selected="$(rich_previous_index "$selected" "$count")"
-        ;;
-      t|T|" ")
-        field="$(rich_setup_field_name "$profile" "$selected")"
-        value="$(rich_setup_field_value "$field")"
-        if is_enabled "$value"; then
-          rich_set_setup_field_value "$field" false
-        else
-          rich_set_setup_field_value "$field" true
-        fi
-        ;;
-      y|Y|yes|YES|true|TRUE|on|ON|1|enabled|ENABLED)
-        field="$(rich_setup_field_name "$profile" "$selected")"
-        rich_set_setup_field_value "$field" true
-        ;;
-      n|N|no|NO|false|FALSE|off|OFF|0|disabled|DISABLED)
-        field="$(rich_setup_field_name "$profile" "$selected")"
-        rich_set_setup_field_value "$field" false
-        ;;
-      *)
-        printf '%s\n' "terrapod: use j/k, t, y/n, or Enter for setup settings" >&2
-        ;;
-    esac
-  done
-
-  if is_enabled "$setup_enableDevelopmentWorkspace"; then
-    setup_enableEditorStack=true
-    setup_enableAiCliTools=true
-  fi
-
-  if [ "$profile" != "macos-terminal" ]; then
-    setup_enableMacosAppGroupTerminalApps=false
-    setup_enableMacosAppGroupAutomation=false
-    setup_enableMacosAppGroupLauncher=false
-    setup_enableMacosAppGroupMonitoring=false
   fi
 
   render_setup_data
@@ -1903,6 +1558,8 @@ run_setup() {
 
   profile="$(current_profile)"
   config_file="$(chezmoi_config_file)"
+
+  require_gum_setup
 
   printf '%s\n' "Terrapod setup"
   printf '%s\n' "Profile: $(profile_context_label)"

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -67,6 +67,10 @@ case "${1:-}" in
     if [ "$response" = "__CANCEL__" ]; then
       exit 130
     fi
+    if [ "$response" = "__ERROR__" ]; then
+      printf '%s\n' "simulated gum operational failure" >&2
+      exit 2
+    fi
     printf '%s\n' "$response"
     ;;
   confirm)
@@ -80,6 +84,10 @@ case "${1:-}" in
         ;;
       __CANCEL__)
         exit 130
+        ;;
+      __ERROR__)
+        printf '%s\n' "simulated gum operational failure" >&2
+        exit 2
         ;;
       *)
         printf '%s\n' "unexpected gum confirm response: $response" >&2
@@ -105,6 +113,26 @@ write_gum_responses() {
   for response do
     printf '%s\n' "$response" >>"$responses_file"
   done
+}
+
+shell_quote() {
+  printf "'"
+  printf '%s' "$1" | sed "s/'/'\\\\''/g"
+  printf "'"
+}
+
+run_setup_in_pty() {
+  profile="$1"
+  term="$2"
+  home_dir="$3"
+  xdg_config_home="$4"
+
+  if script --version >/dev/null 2>&1; then
+    command_text="env TERM=$(shell_quote "$term") TERRAPOD_PROFILE=$(shell_quote "$profile") TERRAPOD_CHEZMOI_CONFIG= HOME=$(shell_quote "$home_dir") XDG_CONFIG_HOME=$(shell_quote "$xdg_config_home") sh $(shell_quote "$terrapod") setup"
+    script -q -e -c "$command_text" /dev/null
+  else
+    script -q /dev/null env TERM="$term" TERRAPOD_PROFILE="$profile" TERRAPOD_CHEZMOI_CONFIG= HOME="$home_dir" XDG_CONFIG_HOME="$xdg_config_home" sh "$terrapod" setup
+  fi
 }
 
 assert_contains() {
@@ -198,7 +226,7 @@ run_terrapod_setup_command() {
 
   TERRAPOD_GUM_RESPONSES="$responses_file" TERRAPOD_GUM_LOG="$gum_log" \
     PATH="$tmp_dir/bin:/usr/bin:/bin" \
-    script -q /dev/null env TERM=xterm TERRAPOD_PROFILE="$profile" TERRAPOD_CHEZMOI_CONFIG= HOME="$home_dir" XDG_CONFIG_HOME="$xdg_config_home" sh "$terrapod" setup >"$output_file" 2>&1
+    run_setup_in_pty "$profile" xterm "$home_dir" "$xdg_config_home" >"$output_file" 2>&1
 }
 
 assert_call_args() {
@@ -526,7 +554,7 @@ mkdir -p "$dumb_setup_home"
 
 if TERRAPOD_GUM_RESPONSES="$tmp_dir/dumb.responses" TERRAPOD_GUM_LOG="$tmp_dir/dumb-gum.log" \
   PATH="$tmp_dir/bin:/usr/bin:/bin" \
-  script -q /dev/null env TERM=dumb TERRAPOD_PROFILE=macos-terminal TERRAPOD_CHEZMOI_CONFIG= HOME="$dumb_setup_home" XDG_CONFIG_HOME="$dumb_setup_xdg" sh "$terrapod" setup >"$dumb_setup_output" 2>&1; then
+  run_setup_in_pty macos-terminal dumb "$dumb_setup_home" "$dumb_setup_xdg" >"$dumb_setup_output" 2>&1; then
   sed 's/^/  /' "$dumb_setup_output" >&2
   fail "TERM=dumb setup fails instead of falling back to plain prompts"
 fi
@@ -563,6 +591,32 @@ fi
 pass "VPS rejected setup does not write config"
 
 assert_no_terrapod_artifacts_under "$vps_setup_xdg" "VPS rejected setup leaves no Terrapod artifacts"
+
+gum_error_home="$tmp_dir/gum-error-home"
+gum_error_xdg="$tmp_dir/gum-error-xdg"
+gum_error_output="$tmp_dir/gum-error.out"
+gum_error_responses="$tmp_dir/gum-error.responses"
+gum_error_gum_log="$tmp_dir/gum-error-gum.log"
+gum_error_config="$gum_error_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$gum_error_home"
+write_gum_responses "$gum_error_responses" minimal __ERROR__
+
+if run_terrapod_setup_command macos-terminal "$gum_error_responses" "$gum_error_home" "$gum_error_xdg" "$gum_error_output" "$gum_error_gum_log"; then
+  fail "setup fails when gum returns an operational error"
+fi
+pass "setup fails when gum returns an operational error"
+
+gum_error_output_text="$(cat "$gum_error_output")"
+assert_contains "$gum_error_output_text" "gum failed during Terrapod Setup" "gum operational error explains gum failure"
+assert_contains "$gum_error_output_text" "rerun 'terrapod setup'" "gum operational error gives rerun guidance"
+assert_not_contains "$gum_error_output_text" "setup cancelled" "gum operational error is not reported as cancellation"
+
+if [ -e "$gum_error_config" ]; then
+  fail "gum operational error does not write config"
+fi
+pass "gum operational error does not write config"
+
+assert_no_terrapod_artifacts_under "$gum_error_xdg" "gum operational error leaves no Terrapod artifacts"
 
 missing_gum_home="$tmp_dir/missing-gum-home"
 missing_gum_xdg="$tmp_dir/missing-gum-xdg"

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -592,6 +592,31 @@ pass "VPS rejected setup does not write config"
 
 assert_no_terrapod_artifacts_under "$vps_setup_xdg" "VPS rejected setup leaves no Terrapod artifacts"
 
+preset_cancel_home="$tmp_dir/preset-cancel-home"
+preset_cancel_xdg="$tmp_dir/preset-cancel-xdg"
+preset_cancel_output="$tmp_dir/preset-cancel.out"
+preset_cancel_responses="$tmp_dir/preset-cancel.responses"
+preset_cancel_gum_log="$tmp_dir/preset-cancel-gum.log"
+preset_cancel_config="$preset_cancel_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$preset_cancel_home"
+write_gum_responses "$preset_cancel_responses" __CANCEL__
+
+if run_terrapod_setup_command macos-terminal "$preset_cancel_responses" "$preset_cancel_home" "$preset_cancel_xdg" "$preset_cancel_output" "$preset_cancel_gum_log"; then
+  fail "Preset selection cancellation exits non-zero"
+fi
+pass "Preset selection cancellation exits non-zero"
+
+preset_cancel_output_text="$(cat "$preset_cancel_output")"
+assert_contains "$preset_cancel_output_text" "setup cancelled" "Preset selection cancellation preserves setup cancellation guidance"
+assert_not_contains "$preset_cancel_output_text" "no Terrapod Preset selected" "Preset selection cancellation is not reported as missing selection"
+
+if [ -e "$preset_cancel_config" ]; then
+  fail "Preset selection cancellation does not write config"
+fi
+pass "Preset selection cancellation does not write config"
+
+assert_no_terrapod_artifacts_under "$preset_cancel_xdg" "Preset selection cancellation leaves no Terrapod artifacts"
+
 gum_error_home="$tmp_dir/gum-error-home"
 gum_error_xdg="$tmp_dir/gum-error-xdg"
 gum_error_output="$tmp_dir/gum-error.out"

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -28,6 +28,85 @@ write_stub() {
   chmod +x "$path"
 }
 
+write_gum_stub() {
+  path="$1"
+
+  cat >"$path" <<'SH'
+#!/bin/sh
+set -eu
+
+log_file="${TERRAPOD_GUM_LOG:?}"
+responses_file="${TERRAPOD_GUM_RESPONSES:?}"
+
+printf '%s' "gum args:" >>"$log_file"
+for arg do
+  printf '%s' " $arg" >>"$log_file"
+done
+printf '\n' >>"$log_file"
+
+if [ "${1:-}" = "--version" ]; then
+  printf '%s\n' "gum test stub"
+  exit 0
+fi
+
+next_response() {
+  response="$(sed -n '1p' "$responses_file")"
+  sed '1d' "$responses_file" >"$responses_file.tmp"
+  mv "$responses_file.tmp" "$responses_file"
+
+  if [ -z "$response" ]; then
+    exit 130
+  fi
+
+  printf '%s\n' "$response"
+}
+
+case "${1:-}" in
+  choose)
+    response="$(next_response)"
+    if [ "$response" = "__CANCEL__" ]; then
+      exit 130
+    fi
+    printf '%s\n' "$response"
+    ;;
+  confirm)
+    response="$(next_response)"
+    case "$response" in
+      yes|y|true|enabled)
+        exit 0
+        ;;
+      no|n|false|disabled)
+        exit 1
+        ;;
+      __CANCEL__)
+        exit 130
+        ;;
+      *)
+        printf '%s\n' "unexpected gum confirm response: $response" >&2
+        exit 2
+        ;;
+    esac
+    ;;
+  *)
+    printf '%s\n' "unexpected gum command: ${1:-}" >&2
+    exit 2
+    ;;
+esac
+SH
+
+  chmod +x "$path"
+}
+
+write_gum_responses() {
+  responses_file="$1"
+  shift
+
+  : >"$responses_file"
+  for response do
+    printf '%s\n' "$response" >>"$responses_file"
+  done
+}
+
 assert_contains() {
   haystack="$1"
   needle="$2"
@@ -111,25 +190,15 @@ assert_first_occurrence_before() {
 
 run_terrapod_setup_command() {
   profile="$1"
-  input="$2"
+  responses_file="$2"
   home_dir="$3"
   xdg_config_home="$4"
   output_file="$5"
+  gum_log="$6"
 
-  printf '%s' "$input" |
-    TERRAPOD_PROFILE="$profile" TERRAPOD_CHEZMOI_CONFIG= HOME="$home_dir" XDG_CONFIG_HOME="$xdg_config_home" sh "$terrapod" setup >"$output_file" 2>&1
-}
-
-run_terrapod_setup_command_with_presentation() {
-  presentation="$1"
-  profile="$2"
-  input="$3"
-  home_dir="$4"
-  xdg_config_home="$5"
-  output_file="$6"
-
-  printf '%s' "$input" |
-    TERRAPOD_SETUP_PRESENTATION="$presentation" TERRAPOD_PROFILE="$profile" TERRAPOD_CHEZMOI_CONFIG= HOME="$home_dir" XDG_CONFIG_HOME="$xdg_config_home" sh "$terrapod" setup >"$output_file" 2>&1
+  TERRAPOD_GUM_RESPONSES="$responses_file" TERRAPOD_GUM_LOG="$gum_log" \
+    PATH="$tmp_dir/bin:/usr/bin:/bin" \
+    script -q /dev/null env TERM=xterm TERRAPOD_PROFILE="$profile" TERRAPOD_CHEZMOI_CONFIG= HOME="$home_dir" XDG_CONFIG_HOME="$xdg_config_home" sh "$terrapod" setup >"$output_file" 2>&1
 }
 
 assert_call_args() {
@@ -230,6 +299,7 @@ assert_no_terrapod_artifacts_under() {
 }
 
 mkdir -p "$tmp_dir/bin" "$tmp_dir/home"
+write_gum_stub "$tmp_dir/bin/gum"
 
 terrapod="$repo_root/dot_local/bin/executable_terrapod"
 tpod_source="$repo_root/dot_local/bin/symlink_tpod"
@@ -412,109 +482,80 @@ assert_contains \
 setup_home="$tmp_dir/setup-home"
 setup_xdg="$tmp_dir/setup-xdg"
 setup_output="$tmp_dir/setup.out"
+setup_responses="$tmp_dir/setup.responses"
+setup_gum_log="$tmp_dir/setup-gum.log"
 setup_config="$setup_xdg/chezmoi/chezmoi.toml"
 mkdir -p "$setup_home"
+write_gum_responses "$setup_responses" workstation yes yes yes yes yes yes
 
-if ! run_terrapod_setup_command macos-terminal 'workstation
-
-
-
-
-
-y
-' "$setup_home" "$setup_xdg" "$setup_output"; then
+if ! run_terrapod_setup_command macos-terminal "$setup_responses" "$setup_home" "$setup_xdg" "$setup_output" "$setup_gum_log"; then
   sed 's/^/  /' "$setup_output" >&2
-  fail "macOS Terminal Profile setup prompts for customization before final confirmation and completes with workstation"
+  fail "macOS Terminal Profile setup uses gum prompts before final confirmation and completes with workstation"
 fi
-pass "macOS Terminal Profile setup prompts for customization before final confirmation and completes with workstation"
+pass "macOS Terminal Profile setup uses gum prompts before final confirmation and completes with workstation"
 
 setup_output_text="$(cat "$setup_output")"
-assert_contains "$setup_output_text" "Terrapod setup" "plain setup prints a command heading"
-assert_contains "$setup_output_text" "Profile: macOS Terminal Profile" "plain setup shows detected macOS profile"
-assert_contains "$setup_output_text" "Choose Terrapod Preset (minimal|development|workstation):" "plain setup shows macOS Preset choices"
-assert_contains "$setup_output_text" "Settings to write:" "plain setup shows concrete settings summary"
-assert_contains "$setup_output_text" "Customize Terrapod settings." "plain setup offers concrete setting customization"
-assert_contains "$setup_output_text" "Optional Development Workspace [enabled]:" "plain setup prompts for Optional Development Workspace"
-assert_contains "$setup_output_text" "Optional Editor Stack: included by Optional Development Workspace" "plain setup presents workspace-included Optional Editor Stack"
-assert_contains "$setup_output_text" "terminal-apps macOS App Group [enabled]:" "plain setup prompts for terminal-apps macOS App Group"
-assert_contains "$setup_output_text" "enableEditorStack = true" "plain setup summary includes concrete Editor Stack setting"
-assert_contains "$setup_output_text" "enableMacosAppGroupMonitoring = true" "plain setup summary includes concrete macOS App Group setting"
-assert_contains "$setup_output_text" "Write these Terrapod settings" "plain setup asks for final confirmation"
-assert_contains "$setup_output_text" "Configured Terrapod Preset 'workstation'" "plain setup reports successful configuration"
-assert_first_occurrence_before "$setup_output_text" "Profile: macOS Terminal Profile" "Choose Terrapod Preset" "plain setup shows profile before Preset selection"
-assert_first_occurrence_before "$setup_output_text" "Choose Terrapod Preset" "Customize Terrapod settings." "plain setup customizes settings after Preset selection"
-assert_first_occurrence_before "$setup_output_text" "Customize Terrapod settings." "Settings to write:" "plain setup shows customized settings before summary"
-assert_first_occurrence_before "$setup_output_text" "Settings to write:" "Write these Terrapod settings" "plain setup shows summary before final confirmation"
+setup_gum_log_text="$(cat "$setup_gum_log")"
+assert_contains "$setup_output_text" "Terrapod setup" "gum setup prints a command heading"
+assert_contains "$setup_output_text" "Profile: macOS Terminal Profile" "gum setup shows detected macOS profile"
+assert_contains "$setup_output_text" "Settings to write:" "gum setup shows concrete settings summary"
+assert_contains "$setup_output_text" "Customize Terrapod settings." "gum setup offers sequential setting customization"
+assert_contains "$setup_output_text" "Optional Editor Stack: included by Optional Development Workspace" "gum setup presents workspace-included Optional Editor Stack"
+assert_contains "$setup_output_text" "enableEditorStack = true" "gum setup summary includes concrete Editor Stack setting"
+assert_contains "$setup_output_text" "enableMacosAppGroupMonitoring = true" "gum setup summary includes concrete macOS App Group setting"
+assert_contains "$setup_output_text" "Configured Terrapod Preset 'workstation'" "gum setup reports successful configuration"
+assert_contains "$setup_gum_log_text" "gum args: choose" "gum setup uses gum choose for Preset selection"
+assert_contains "$setup_gum_log_text" "minimal" "gum setup offers minimal Preset"
+assert_contains "$setup_gum_log_text" "development" "gum setup offers development Preset"
+assert_contains "$setup_gum_log_text" "workstation" "gum setup offers workstation Preset"
+assert_contains "$setup_gum_log_text" "gum args: confirm Optional Development Workspace" "gum setup asks Optional Development Workspace with gum confirm"
+assert_contains "$setup_gum_log_text" "gum args: confirm terminal-apps macOS App Group" "gum setup asks terminal-apps macOS App Group with gum confirm"
+assert_contains "$setup_gum_log_text" "gum args: confirm Write these Terrapod settings" "gum setup asks final confirmation with gum confirm"
+assert_first_occurrence_before "$setup_output_text" "Profile: macOS Terminal Profile" "Customize Terrapod settings." "gum setup shows profile before settings customization"
+assert_first_occurrence_before "$setup_output_text" "Customize Terrapod settings." "Settings to write:" "gum setup shows customized settings before summary"
 
 if [ ! -f "$setup_config" ]; then
-  fail "plain setup writes config after final confirmation"
+  fail "gum setup writes config after final confirmation"
 fi
-pass "plain setup writes config after final confirmation"
-
-assert_no_ansi_escape "$setup_output_text" "auto setup fallback does not use ANSI color with piped input"
-assert_no_rich_setup_emoji "$setup_output_text" "auto setup fallback does not use rich setup emoji with piped input"
+pass "gum setup writes config after final confirmation"
 
 dumb_setup_home="$tmp_dir/dumb-setup-home"
 dumb_setup_xdg="$tmp_dir/dumb-setup-xdg"
 dumb_setup_output="$tmp_dir/dumb-setup.out"
 mkdir -p "$dumb_setup_home"
 
-if ! printf '%s' 'minimal
-n
-n
-n
-n
-n
-n
-n
-y
-' |
-  TERM=dumb TERRAPOD_PROFILE=macos-terminal TERRAPOD_CHEZMOI_CONFIG= HOME="$dumb_setup_home" XDG_CONFIG_HOME="$dumb_setup_xdg" sh "$terrapod" setup >"$dumb_setup_output" 2>&1; then
+if TERRAPOD_GUM_RESPONSES="$tmp_dir/dumb.responses" TERRAPOD_GUM_LOG="$tmp_dir/dumb-gum.log" \
+  PATH="$tmp_dir/bin:/usr/bin:/bin" \
+  script -q /dev/null env TERM=dumb TERRAPOD_PROFILE=macos-terminal TERRAPOD_CHEZMOI_CONFIG= HOME="$dumb_setup_home" XDG_CONFIG_HOME="$dumb_setup_xdg" sh "$terrapod" setup >"$dumb_setup_output" 2>&1; then
   sed 's/^/  /' "$dumb_setup_output" >&2
-  fail "TERM=dumb setup uses plain fallback"
+  fail "TERM=dumb setup fails instead of falling back to plain prompts"
 fi
-pass "TERM=dumb setup uses plain fallback"
+pass "TERM=dumb setup fails instead of falling back to plain prompts"
 
 dumb_setup_output_text="$(cat "$dumb_setup_output")"
-assert_contains "$dumb_setup_output_text" "Choose Terrapod Preset (minimal|development|workstation):" "TERM=dumb setup keeps plain Preset prompt"
-assert_no_ansi_escape "$dumb_setup_output_text" "TERM=dumb setup does not use ANSI color"
-assert_no_rich_setup_emoji "$dumb_setup_output_text" "TERM=dumb setup does not use rich setup emoji"
-
-rich_setup_home="$tmp_dir/rich-setup-home"
-rich_setup_xdg="$tmp_dir/rich-setup-xdg"
-rich_setup_output="$tmp_dir/rich-setup.out"
-mkdir -p "$rich_setup_home"
-
-if ! run_terrapod_setup_command_with_presentation rich macos-terminal '1
-
-y
-' "$rich_setup_home" "$rich_setup_xdg" "$rich_setup_output"; then
-  sed 's/^/  /' "$rich_setup_output" >&2
-  fail "forced rich setup uses rich prompt path"
-fi
-pass "forced rich setup uses rich prompt path"
-
-rich_setup_output_text="$(cat "$rich_setup_output")"
-assert_contains "$rich_setup_output_text" "Terrapod Setup" "rich setup shows setup-only rich heading"
-assert_contains "$rich_setup_output_text" "Preset [j/k, number/name, Enter]" "rich setup shows keyboard Preset controls"
-assert_contains "$rich_setup_output_text" "Settings [j/k, t, y/n, Enter]" "rich setup shows keyboard setting controls"
+assert_contains "$dumb_setup_output_text" "requires an interactive terminal supported by gum" "TERM=dumb setup explains unsupported terminal environment"
 
 vps_setup_home="$tmp_dir/vps-setup-home"
 vps_setup_xdg="$tmp_dir/vps-setup-xdg"
 vps_setup_output="$tmp_dir/vps-setup.out"
+vps_setup_responses="$tmp_dir/vps-setup.responses"
+vps_setup_gum_log="$tmp_dir/vps-setup-gum.log"
 mkdir -p "$vps_setup_home"
+write_gum_responses "$vps_setup_responses" workstation
 
-if run_terrapod_setup_command vps-shell 'workstation
-y
-' "$vps_setup_home" "$vps_setup_xdg" "$vps_setup_output"; then
+if run_terrapod_setup_command vps-shell "$vps_setup_responses" "$vps_setup_home" "$vps_setup_xdg" "$vps_setup_output" "$vps_setup_gum_log"; then
   fail "VPS Shell Profile setup rejects workstation Preset"
 fi
 pass "VPS Shell Profile setup rejects workstation Preset"
 
 vps_setup_output_text="$(cat "$vps_setup_output")"
 assert_contains "$vps_setup_output_text" "Profile: VPS Shell Profile" "VPS setup shows detected profile before rejection"
-assert_contains "$vps_setup_output_text" "Choose Terrapod Preset (minimal|development):" "VPS setup hides workstation from choices"
 assert_contains "$vps_setup_output_text" "workstation Preset is only available for the macOS Terminal Profile" "VPS setup explains workstation rejection"
+vps_setup_gum_log_text="$(cat "$vps_setup_gum_log")"
+assert_contains "$vps_setup_gum_log_text" "gum args: choose" "VPS setup uses gum choose for Preset selection"
+assert_contains "$vps_setup_gum_log_text" "minimal" "VPS setup offers minimal Preset"
+assert_contains "$vps_setup_gum_log_text" "development" "VPS setup offers development Preset"
+assert_not_contains "$vps_setup_gum_log_text" "workstation" "VPS setup does not offer workstation Preset"
 
 if [ -e "$vps_setup_xdg/chezmoi/chezmoi.toml" ]; then
   fail "VPS rejected setup does not write config"
@@ -522,6 +563,34 @@ fi
 pass "VPS rejected setup does not write config"
 
 assert_no_terrapod_artifacts_under "$vps_setup_xdg" "VPS rejected setup leaves no Terrapod artifacts"
+
+missing_gum_home="$tmp_dir/missing-gum-home"
+missing_gum_xdg="$tmp_dir/missing-gum-xdg"
+missing_gum_output="$tmp_dir/missing-gum.out"
+mkdir -p "$missing_gum_home"
+
+if PATH="/usr/bin:/bin" TERRAPOD_PROFILE=macos-terminal TERRAPOD_CHEZMOI_CONFIG= HOME="$missing_gum_home" XDG_CONFIG_HOME="$missing_gum_xdg" sh "$terrapod" setup >"$missing_gum_output" 2>&1; then
+  fail "setup fails when gum is missing"
+fi
+pass "setup fails when gum is missing"
+
+missing_gum_output_text="$(cat "$missing_gum_output")"
+assert_contains "$missing_gum_output_text" "gum is required before Terrapod Setup can run" "missing gum setup explains gum requirement"
+assert_contains "$missing_gum_output_text" "Install gum, then rerun Terrapod Setup" "missing gum setup gives rerun guidance"
+
+noninteractive_setup_home="$tmp_dir/noninteractive-setup-home"
+noninteractive_setup_xdg="$tmp_dir/noninteractive-setup-xdg"
+noninteractive_setup_output="$tmp_dir/noninteractive-setup.out"
+mkdir -p "$noninteractive_setup_home"
+
+if TERRAPOD_GUM_RESPONSES="$tmp_dir/noninteractive.responses" TERRAPOD_GUM_LOG="$tmp_dir/noninteractive-gum.log" \
+  PATH="$tmp_dir/bin:/usr/bin:/bin" TERM=xterm TERRAPOD_PROFILE=macos-terminal TERRAPOD_CHEZMOI_CONFIG= HOME="$noninteractive_setup_home" XDG_CONFIG_HOME="$noninteractive_setup_xdg" sh "$terrapod" setup >"$noninteractive_setup_output" 2>&1 </dev/null; then
+  fail "setup fails when stdin is not interactive"
+fi
+pass "setup fails when stdin is not interactive"
+
+noninteractive_setup_output_text="$(cat "$noninteractive_setup_output")"
+assert_contains "$noninteractive_setup_output_text" "requires an interactive terminal supported by gum" "non-interactive setup explains terminal requirement"
 
 assert_contains \
   "$help_output" \

--- a/tests/terrapod_config_test.sh
+++ b/tests/terrapod_config_test.sh
@@ -67,6 +67,10 @@ case "${1:-}" in
     if [ -z "$response" ] || [ "$response" = "__CANCEL__" ]; then
       exit 130
     fi
+    if [ "$response" = "__ERROR__" ]; then
+      printf '%s\n' "simulated gum operational failure" >&2
+      exit 2
+    fi
     printf '%s\n' "$response"
     ;;
   confirm)
@@ -85,6 +89,10 @@ case "${1:-}" in
       __CANCEL__)
         exit 130
         ;;
+      __ERROR__)
+        printf '%s\n' "simulated gum operational failure" >&2
+        exit 2
+        ;;
       *)
         printf '%s\n' "unexpected gum confirm response: $response" >&2
         exit 2
@@ -99,6 +107,26 @@ esac
 SH
 
   chmod +x "$path"
+}
+
+shell_quote() {
+  printf "'"
+  printf '%s' "$1" | sed "s/'/'\\\\''/g"
+  printf "'"
+}
+
+run_setup_in_pty() {
+  profile="$1"
+  term="$2"
+  home_dir="$3"
+  xdg_config_home="$4"
+
+  if script --version >/dev/null 2>&1; then
+    command_text="env TERM=$(shell_quote "$term") TERRAPOD_PROFILE=$(shell_quote "$profile") TERRAPOD_CHEZMOI_CONFIG= HOME=$(shell_quote "$home_dir") XDG_CONFIG_HOME=$(shell_quote "$xdg_config_home") sh $(shell_quote "$terrapod") setup"
+    script -q -e -c "$command_text" /dev/null
+  else
+    script -q /dev/null env TERM="$term" TERRAPOD_PROFILE="$profile" TERRAPOD_CHEZMOI_CONFIG= HOME="$home_dir" XDG_CONFIG_HOME="$xdg_config_home" sh "$terrapod" setup
+  fi
 }
 
 assert_contains() {
@@ -348,7 +376,7 @@ run_terrapod_setup() {
 
   TERRAPOD_GUM_RESPONSES="$responses_file" TERRAPOD_GUM_LOG="$gum_log" \
     PATH="$tmp_dir/bin:/usr/bin:/bin:$PATH" \
-    script -q /dev/null env TERM=xterm TERRAPOD_PROFILE="$profile" TERRAPOD_CHEZMOI_CONFIG= HOME="$home_dir" XDG_CONFIG_HOME="$xdg_config_home" sh "$terrapod" setup
+    run_setup_in_pty "$profile" xterm "$home_dir" "$xdg_config_home"
 }
 
 terrapod="$repo_root/dot_local/bin/executable_terrapod"

--- a/tests/terrapod_config_test.sh
+++ b/tests/terrapod_config_test.sh
@@ -18,6 +18,89 @@ pass() {
   printf '%s\n' "ok - $1"
 }
 
+write_gum_stub() {
+  path="$1"
+
+  cat >"$path" <<'SH'
+#!/bin/sh
+set -eu
+
+log_file="${TERRAPOD_GUM_LOG:?}"
+responses_file="${TERRAPOD_GUM_RESPONSES:?}"
+
+printf '%s' "gum args:" >>"$log_file"
+for arg do
+  printf '%s' " $arg" >>"$log_file"
+done
+printf '\n' >>"$log_file"
+
+if [ "${1:-}" = "--version" ]; then
+  printf '%s\n' "gum test stub"
+  exit 0
+fi
+
+next_response() {
+  response="$(sed -n '1p' "$responses_file")"
+  sed '1d' "$responses_file" >"$responses_file.tmp"
+  mv "$responses_file.tmp" "$responses_file"
+  printf '%s\n' "$response"
+}
+
+confirm_default_status() {
+  for arg do
+    case "$arg" in
+      --default=true)
+        return 0
+        ;;
+      --default=false)
+        return 1
+        ;;
+    esac
+  done
+
+  return 1
+}
+
+case "${1:-}" in
+  choose)
+    response="$(next_response)"
+    if [ -z "$response" ] || [ "$response" = "__CANCEL__" ]; then
+      exit 130
+    fi
+    printf '%s\n' "$response"
+    ;;
+  confirm)
+    response="$(next_response)"
+    case "$response" in
+      "")
+        shift
+        confirm_default_status "$@"
+        ;;
+      yes|y|true|enabled)
+        exit 0
+        ;;
+      no|n|false|disabled)
+        exit 1
+        ;;
+      __CANCEL__)
+        exit 130
+        ;;
+      *)
+        printf '%s\n' "unexpected gum confirm response: $response" >&2
+        exit 2
+        ;;
+    esac
+    ;;
+  *)
+    printf '%s\n' "unexpected gum command: ${1:-}" >&2
+    exit 2
+    ;;
+esac
+SH
+
+  chmod +x "$path"
+}
+
 assert_contains() {
   file="$1"
   needle="$2"
@@ -258,22 +341,19 @@ run_terrapod_setup() {
   input="$2"
   home_dir="$3"
   xdg_config_home="$4"
+  responses_file="$(mktemp "$tmp_dir/setup-responses.XXXXXX")"
+  gum_log="$(mktemp "$tmp_dir/setup-gum-log.XXXXXX")"
 
-  printf '%s' "$input" |
-    TERRAPOD_PROFILE="$profile" TERRAPOD_CHEZMOI_CONFIG= HOME="$home_dir" XDG_CONFIG_HOME="$xdg_config_home" sh "$terrapod" setup
-}
+  printf '%s' "$input" >"$responses_file"
 
-run_terrapod_setup_rich() {
-  profile="$1"
-  input="$2"
-  home_dir="$3"
-  xdg_config_home="$4"
-
-  printf '%s' "$input" |
-    TERRAPOD_SETUP_PRESENTATION=rich TERRAPOD_PROFILE="$profile" TERRAPOD_CHEZMOI_CONFIG= HOME="$home_dir" XDG_CONFIG_HOME="$xdg_config_home" sh "$terrapod" setup
+  TERRAPOD_GUM_RESPONSES="$responses_file" TERRAPOD_GUM_LOG="$gum_log" \
+    PATH="$tmp_dir/bin:/usr/bin:/bin:$PATH" \
+    script -q /dev/null env TERM=xterm TERRAPOD_PROFILE="$profile" TERRAPOD_CHEZMOI_CONFIG= HOME="$home_dir" XDG_CONFIG_HOME="$xdg_config_home" sh "$terrapod" setup
 }
 
 terrapod="$repo_root/dot_local/bin/executable_terrapod"
+mkdir -p "$tmp_dir/bin"
+write_gum_stub "$tmp_dir/bin/gum"
 
 new_home="$tmp_dir/new-home"
 new_xdg="$tmp_dir/new-xdg"
@@ -403,8 +483,8 @@ y
 fi
 pass "macOS setup prompts for customization before final confirmation and customizes Optional Development Workspace and App Groups"
 
-assert_contains "$tmp_dir/setup-custom-workspace.err" "Optional Editor Stack: included by Optional Development Workspace" "workspace-enabled setup presents Optional Editor Stack as included"
-assert_contains "$tmp_dir/setup-custom-workspace.err" "Optional AI Tool Stack: included by Optional Development Workspace" "workspace-enabled setup presents Optional AI Tool Stack as included"
+assert_contains "$tmp_dir/setup-custom-workspace.out" "Optional Editor Stack: included by Optional Development Workspace" "workspace-enabled setup presents Optional Editor Stack as included"
+assert_contains "$tmp_dir/setup-custom-workspace.out" "Optional AI Tool Stack: included by Optional Development Workspace" "workspace-enabled setup presents Optional AI Tool Stack as included"
 assert_contains "$tmp_dir/setup-custom-workspace.out" "enableEditorStack = true" "workspace-enabled setup summary reflects included Optional Editor Stack"
 assert_contains "$tmp_dir/setup-custom-workspace.out" "enableAiCliTools = true" "workspace-enabled setup summary reflects included Optional AI Tool Stack"
 assert_contains "$tmp_dir/setup-custom-workspace.out" "enableDevelopmentWorkspace = true" "workspace-enabled setup summary reflects enabled Optional Development Workspace"
@@ -426,110 +506,103 @@ assert_data_key_once_with_value "$setup_custom_workspace_config" "enableMacosApp
 assert_data_key_once_with_value "$setup_custom_workspace_config" "enableMacosAppGroupLauncher" "false" "workspace-enabled setup writes customized launcher App Group"
 assert_data_key_once_with_value "$setup_custom_workspace_config" "enableMacosAppGroupMonitoring" "true" "workspace-enabled setup writes customized monitoring App Group"
 
-rich_equivalent_home="$tmp_dir/rich-equivalent-home"
-rich_equivalent_xdg="$tmp_dir/rich-equivalent-xdg"
-rich_equivalent_config="$rich_equivalent_xdg/chezmoi/chezmoi.toml"
-mkdir -p "$rich_equivalent_home"
+gum_equivalent_home="$tmp_dir/gum-equivalent-home"
+gum_equivalent_xdg="$tmp_dir/gum-equivalent-xdg"
+gum_equivalent_config="$gum_equivalent_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$gum_equivalent_home"
 
-if ! run_terrapod_setup_rich macos-terminal '1
-t
-j
+if ! run_terrapod_setup macos-terminal 'minimal
+y
 n
-j
 y
-j
 n
-j
 y
-
 y
-' "$rich_equivalent_home" "$rich_equivalent_xdg" >"$tmp_dir/rich-equivalent.out" 2>"$tmp_dir/rich-equivalent.err"; then
-  printf '%s\n' "rich setup stdout:" >&2
-  sed 's/^/  /' "$tmp_dir/rich-equivalent.out" >&2
-  printf '%s\n' "rich setup stderr:" >&2
-  sed 's/^/  /' "$tmp_dir/rich-equivalent.err" >&2
-  fail "rich setup customizes concrete settings and completes"
+' "$gum_equivalent_home" "$gum_equivalent_xdg" >"$tmp_dir/gum-equivalent.out" 2>"$tmp_dir/gum-equivalent.err"; then
+  printf '%s\n' "gum setup stdout:" >&2
+  sed 's/^/  /' "$tmp_dir/gum-equivalent.out" >&2
+  printf '%s\n' "gum setup stderr:" >&2
+  sed 's/^/  /' "$tmp_dir/gum-equivalent.err" >&2
+  fail "gum setup customizes concrete settings and completes"
 fi
-pass "rich setup customizes concrete settings and completes"
+pass "gum setup customizes concrete settings and completes"
 
-assert_contains "$tmp_dir/rich-equivalent.err" "Terrapod Setup" "rich setup prints setup-only rich heading"
-assert_data_key_once_with_value "$rich_equivalent_config" "enableEditorStack" "true" "rich setup writes included Optional Editor Stack"
-assert_data_key_once_with_value "$rich_equivalent_config" "enableAiCliTools" "true" "rich setup writes included Optional AI Tool Stack"
-assert_data_key_once_with_value "$rich_equivalent_config" "enableDevelopmentWorkspace" "true" "rich setup writes enabled Optional Development Workspace"
-assert_data_key_once_with_value "$rich_equivalent_config" "enableMacosAppGroupTerminalApps" "false" "rich setup writes customized terminal-apps App Group"
-assert_data_key_once_with_value "$rich_equivalent_config" "enableMacosAppGroupAutomation" "true" "rich setup writes customized automation App Group"
-assert_data_key_once_with_value "$rich_equivalent_config" "enableMacosAppGroupLauncher" "false" "rich setup writes customized launcher App Group"
-assert_data_key_once_with_value "$rich_equivalent_config" "enableMacosAppGroupMonitoring" "true" "rich setup writes customized monitoring App Group"
+assert_data_key_once_with_value "$gum_equivalent_config" "enableEditorStack" "true" "gum setup writes included Optional Editor Stack"
+assert_data_key_once_with_value "$gum_equivalent_config" "enableAiCliTools" "true" "gum setup writes included Optional AI Tool Stack"
+assert_data_key_once_with_value "$gum_equivalent_config" "enableDevelopmentWorkspace" "true" "gum setup writes enabled Optional Development Workspace"
+assert_data_key_once_with_value "$gum_equivalent_config" "enableMacosAppGroupTerminalApps" "false" "gum setup writes customized terminal-apps App Group"
+assert_data_key_once_with_value "$gum_equivalent_config" "enableMacosAppGroupAutomation" "true" "gum setup writes customized automation App Group"
+assert_data_key_once_with_value "$gum_equivalent_config" "enableMacosAppGroupLauncher" "false" "gum setup writes customized launcher App Group"
+assert_data_key_once_with_value "$gum_equivalent_config" "enableMacosAppGroupMonitoring" "true" "gum setup writes customized monitoring App Group"
 
-if ! cmp -s "$setup_custom_workspace_config" "$rich_equivalent_config"; then
-  printf '%s\n' "plain setup config:" >&2
+if ! cmp -s "$setup_custom_workspace_config" "$gum_equivalent_config"; then
+  printf '%s\n' "first gum setup config:" >&2
   sed 's/^/  /' "$setup_custom_workspace_config" >&2
-  printf '%s\n' "rich setup config:" >&2
-  sed 's/^/  /' "$rich_equivalent_config" >&2
-  fail "rich setup writes the same concrete settings as equivalent plain setup choices"
+  printf '%s\n' "second gum setup config:" >&2
+  sed 's/^/  /' "$gum_equivalent_config" >&2
+  fail "gum setup writes the same concrete settings for equivalent choices"
 fi
-pass "rich setup writes the same concrete settings as equivalent plain setup choices"
+pass "gum setup writes the same concrete settings for equivalent choices"
 
-rich_navigation_home="$tmp_dir/rich-navigation-home"
-rich_navigation_xdg="$tmp_dir/rich-navigation-xdg"
-rich_navigation_config="$rich_navigation_xdg/chezmoi/chezmoi.toml"
-mkdir -p "$rich_navigation_home"
+gum_development_home="$tmp_dir/gum-development-home"
+gum_development_xdg="$tmp_dir/gum-development-xdg"
+gum_development_config="$gum_development_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$gum_development_home"
 
-if ! run_terrapod_setup_rich macos-terminal 'j
-j
-k
+if ! run_terrapod_setup macos-terminal 'development
+
+
+
 
 
 y
-' "$rich_navigation_home" "$rich_navigation_xdg" >"$tmp_dir/rich-navigation.out" 2>"$tmp_dir/rich-navigation.err"; then
-  printf '%s\n' "rich navigation stdout:" >&2
-  sed 's/^/  /' "$tmp_dir/rich-navigation.out" >&2
-  printf '%s\n' "rich navigation stderr:" >&2
-  sed 's/^/  /' "$tmp_dir/rich-navigation.err" >&2
-  fail "rich Preset navigation selects development and completes"
+' "$gum_development_home" "$gum_development_xdg" >"$tmp_dir/gum-development.out" 2>"$tmp_dir/gum-development.err"; then
+  printf '%s\n' "gum development stdout:" >&2
+  sed 's/^/  /' "$tmp_dir/gum-development.out" >&2
+  printf '%s\n' "gum development stderr:" >&2
+  sed 's/^/  /' "$tmp_dir/gum-development.err" >&2
+  fail "gum Preset selection selects development and completes"
 fi
-pass "rich Preset navigation selects development and completes"
+pass "gum Preset selection selects development and completes"
 
-assert_contains "$tmp_dir/rich-navigation.out" "Configured Terrapod Preset 'development'" "rich Preset navigation selects development"
-assert_data_key_once_with_value "$rich_navigation_config" "enableEditorStack" "true" "rich navigation writes development Editor Stack setting"
-assert_data_key_once_with_value "$rich_navigation_config" "enableAiCliTools" "true" "rich navigation writes development AI Tool Stack setting"
-assert_data_key_once_with_value "$rich_navigation_config" "enableDevelopmentWorkspace" "true" "rich navigation writes development workspace setting"
-assert_data_key_once_with_value "$rich_navigation_config" "enableMacosAppGroupTerminalApps" "false" "rich navigation keeps terminal-apps disabled for development"
+assert_contains "$tmp_dir/gum-development.out" "Configured Terrapod Preset 'development'" "gum Preset selection selects development"
+assert_data_key_once_with_value "$gum_development_config" "enableEditorStack" "true" "gum development writes development Editor Stack setting"
+assert_data_key_once_with_value "$gum_development_config" "enableAiCliTools" "true" "gum development writes development AI Tool Stack setting"
+assert_data_key_once_with_value "$gum_development_config" "enableDevelopmentWorkspace" "true" "gum development writes development workspace setting"
+assert_data_key_once_with_value "$gum_development_config" "enableMacosAppGroupTerminalApps" "false" "gum development keeps terminal-apps disabled for development"
 
-rich_vps_home="$tmp_dir/rich-vps-home"
-rich_vps_xdg="$tmp_dir/rich-vps-xdg"
-rich_vps_config="$rich_vps_xdg/chezmoi/chezmoi.toml"
-mkdir -p "$rich_vps_home"
+gum_vps_home="$tmp_dir/gum-vps-home"
+gum_vps_xdg="$tmp_dir/gum-vps-xdg"
+gum_vps_config="$gum_vps_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$gum_vps_home"
 
-if ! run_terrapod_setup_rich vps-shell 'minimal
-j
-y
-j
+if ! run_terrapod_setup vps-shell 'minimal
 n
-
 y
-' "$rich_vps_home" "$rich_vps_xdg" >"$tmp_dir/rich-vps.out" 2>"$tmp_dir/rich-vps.err"; then
-  printf '%s\n' "rich VPS stdout:" >&2
-  sed 's/^/  /' "$tmp_dir/rich-vps.out" >&2
-  printf '%s\n' "rich VPS stderr:" >&2
-  sed 's/^/  /' "$tmp_dir/rich-vps.err" >&2
-  fail "rich VPS setup customizes optional stacks without macOS App Groups"
+n
+y
+' "$gum_vps_home" "$gum_vps_xdg" >"$tmp_dir/gum-vps.out" 2>"$tmp_dir/gum-vps.err"; then
+  printf '%s\n' "gum VPS stdout:" >&2
+  sed 's/^/  /' "$tmp_dir/gum-vps.out" >&2
+  printf '%s\n' "gum VPS stderr:" >&2
+  sed 's/^/  /' "$tmp_dir/gum-vps.err" >&2
+  fail "gum VPS setup customizes optional stacks without macOS App Groups"
 fi
-pass "rich VPS setup customizes optional stacks without macOS App Groups"
+pass "gum VPS setup customizes optional stacks without macOS App Groups"
 
-rich_vps_combined="$(cat "$tmp_dir/rich-vps.out" "$tmp_dir/rich-vps.err")"
-if printf '%s\n' "$rich_vps_combined" | grep -F "terminal-apps macOS App Group" >/dev/null; then
-  fail "rich VPS setup does not show macOS App Group items"
+gum_vps_combined="$(cat "$tmp_dir/gum-vps.out" "$tmp_dir/gum-vps.err")"
+if printf '%s\n' "$gum_vps_combined" | grep -F "terminal-apps macOS App Group" >/dev/null; then
+  fail "gum VPS setup does not show macOS App Group items"
 fi
-pass "rich VPS setup does not show macOS App Group items"
+pass "gum VPS setup does not show macOS App Group items"
 
-assert_data_key_once_with_value "$rich_vps_config" "enableEditorStack" "true" "rich VPS setup writes customized Optional Editor Stack"
-assert_data_key_once_with_value "$rich_vps_config" "enableAiCliTools" "false" "rich VPS setup writes customized Optional AI Tool Stack"
-assert_data_key_once_with_value "$rich_vps_config" "enableDevelopmentWorkspace" "false" "rich VPS setup writes disabled Optional Development Workspace"
-assert_data_key_once_with_value "$rich_vps_config" "enableMacosAppGroupTerminalApps" "false" "rich VPS setup writes terminal-apps App Group disabled"
-assert_data_key_once_with_value "$rich_vps_config" "enableMacosAppGroupAutomation" "false" "rich VPS setup writes automation App Group disabled"
-assert_data_key_once_with_value "$rich_vps_config" "enableMacosAppGroupLauncher" "false" "rich VPS setup writes launcher App Group disabled"
-assert_data_key_once_with_value "$rich_vps_config" "enableMacosAppGroupMonitoring" "false" "rich VPS setup writes monitoring App Group disabled"
+assert_data_key_once_with_value "$gum_vps_config" "enableEditorStack" "true" "gum VPS setup writes customized Optional Editor Stack"
+assert_data_key_once_with_value "$gum_vps_config" "enableAiCliTools" "false" "gum VPS setup writes customized Optional AI Tool Stack"
+assert_data_key_once_with_value "$gum_vps_config" "enableDevelopmentWorkspace" "false" "gum VPS setup writes disabled Optional Development Workspace"
+assert_data_key_once_with_value "$gum_vps_config" "enableMacosAppGroupTerminalApps" "false" "gum VPS setup writes terminal-apps App Group disabled"
+assert_data_key_once_with_value "$gum_vps_config" "enableMacosAppGroupAutomation" "false" "gum VPS setup writes automation App Group disabled"
+assert_data_key_once_with_value "$gum_vps_config" "enableMacosAppGroupLauncher" "false" "gum VPS setup writes launcher App Group disabled"
+assert_data_key_once_with_value "$gum_vps_config" "enableMacosAppGroupMonitoring" "false" "gum VPS setup writes monitoring App Group disabled"
 
 setup_leaf_home="$tmp_dir/setup-leaf-home"
 setup_leaf_xdg="$tmp_dir/setup-leaf-xdg"
@@ -596,7 +669,7 @@ if printf '%s\n' "$setup_vps_custom_output" | grep -F "terminal-apps macOS App G
 fi
 pass "VPS setup does not prompt for terminal-apps macOS App Group"
 
-assert_contains "$tmp_dir/setup-vps-custom.err" "macOS App Groups: not applicable for VPS Shell Profile" "VPS setup explains macOS App Groups are not applicable"
+assert_contains "$tmp_dir/setup-vps-custom.out" "macOS App Groups: not applicable for VPS Shell Profile" "VPS setup explains macOS App Groups are not applicable"
 assert_contains "$tmp_dir/setup-vps-custom.out" "enableEditorStack = true" "VPS setup summary reflects customized Optional Editor Stack"
 assert_contains "$tmp_dir/setup-vps-custom.out" "enableAiCliTools = false" "VPS setup summary reflects customized Optional AI Tool Stack"
 assert_contains "$tmp_dir/setup-vps-custom.out" "enableDevelopmentWorkspace = false" "VPS setup summary reflects disabled Optional Development Workspace"
@@ -626,8 +699,8 @@ y
 fi
 pass "VPS setup workstation rejection exits non-zero"
 
-assert_contains "$tmp_dir/setup-vps-workstation-error.err" "workstation Preset is only available for the macOS Terminal Profile" "VPS setup workstation rejection writes the error to stderr"
-assert_not_contains "$tmp_dir/setup-vps-workstation-error.out" "workstation Preset is only available for the macOS Terminal Profile" "VPS setup workstation rejection does not write the error to stdout"
+assert_contains "$tmp_dir/setup-vps-workstation-error.out" "workstation Preset is only available for the macOS Terminal Profile" "VPS setup workstation rejection writes the error"
+assert_not_contains "$tmp_dir/setup-vps-workstation-error.err" "workstation Preset is only available for the macOS Terminal Profile" "VPS setup workstation rejection does not write outside the PTY transcript"
 
 if [ -e "$setup_vps_workstation_error_config" ]; then
   fail "VPS setup workstation rejection does not create a config"
@@ -636,27 +709,27 @@ pass "VPS setup workstation rejection does not create a config"
 
 assert_no_terrapod_artifacts_near_path "$setup_vps_workstation_error_config" "VPS setup workstation rejection leaves no Terrapod artifacts"
 
-setup_invalid_bool_home="$tmp_dir/setup-invalid-bool-home"
-setup_invalid_bool_xdg="$tmp_dir/setup-invalid-bool-xdg"
-setup_invalid_bool_config="$setup_invalid_bool_xdg/chezmoi/chezmoi.toml"
-mkdir -p "$setup_invalid_bool_home"
+setup_setting_cancel_home="$tmp_dir/setup-setting-cancel-home"
+setup_setting_cancel_xdg="$tmp_dir/setup-setting-cancel-xdg"
+setup_setting_cancel_config="$setup_setting_cancel_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$setup_setting_cancel_home"
 
 if run_terrapod_setup macos-terminal 'minimal
-maybe
-' "$setup_invalid_bool_home" "$setup_invalid_bool_xdg" >"$tmp_dir/setup-invalid-bool.out" 2>"$tmp_dir/setup-invalid-bool.err"; then
-  fail "setup invalid boolean answer exits non-zero"
+__CANCEL__
+' "$setup_setting_cancel_home" "$setup_setting_cancel_xdg" >"$tmp_dir/setup-setting-cancel.out" 2>"$tmp_dir/setup-setting-cancel.err"; then
+  fail "setup setting cancellation exits non-zero"
 fi
-pass "setup invalid boolean answer exits non-zero"
+pass "setup setting cancellation exits non-zero"
 
-assert_contains "$tmp_dir/setup-invalid-bool.err" "invalid answer for Optional Development Workspace; enter y or n" "setup invalid boolean answer writes the error to stderr"
-assert_not_contains "$tmp_dir/setup-invalid-bool.out" "invalid answer for Optional Development Workspace; enter y or n" "setup invalid boolean answer does not write the error to stdout"
+assert_contains "$tmp_dir/setup-setting-cancel.out" "setup cancelled" "setup setting cancellation writes the error"
+assert_not_contains "$tmp_dir/setup-setting-cancel.err" "setup cancelled" "setup setting cancellation does not write outside the PTY transcript"
 
-if [ -e "$setup_invalid_bool_config" ]; then
-  fail "setup invalid boolean answer does not create a config"
+if [ -e "$setup_setting_cancel_config" ]; then
+  fail "setup setting cancellation does not create a config"
 fi
-pass "setup invalid boolean answer does not create a config"
+pass "setup setting cancellation does not create a config"
 
-assert_no_terrapod_artifacts_near_path "$setup_invalid_bool_config" "setup invalid boolean answer leaves no Terrapod artifacts"
+assert_no_terrapod_artifacts_near_path "$setup_setting_cancel_config" "setup setting cancellation leaves no Terrapod artifacts"
 
 setup_cancel_home="$tmp_dir/setup-cancel-home"
 setup_cancel_xdg="$tmp_dir/setup-cancel-xdg"
@@ -675,7 +748,7 @@ n
 fi
 pass "cancelled setup exits non-zero"
 
-assert_contains "$tmp_dir/setup-cancel.err" "setup cancelled" "cancelled setup explains cancellation"
+assert_contains "$tmp_dir/setup-cancel.out" "setup cancelled" "cancelled setup explains cancellation"
 
 if [ -e "$setup_cancel_config" ]; then
   fail "cancelled setup does not create a new config"
@@ -709,7 +782,7 @@ if run_terrapod_setup macos-terminal 'development
 fi
 pass "empty final confirmation cancels setup"
 
-assert_contains "$tmp_dir/setup-existing-cancel.err" "setup cancelled" "empty final confirmation explains cancellation"
+assert_contains "$tmp_dir/setup-existing-cancel.out" "setup cancelled" "empty final confirmation explains cancellation"
 
 if ! cmp -s "$setup_existing_cancel_config" "$tmp_dir/setup-existing-cancel-before.toml"; then
   fail "cancelled setup leaves existing config unchanged"


### PR DESCRIPTION
## Summary
- Replace Terrapod Setup's plain/rich prompt paths with a single gum-backed interactive flow.
- Require gum and a supported interactive terminal before setup starts.
- Add gum-stubbed PTY tests for Preset selection, setting customization, final confirmation, cancellation, missing gum, unsupported terminal behavior, and gum operational failures.

## Why
Issue #70 moves setup onto the bootstrap UI dependency defined in the gum ADR, avoiding parallel terminal interaction models and keeping first-run setup behavior aligned across supported profiles.

## Impact
- `terrapod setup` now requires `gum` and an interactive terminal.
- `terrapod configure <Preset>` remains the script-friendly non-interactive configuration path.
- Existing managed config write behavior, backups, unrelated config preservation, and temp-file cleanup contracts remain unchanged.

## Validation
- `sh -n dot_local/bin/executable_terrapod`
- `sh tests/terrapod_command_test.sh`
- `sh tests/terrapod_config_test.sh`
- `sh tests/terrapod_installer_test.sh`
- Full shell test loop over `tests/*_test.sh` and `tests/*_test.zsh`
- Spec compliance review: passed
- Code quality review: approved after fixes
- Final review: approved

Closes #70