### PR TITLE
Preserve script-friendly Preset configuration without gum

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -64,6 +64,13 @@ machine이 조용히 다시 바뀌지는 않습니다.
 
 `workstation` Preset은 macOS Terminal Profile에서만 사용할 수 있습니다.
 
+`terrapod configure <Preset>`는 script-friendly Preset configuration
+command입니다. 지원되는 Preset 정확히 하나의 concrete settings를 쓰고,
+`gum`이 필요 없으며, interactive customization은 제공하지 않습니다.
+`terrapod configure <Preset>`는 Terrapod Setup의 plain fallback이 아닙니다.
+Terrapod Setup이 `gum` 또는 interactive terminal 부재로 실행되지 않으면
+`gum` 또는 terminal environment를 고친 뒤 `terrapod setup`을 다시 실행합니다.
+
 ## What Terrapod Leaves Alone
 
 Terrapod은 이 저장소의 declared dotfiles state를 적용합니다. 전체 운영체제를 소유하지는 않습니다.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ an already configured machine.
 
 The `workstation` Preset is available only for the macOS Terminal Profile.
 
+`terrapod configure <Preset>` is the script-friendly Preset configuration
+command. It writes concrete settings for exactly one supported Preset, does not
+require `gum`, and has no interactive customization. `terrapod configure
+<Preset>` is not a plain fallback for Terrapod Setup. If Terrapod Setup cannot
+run because `gum` or an interactive terminal is unavailable, fix the `gum` or
+terminal environment and rerun `terrapod setup`.
+
 ## What Terrapod Leaves Alone
 
 Terrapod applies this repository's declared dotfiles state. It does not own the whole operating system.

--- a/tests/readme_korean_test.sh
+++ b/tests/readme_korean_test.sh
@@ -107,6 +107,18 @@ assert_contains "$korean_readme" '🌐 언어: [English](README.md) | **한국�
   "README.ko.md has the agreed language switcher"
 assert_not_contains "$korean_readme" '번역본' \
   "README.ko.md does not label itself as a translation"
+assert_contains "$korean_readme" '`terrapod configure <Preset>`는 script-friendly Preset configuration' \
+  "README.ko.md documents script-friendly Preset configuration"
+assert_contains "$korean_readme" '지원되는 Preset 정확히 하나의 concrete settings를 쓰고,' \
+  "README.ko.md documents configure writes concrete settings for one Preset"
+assert_contains "$korean_readme" '`gum`이 필요 없으며, interactive customization은 제공하지 않습니다.' \
+  "README.ko.md documents configure as no-gum and non-interactive"
+assert_contains "$korean_readme" '`terrapod configure <Preset>`는 Terrapod Setup의 plain fallback이 아닙니다.' \
+  "README.ko.md states configure is not a Setup fallback"
+assert_contains "$korean_readme" 'Terrapod Setup이 `gum` 또는 interactive terminal 부재로 실행되지 않으면' \
+  "README.ko.md documents missing-gum Setup recovery start"
+assert_contains "$korean_readme" '`gum` 또는 terminal environment를 고친 뒤 `terrapod setup`을 다시 실행합니다.' \
+  "README.ko.md documents missing-gum Setup recovery"
 
 extract_headings "$readme" >"$tmp_dir/readme.headings"
 extract_headings "$korean_readme" >"$tmp_dir/readme-ko.headings"

--- a/tests/readme_optional_stack_profiles_test.sh
+++ b/tests/readme_optional_stack_profiles_test.sh
@@ -134,6 +134,18 @@ assert_contains '## What Terrapod Carries' \
   "README summarizes Terrapod's carried domain concepts"
 assert_contains '## Choose a Preset' \
   "README uses the canonical Preset section title"
