### PR TITLE
Document AI stack decisions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -148,6 +148,11 @@ _Avoid_: separate Korean introduction, independent README, self-labeled translat
 - pnpm belongs to the **Development Runtime Stack** through Node.js Corepack, not as a mise-managed tool.
 - Rich Neovim configuration belongs to the **Optional Editor Stack**, not the **Core Shell Stack**, and is opt-in for every machine profile.
 - Antigravity CLI, Claude Code, and Codex belong to the **Optional AI Tool Stack**, not the **Core Shell Stack**.
+- Antigravity CLI is installed through its official native installer, while Terrapod remains responsible for the managed shell PATH.
+- Legacy Antigravity Desktop and Antigravity IDE app-bundle shell-command paths are not part of the **Optional AI Tool Stack** or the planned ai-apps **macOS App Group**.
+- Claude Code is installed through its official native installer rather than the npm package.
+- Codex is installed through its official standalone installer rather than the npm package or Homebrew cask.
+- **Optional AI Tool Stack** installers run before the final chezmoi-managed shell files are applied, so vendor installer shell-profile edits do not define the final declared shell state.
 - Existing npm-installed AI CLIs are unmanaged legacy tools; Terrapod does not uninstall or warn merely because they remain on a machine.
 - Enabling only the **Optional AI Tool Stack** does not imply the **Optional Editor Stack** or **Optional Development Workspace**.
 - Development-specific terminal layouts belong to the **Optional Development Workspace**, not the **Core Shell Stack**.
@@ -168,11 +173,16 @@ _Avoid_: separate Korean introduction, independent README, self-labeled translat
 - Terminal font casks belong to the macOS Terminal Profile core bootstrap because the managed terminal configuration depends on them and they are not desktop applications.
 - Enabling the **Optional Development Workspace** does not enable the **macOS Desktop App Stack**.
 - **macOS App Groups** are configured during **Terrapod** setup and remain within the **macOS Desktop App Stack** boundary.
-- The first **macOS App Groups** are terminal-apps, automation, launcher, and monitoring.
-- The terminal-apps **macOS App Group** contains Ghostty and cmux.
+- The first implemented **macOS App Groups** are terminal-apps, automation, launcher, and monitoring.
+- The terminal-apps **macOS App Group** currently contains Ghostty and cmux.
+- Removing cmux from the **macOS Desktop App Stack** is a planned change; once removed, existing cmux installs or settings may remain on a machine unmanaged.
 - The automation **macOS App Group** contains Hammerspoon and Karabiner-Elements.
 - The launcher **macOS App Group** contains Raycast and 1Password CLI.
 - The monitoring **macOS App Group** contains iStat Menus.
+- The planned ai-apps **macOS App Group** contains Claude Desktop, Codex Desktop, Antigravity 2.0, and Antigravity IDE.
+- The planned ai-apps **macOS App Group** installs these desktop apps through Homebrew casks `claude`, `codex-app`, `antigravity`, and `antigravity-ide`.
+- The planned Hammerspoon app launcher change maps Codex Desktop to `1`, Claude Desktop to `2`, Antigravity 2.0 to `3`, and Antigravity IDE to `i`.
+- Removing ChatGPT Atlas from the Hammerspoon app launcher is part of the planned launcher change.
 - Individual macOS app toggles are excluded from the current **Terrapod** setup scope.
 - Repository renaming makes `juty9026/terrapod` the canonical slug for the **Terrapod Source Repository** without adding legacy URL fallback behavior.
 - Non-interactive setup options are deferred outside the current **Terrapod** installer and management command work, so **Terrapod Setup** may require an interactive terminal and the **Bootstrap UI Dependency**.

--- a/docs/adr/0006-use-official-installers-for-ai-cli-tools.md
+++ b/docs/adr/0006-use-official-installers-for-ai-cli-tools.md
@@ -1,0 +1,9 @@
+# Use official installers for AI CLI tools
+
+The **Optional AI Tool Stack** now installs Antigravity CLI, Claude Code, and Codex through each vendor's official native or standalone installer instead of managing all three as global npm packages through the mise-managed Node.js runtime. This follows current vendor installation guidance and replaces Gemini CLI with Antigravity CLI for the Google assistant slot. Terrapod's command output follows the same naming: setup describes Antigravity CLI, while status and doctor validate the `agy` binary. The transition remains non-destructive by leaving any existing npm-installed AI CLIs unmanaged rather than uninstalling them.
+
+## Consequences
+
+- Vendor installers may edit shell profiles during installation, so the AI CLI installer runs before the final chezmoi-managed shell files are applied.
+- `terrapod setup`, `terrapod status`, and `terrapod doctor` keep the **Optional AI Tool Stack** command surface aligned with Antigravity CLI, Claude Code, and Codex.
+- Existing `gemini` binaries may remain on machines but are no longer part of Terrapod's declared optional AI tool state.

--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -369,7 +369,7 @@ setup_option_description() {
       printf '%s\n' "Optional Editor Stack: Rich Neovim configuration."
       ;;
     "Optional AI Tool Stack")
-      printf '%s\n' "Optional AI Tool Stack: Gemini CLI, Claude Code, and Codex."
+      printf '%s\n' "Optional AI Tool Stack: Antigravity CLI, Claude Code, and Codex."
       ;;
     "terminal-apps macOS App Group")
       printf '%s\n' "terminal-apps macOS App Group: Ghostty and cmux."

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -644,7 +644,7 @@ assert_contains "$setup_output_text" "Settings to write:" "gum setup shows concr
 assert_contains "$setup_output_text" "Customize Terrapod settings." "gum setup offers sequential setting customization"
 assert_not_contains "$setup_output_text" "Option guide:" "gum setup does not print a separate option guide"
 assert_contains "$setup_output_text" "Optional Development Workspace: Dev Zellij layouts; also includes Editor and AI tool stacks." "gum setup explains Optional Development Workspace"
-assert_contains "$setup_output_text" "Optional AI Tool Stack: Gemini CLI, Claude Code, and Codex." "gum setup explains Optional AI Tool Stack"
+assert_contains "$setup_output_text" "Optional AI Tool Stack: Antigravity CLI, Claude Code, and Codex." "gum setup explains Optional AI Tool Stack"
 assert_contains "$setup_output_text" "terminal-apps macOS App Group: Ghostty and cmux." "gum setup explains terminal-apps macOS App Group"
 assert_contains "$setup_output_text" "Optional Editor Stack: included by Optional Development Workspace" "gum setup presents workspace-included Optional Editor Stack"
 assert_contains "$setup_output_text" "enableEditorStack = true" "gum setup summary includes concrete Editor Stack setting"


### PR DESCRIPTION
## Summary
- Update the domain context for the Antigravity-based Optional AI Tool Stack and official installer direction.
- Add ADR 0006 documenting the official-installer transition and non-destructive npm migration stance.
- Capture macOS AI app group, cmux exclusion, and Hammerspoon launcher decisions.

## Validation
- `git diff --check`
- `git diff --cached --check`

Related to #81.