+assert_contains '`terrapod configure <Preset>` is the script-friendly Preset configuration' \
+  "README documents script-friendly Preset configuration"
+assert_contains 'It writes concrete settings for exactly one supported Preset' \
+  "README documents configure writes concrete settings for one Preset"
+assert_contains 'require `gum`, and has no interactive customization.' \
+  "README documents configure as no-gum and non-interactive"
+assert_contains '<Preset>` is not a plain fallback for Terrapod Setup.' \
+  "README states configure is not a Setup fallback"
+assert_contains 'If Terrapod Setup cannot' \
+  "README documents missing-gum Setup recovery start"
+assert_contains 'terminal environment and rerun `terrapod setup`.' \
+  "README documents missing-gum Setup recovery"
 assert_contains '## What Terrapod Leaves Alone' \
   "README documents product boundaries near the top"
 assert_contains '## Daily Commands' \

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -486,7 +486,7 @@ assert_not_contains \
   "workstation" \
   "VPS Shell Profile help does not mention workstation anywhere"
 
-if TERRAPOD_PROFILE=vps-shell HOME="$tmp_dir/home" XDG_CONFIG_HOME="$tmp_dir/xdg" sh "$terrapod" configure workstation >"$tmp_dir/vps-workstation.out" 2>"$tmp_dir/vps-workstation.err"; then
+if PATH="/usr/bin:/bin" TERRAPOD_PROFILE=vps-shell TERRAPOD_CHEZMOI_CONFIG= HOME="$tmp_dir/home" XDG_CONFIG_HOME="$tmp_dir/xdg" sh "$terrapod" configure workstation >"$tmp_dir/vps-workstation.out" 2>"$tmp_dir/vps-workstation.err"; then
   fail "VPS Shell Profile rejects workstation Preset"
 fi
 pass "VPS Shell Profile rejects workstation Preset"
@@ -506,6 +506,11 @@ assert_contains \
   "$vps_workstation_error" \
   "workstation Preset is only available for the macOS Terminal Profile" \
   "VPS Shell Profile explains workstation Preset rejection"
+
+assert_not_contains \
+  "$vps_workstation_error" \
+  "gum is required" \
+  "VPS Shell Profile no-gum workstation rejection does not require gum"
 
 setup_home="$tmp_dir/setup-home"
 setup_xdg="$tmp_dir/setup-xdg"
@@ -648,7 +653,8 @@ missing_gum_xdg="$tmp_dir/missing-gum-xdg"
 missing_gum_output="$tmp_dir/missing-gum.out"
 mkdir -p "$missing_gum_home"
 
-if PATH="/usr/bin:/bin" TERRAPOD_PROFILE=macos-terminal TERRAPOD_CHEZMOI_CONFIG= HOME="$missing_gum_home" XDG_CONFIG_HOME="$missing_gum_xdg" sh "$terrapod" setup >"$missing_gum_output" 2>&1; then
+if printf '%s\n' "workstation" |
+  PATH="/usr/bin:/bin" TERRAPOD_PROFILE=macos-terminal TERRAPOD_CHEZMOI_CONFIG= HOME="$missing_gum_home" XDG_CONFIG_HOME="$missing_gum_xdg" sh "$terrapod" setup >"$missing_gum_output" 2>&1; then
   fail "setup fails when gum is missing"
 fi
 pass "setup fails when gum is missing"
@@ -656,6 +662,14 @@ pass "setup fails when gum is missing"
 missing_gum_output_text="$(cat "$missing_gum_output")"
 assert_contains "$missing_gum_output_text" "gum is required before Terrapod Setup can run" "missing gum setup explains gum requirement"
 assert_contains "$missing_gum_output_text" "Install gum, then rerun Terrapod Setup" "missing gum setup gives rerun guidance"
+assert_not_contains "$missing_gum_output_text" "Configured Terrapod Preset" "missing gum setup does not fall back to configure success"
+
+if [ -e "$missing_gum_xdg/chezmoi/chezmoi.toml" ]; then
+  fail "missing gum setup does not write config"
+fi
+pass "missing gum setup does not write config"
+
+assert_no_terrapod_artifacts_under "$missing_gum_xdg" "missing gum setup leaves no Terrapod artifacts"
 
 noninteractive_setup_home="$tmp_dir/noninteractive-setup-home"
 noninteractive_setup_xdg="$tmp_dir/noninteractive-setup-xdg"

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -115,6 +115,26 @@ write_gum_responses() {
   done
 }
 
+write_no_gum_path() {
+  path="$1"
+  shift
+
+  mkdir -p "$path"
+
+  for command_name do
+    command_path="$(command -v "$command_name" 2>/dev/null || true)"
+    if [ -z "$command_path" ]; then
+      fail "no-gum PATH setup requires $command_name"
+    fi
+
+    ln -s "$command_path" "$path/$command_name"
+  done
+
+  if PATH="$path" command -v gum >/dev/null 2>&1; then
+    fail "no-gum PATH setup should hide gum"
+  fi
+}
+
 shell_quote() {
   printf "'"
   printf '%s' "$1" | sed "s/'/'\\\\''/g"
@@ -328,6 +348,8 @@ assert_no_terrapod_artifacts_under() {
 
 mkdir -p "$tmp_dir/bin" "$tmp_dir/home"
 write_gum_stub "$tmp_dir/bin/gum"
+no_gum_path="$tmp_dir/no-gum-bin"
+write_no_gum_path "$no_gum_path" sh
 
 terrapod="$repo_root/dot_local/bin/executable_terrapod"
 tpod_source="$repo_root/dot_local/bin/symlink_tpod"
@@ -654,7 +676,7 @@ missing_gum_output="$tmp_dir/missing-gum.out"
 mkdir -p "$missing_gum_home"
 
 if printf '%s\n' "workstation" |
-  PATH="/usr/bin:/bin" TERRAPOD_PROFILE=macos-terminal TERRAPOD_CHEZMOI_CONFIG= HOME="$missing_gum_home" XDG_CONFIG_HOME="$missing_gum_xdg" sh "$terrapod" setup >"$missing_gum_output" 2>&1; then
+  PATH="$no_gum_path" TERRAPOD_PROFILE=macos-terminal TERRAPOD_CHEZMOI_CONFIG= HOME="$missing_gum_home" XDG_CONFIG_HOME="$missing_gum_xdg" sh "$terrapod" setup >"$missing_gum_output" 2>&1; then
   fail "setup fails when gum is missing"
 fi
 pass "setup fails when gum is missing"

--- a/tests/terrapod_config_test.sh
+++ b/tests/terrapod_config_test.sh
@@ -364,6 +364,17 @@ run_terrapod_configure() {
   fi
 }
 
+run_terrapod_configure_without_gum() {
+  profile="$1"
+  preset="$2"
+  home_dir="$3"
+  xdg_config_home="$4"
+
+  PATH="/usr/bin:/bin" TERRAPOD_PROFILE="$profile" TERRAPOD_CHEZMOI_CONFIG= \
+    HOME="$home_dir" XDG_CONFIG_HOME="$xdg_config_home" \
+    sh "$terrapod" configure "$preset" </dev/null
+}
+
 run_terrapod_setup() {
   profile="$1"
   input="$2"
@@ -452,6 +463,89 @@ assert_data_key_once_with_value "$workstation_config" "enableMacosAppGroupMonito
 assert_not_contains "$workstation_config" "enableMacosDesktopApps" "workstation Preset does not write the legacy all-in desktop app toggle"
 assert_not_contains "$workstation_config" "terrapodPreset" "workstation Preset stores concrete values instead of a dynamic Preset"
 assert_backup_count "$workstation_config" 0 "workstation config creation does not create a backup"
+
+nogum_minimal_home="$tmp_dir/nogum-minimal-home"
+nogum_minimal_xdg="$tmp_dir/nogum-minimal-xdg"
+nogum_minimal_config="$nogum_minimal_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$nogum_minimal_home"
+
+run_terrapod_configure_without_gum vps-shell minimal "$nogum_minimal_home" "$nogum_minimal_xdg"
+
+if [ ! -f "$nogum_minimal_config" ]; then
+  fail "no-gum minimal Preset creates a chezmoi config file"
+fi
+pass "no-gum minimal Preset creates a chezmoi config file"
+
+assert_data_key_once_with_value "$nogum_minimal_config" "enableEditorStack" "false" "no-gum minimal writes concrete Editor Stack setting"
+assert_data_key_once_with_value "$nogum_minimal_config" "enableDevelopmentWorkspace" "false" "no-gum minimal writes concrete Development Workspace setting"
+assert_not_contains "$nogum_minimal_config" "terrapodPreset" "no-gum minimal stores concrete values instead of a dynamic Preset"
+
+nogum_development_home="$tmp_dir/nogum-development-home"
+nogum_development_xdg="$tmp_dir/nogum-development-xdg"
+nogum_development_config="$nogum_development_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$nogum_development_home"
+
+run_terrapod_configure_without_gum vps-shell development "$nogum_development_home" "$nogum_development_xdg"
+
+if [ ! -f "$nogum_development_config" ]; then
+  fail "no-gum development Preset creates a chezmoi config file"
+fi
+pass "no-gum development Preset creates a chezmoi config file"
+
+assert_data_key_once_with_value "$nogum_development_config" "enableEditorStack" "true" "no-gum development writes concrete Editor Stack setting"
+assert_data_key_once_with_value "$nogum_development_config" "enableDevelopmentWorkspace" "true" "no-gum development writes concrete Development Workspace setting"
+assert_data_key_once_with_value "$nogum_development_config" "enableMacosAppGroupTerminalApps" "false" "no-gum development writes concrete macOS App Group setting"
+assert_not_contains "$nogum_development_config" "terrapodPreset" "no-gum development stores concrete values instead of a dynamic Preset"
+
+nogum_macos_minimal_home="$tmp_dir/nogum-macos-minimal-home"
+nogum_macos_minimal_xdg="$tmp_dir/nogum-macos-minimal-xdg"
+nogum_macos_minimal_config="$nogum_macos_minimal_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$nogum_macos_minimal_home"
+
+run_terrapod_configure_without_gum macos-terminal minimal "$nogum_macos_minimal_home" "$nogum_macos_minimal_xdg"
+
+if [ ! -f "$nogum_macos_minimal_config" ]; then
+  fail "no-gum macOS minimal Preset creates a chezmoi config file"
+fi
+pass "no-gum macOS minimal Preset creates a chezmoi config file"
+
+assert_data_key_once_with_value "$nogum_macos_minimal_config" "enableEditorStack" "false" "no-gum macOS minimal writes concrete Editor Stack setting"
+assert_data_key_once_with_value "$nogum_macos_minimal_config" "enableDevelopmentWorkspace" "false" "no-gum macOS minimal writes concrete Development Workspace setting"
+assert_not_contains "$nogum_macos_minimal_config" "terrapodPreset" "no-gum macOS minimal stores concrete values instead of a dynamic Preset"
+
+nogum_macos_development_home="$tmp_dir/nogum-macos-development-home"
+nogum_macos_development_xdg="$tmp_dir/nogum-macos-development-xdg"
+nogum_macos_development_config="$nogum_macos_development_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$nogum_macos_development_home"
+
+run_terrapod_configure_without_gum macos-terminal development "$nogum_macos_development_home" "$nogum_macos_development_xdg"
+
+if [ ! -f "$nogum_macos_development_config" ]; then
+  fail "no-gum macOS development Preset creates a chezmoi config file"
+fi
+pass "no-gum macOS development Preset creates a chezmoi config file"
+
+assert_data_key_once_with_value "$nogum_macos_development_config" "enableEditorStack" "true" "no-gum macOS development writes concrete Editor Stack setting"
+assert_data_key_once_with_value "$nogum_macos_development_config" "enableDevelopmentWorkspace" "true" "no-gum macOS development writes concrete Development Workspace setting"
+assert_data_key_once_with_value "$nogum_macos_development_config" "enableMacosAppGroupTerminalApps" "false" "no-gum macOS development writes concrete macOS App Group setting"
+assert_not_contains "$nogum_macos_development_config" "terrapodPreset" "no-gum macOS development stores concrete values instead of a dynamic Preset"
+
+nogum_workstation_home="$tmp_dir/nogum-workstation-home"
+nogum_workstation_xdg="$tmp_dir/nogum-workstation-xdg"
+nogum_workstation_config="$nogum_workstation_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$nogum_workstation_home"
+
+run_terrapod_configure_without_gum macos-terminal workstation "$nogum_workstation_home" "$nogum_workstation_xdg"
+
+if [ ! -f "$nogum_workstation_config" ]; then
+  fail "no-gum workstation Preset creates a chezmoi config file"
+fi
+pass "no-gum workstation Preset creates a chezmoi config file"
+
+assert_data_key_once_with_value "$nogum_workstation_config" "enableEditorStack" "true" "no-gum workstation writes concrete Editor Stack setting"
+assert_data_key_once_with_value "$nogum_workstation_config" "enableDevelopmentWorkspace" "true" "no-gum workstation writes concrete Development Workspace setting"
+assert_data_key_once_with_value "$nogum_workstation_config" "enableMacosAppGroupMonitoring" "true" "no-gum workstation writes concrete macOS App Group setting"
+assert_not_contains "$nogum_workstation_config" "terrapodPreset" "no-gum workstation stores concrete values instead of a dynamic Preset"
 
 setup_workstation_home="$tmp_dir/setup-workstation-home"
 setup_workstation_xdg="$tmp_dir/setup-workstation-xdg"

--- a/tests/terrapod_config_test.sh
+++ b/tests/terrapod_config_test.sh
@@ -109,6 +109,26 @@ SH
   chmod +x "$path"
 }
 
+write_no_gum_path() {
+  path="$1"
+  shift
+
+  mkdir -p "$path"
+
+  for command_name do
+    command_path="$(command -v "$command_name" 2>/dev/null || true)"
+    if [ -z "$command_path" ]; then
+      fail "no-gum PATH setup requires $command_name"
+    fi
+
+    ln -s "$command_path" "$path/$command_name"
+  done
+
+  if PATH="$path" command -v gum >/dev/null 2>&1; then
+    fail "no-gum PATH setup should hide gum"
+  fi
+}
+
 shell_quote() {
   printf "'"
   printf '%s' "$1" | sed "s/'/'\\\\''/g"
@@ -370,7 +390,7 @@ run_terrapod_configure_without_gum() {
   home_dir="$3"
   xdg_config_home="$4"
 
-  PATH="/usr/bin:/bin" TERRAPOD_PROFILE="$profile" TERRAPOD_CHEZMOI_CONFIG= \
+  PATH="$no_gum_path" TERRAPOD_PROFILE="$profile" TERRAPOD_CHEZMOI_CONFIG= \
     HOME="$home_dir" XDG_CONFIG_HOME="$xdg_config_home" \
     sh "$terrapod" configure "$preset" </dev/null
 }
@@ -393,6 +413,8 @@ run_terrapod_setup() {
 terrapod="$repo_root/dot_local/bin/executable_terrapod"
 mkdir -p "$tmp_dir/bin"
 write_gum_stub "$tmp_dir/bin/gum"
+no_gum_path="$tmp_dir/no-gum-bin"
+write_no_gum_path "$no_gum_path" sh dirname mkdir mktemp awk sed mv rm cat chmod stat cp date
 
 new_home="$tmp_dir/new-home"
 new_xdg="$tmp_dir/new-xdg"


### PR DESCRIPTION
## Summary

- Add no-gum regression coverage for `terrapod configure <Preset>` across supported Preset/profile combinations.
- Prove unsupported Preset/profile combinations reject without requiring `gum`.
- Document that `configure <Preset>` is script-friendly, non-interactive, and not a fallback for gum-backed Terrapod Setup.

## Why

Issue #71 keeps the script-friendly Preset configuration command independent from Terrapod Setup after Setup moved to a required `gum` interaction model.

Closes #71

## Validation

- `git diff --check HEAD~1..HEAD`
- Full shell test loop: `for test_file in tests/*_test.sh tests/*_test.zsh; do [ -e "$test_file" ] || continue; case "$test_file" in *.zsh) zsh "$test_file" ;; *) sh "$test_file" ;; esac; done`
- Spec compliance review: pass
- Code quality review: pass