### PR TITLE
Improve tpod routine output

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -69,8 +69,8 @@ The GitHub repository that hosts **Terrapod** and this repository's declared dot
 _Avoid_: dotfiles repository, legacy source URL
 
 **tpod**:
-The short command alias for **Terrapod**.
-_Avoid_: separate tool, primary brand name
+The preferred day-to-day command spelling for **Terrapod**.
+_Avoid_: separate tool, brand name
 
 **Terrapod Setup**:
 The interactive setup workflow that turns a **Preset** into concrete machine-local **Terrapod** settings before the initial apply.
@@ -91,10 +91,10 @@ _Avoid_: separate Korean introduction, independent README, self-labeled translat
 ## Relationships
 
 - The **Dotfiles Management Tool** is the user-facing entry point for first install, configuration changes, and routine dotfiles maintenance.
-- **Terrapod** is the primary command and brand name for the **Dotfiles Management Tool**.
-- **tpod** is a compatibility and convenience alias for **Terrapod**, not a separate interface.
-- User-facing quick-start and routine command examples should introduce `tpod` as the preferred day-to-day short command while preserving `terrapod` as the full command and brand.
-- Installation, bootstrap recovery, and explicit setup/configuration examples may continue to use `terrapod` when the full command name improves clarity.
+- **Terrapod** is the brand name and full command for the **Dotfiles Management Tool**.
+- **tpod** is the preferred day-to-day command spelling for **Terrapod**, not a separate interface.
+- User-facing help, quick-start, routine command examples, and guidance should use `tpod` for copyable commands while preserving `terrapod` as the full executable spelling in a concise alias note.
+- Installation and bootstrap recovery examples may continue to use checked-out executable paths or `terrapod` when the full command name improves clarity before the alias is installed.
 - The **Terrapod Source Repository** uses `juty9026/terrapod` as its canonical GitHub slug.
 - Public first-run installation references use the HTTPS **Terrapod Source Repository** URL `https://github.com/juty9026/terrapod.git`.
 - Maintainer remotes may use the SSH **Terrapod Source Repository** URL `git@github.com:juty9026/terrapod.git`.
@@ -171,9 +171,9 @@ _Avoid_: separate Korean introduction, independent README, self-labeled translat
 - mise with its aqua backend is the **Modern CLI Provider**.
 - **Terrapod** applies this repository's declared dotfiles state; it does not act as the package manager for OS packages or mise-managed tool upgrades.
 - **Terrapod** may install declared dependencies needed to reach the target state, but it does not run broad version upgrade commands such as `brew upgrade`, `apt upgrade`, or `mise upgrade`.
-- `terrapod update` delegates repository update semantics to `chezmoi update` and adds Terrapod-specific context and validation around it.
-- README and command output describe `terrapod update` as a source update so it is not confused with Homebrew, APT, or mise upgrades.
-- README and command output describe `terrapod diff` and `terrapod apply` as declared-state operations delegated to chezmoi.
+- `tpod update` delegates repository update semantics to `chezmoi update` and adds Terrapod-specific context and validation around it.
+- README and command output describe `tpod update` as a source update so it is not confused with Homebrew, APT, or mise upgrades.
+- README and command output describe `tpod diff` and `tpod apply` as declared-state operations delegated to chezmoi.
 - After successful first-run apply, the installer should surface `tpod help` so users discover the day-to-day short command immediately.
 - The **macOS Desktop App Stack** is opt-in because Homebrew casks can install shared applications and desktop support assets outside a single user's home directory.
 - The **macOS Desktop App Stack** excludes Homebrew itself, shared CLI formulae such as mise and btop, and terminal font casks.
@@ -213,16 +213,18 @@ _Avoid_: separate Korean introduction, independent README, self-labeled translat
 - Changes to the **Canonical README** should make heading-structure drift in the **Korean README** visible during maintenance.
 - README drift checks compare corresponding section headings only; they do not enforce paragraph, table, or code block parity.
 - README drift checks compare all Markdown heading lines from `README.md` and `README.ko.md` for exact text and order.
-- `terrapod help` may carry a concise product introduction, but routine command output stays operational and scan-friendly.
-- `terrapod help` introduces **Terrapod** as a small landing pod for dotfiles and immediately states that chezmoi remains underneath while package-manager upgrades stay outside scope.
-- Routine command output uses stable labels such as Profile, Config, Preflight, Delegating, Post-apply validation, and Guidance instead of brand metaphors.
-- Routine command stage labels may be lightly polished when the result stays concise, stable, and clear in copied logs.
-- The current command-output pass stays simple and does not add emoji or terminal color behavior.
-- `terrapod apply` should stay focused on declared-state apply context, preflight, delegation, and post-apply validation; it should not expand into a rich installed-tool report in the current scope.
+- `tpod help` may carry a concise product introduction, but routine command output stays operational and scan-friendly.
+- `tpod help` introduces **Terrapod** as a small landing pod for dotfiles and immediately states that chezmoi remains underneath while package-manager upgrades stay outside scope.
+- Routine command output uses stable labels such as Profile, Config, Preflight, Delegating, Post-apply validation, and Guidance, with visual alignment and terminal color when they improve scanning without obscuring copied logs.
+- Routine command stage labels may be polished when the result stays concise, stable, and clear.
+- Routine command visual treatment applies to `tpod help`, `tpod status`, `tpod doctor`, `tpod diff`, `tpod apply`, and `tpod update`, without emoji or a separate plain-mode environment variable.
+- Routine command color is enabled only for compatible terminal output and disabled for non-TTY output, `TERM=dumb`, or `NO_COLOR`.
+- Routine command color uses cyan or bold for titles and sections, green for successful or enabled states, yellow for warnings and missing/unsupported states, red for failed states, and neutral styling for paths, commands, and values.
+- `tpod apply` should stay focused on declared-state apply context, preflight, delegation, and post-apply validation; it should not expand into a rich installed-tool report in the current scope.
 - The first-run **Terrapod** installer uses a gum-backed terminal presentation for initial setup prompts such as **Preset** selection.
 - The gum-backed first-run installer presentation is a required interactive path; non-TTY, dumb terminal, scripted, and missing-gum environments fail with guidance until non-interactive setup options are designed.
 - Rich **Terrapod Setup** presentation may use setup-only emoji, color, spacing, and aligned prompt layout when it improves first-run review clarity.
-- Rich **Terrapod Setup** presentation does not imply emoji or terminal color behavior for routine **Terrapod** command output.
+- Routine command visual treatment is separate from rich **Terrapod Setup** presentation; Setup remains its own gum-backed UI.
 - Error output avoids product metaphor and states the failed condition plus the next useful action.
 
 ## Example Dialogue

--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -eu
 
+STATE_LABEL_WIDTH=30
+
 supports_color() {
   [ -t 1 ] &&
     [ -n "${TERM:-}" ] &&
@@ -61,7 +63,7 @@ print_colon_state_line() {
   state="$2"
   detail="${3:-}"
 
-  printf '%s: ' "$prefix"
+  printf '%-*s: ' "$STATE_LABEL_WIDTH" "$prefix"
   print_state_word "$state"
   if [ -n "$detail" ]; then
     printf ' %s' "$detail"
@@ -74,7 +76,8 @@ print_indented_colon_state_line() {
   state="$2"
   detail="${3:-}"
 
-  printf '  %s: ' "$prefix"
+  printf '  '
+  printf '%-*s: ' "$STATE_LABEL_WIDTH" "$prefix"
   print_state_word "$state"
   if [ -n "$detail" ]; then
     printf ' %s' "$detail"
@@ -806,7 +809,7 @@ print_stack_status() {
       print_indented_colon_state_line "$label" "enabled" "(tools available: $(join_tools "$@"))"
     fi
   else
-    printf '  %s: disabled\n' "$label"
+    print_indented_colon_state_line "$label" "disabled"
   fi
 }
 
@@ -818,7 +821,7 @@ print_optional_setting_status() {
   if is_enabled "$enabled"; then
     print_indented_colon_state_line "$label" "enabled" "($detail)"
   else
-    printf '  %s: disabled\n' "$label"
+    print_indented_colon_state_line "$label" "disabled"
   fi
 }
 
@@ -835,27 +838,27 @@ print_macos_app_group_status() {
   if is_enabled "$(config_data_bool "$config_file" enableMacosAppGroupTerminalApps)"; then
     print_indented_colon_state_line "terminal-apps" "enabled" "(Ghostty)"
   else
-    printf '%s\n' "  terminal-apps: disabled"
+    print_indented_colon_state_line "terminal-apps" "disabled"
   fi
   if is_enabled "$(config_data_bool "$config_file" enableMacosAppGroupAutomation)"; then
     print_indented_colon_state_line "automation" "enabled" "(Hammerspoon and Karabiner-Elements)"
   else
-    printf '%s\n' "  automation: disabled"
+    print_indented_colon_state_line "automation" "disabled"
   fi
   if is_enabled "$(config_data_bool "$config_file" enableMacosAppGroupLauncher)"; then
     print_indented_colon_state_line "launcher" "enabled" "(Raycast and 1Password CLI)"
   else
-    printf '%s\n' "  launcher: disabled"
+    print_indented_colon_state_line "launcher" "disabled"
   fi
   if is_enabled "$(config_data_bool "$config_file" enableMacosAppGroupMonitoring)"; then
     print_indented_colon_state_line "monitoring" "enabled" "(iStat Menus)"
   else
-    printf '%s\n' "  monitoring: disabled"
+    print_indented_colon_state_line "monitoring" "disabled"
   fi
   if is_enabled "$(config_data_bool "$config_file" enableMacosAppGroupAiApps)"; then
     print_indented_colon_state_line "ai-apps" "enabled" "(Claude Desktop, Codex Desktop, Antigravity 2.0, and Antigravity IDE)"
   else
-    printf '%s\n' "  ai-apps: disabled"
+    print_indented_colon_state_line "ai-apps" "disabled"
   fi
 }
 

--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -1,54 +1,138 @@
 #!/bin/sh
 set -eu
 
+supports_color() {
+  [ -t 1 ] &&
+    [ -n "${TERM:-}" ] &&
+    [ "${TERM:-}" != "dumb" ] &&
+    [ -z "${NO_COLOR+x}" ]
+}
+
+print_styled() {
+  style="$1"
+  text="$2"
+
+  if supports_color; then
+    printf '\033[%sm%s\033[0m' "$style" "$text"
+  else
+    printf '%s' "$text"
+  fi
+}
+
+print_styled_line() {
+  print_styled "$1" "$2"
+  printf '\n'
+}
+
+print_title() {
+  print_styled_line "1;36" "$1"
+}
+
+print_section() {
+  print_styled_line "36" "$1"
+}
+
+print_section_value() {
+  print_styled "36" "$1"
+  printf ' %s\n' "$2"
+}
+
+print_state_word() {
+  state_word="$1"
+
+  case "$state_word" in
+    enabled|available|ok|present|managed|readable|supported|none)
+      print_styled "32" "$state_word"
+      ;;
+    warning|missing|unsupported|warn)
+      print_styled "33" "$state_word"
+      ;;
+    failed|fail)
+      print_styled "31" "$state_word"
+      ;;
+    *)
+      printf '%s' "$state_word"
+      ;;
+  esac
+}
+
+print_colon_state_line() {
+  prefix="$1"
+  state="$2"
+  detail="${3:-}"
+
+  printf '%s: ' "$prefix"
+  print_state_word "$state"
+  if [ -n "$detail" ]; then
+    printf ' %s' "$detail"
+  fi
+  printf '\n'
+}
+
+print_indented_colon_state_line() {
+  prefix="$1"
+  state="$2"
+  detail="${3:-}"
+
+  printf '  %s: ' "$prefix"
+  print_state_word "$state"
+  if [ -n "$detail" ]; then
+    printf ' %s' "$detail"
+  fi
+  printf '\n'
+}
+
+print_warning_line() {
+  print_styled "33" "Warning:"
+  printf ' %s\n' "$1"
+}
+
 show_help() {
   preset_args="$(available_preset_args "$(current_profile)")"
 
-  cat <<EOF
-Terrapod - a small landing pod for your dotfiles
-Uses chezmoi underneath; keeps package-manager upgrades outside its scope.
-
-Usage:
-  terrapod [help|--help|-h]
-  terrapod setup
-  terrapod configure <$preset_args>
-  terrapod status
-  terrapod doctor
-  terrapod diff
-  terrapod apply
-  terrapod update
-  terrapod chezmoi -- <args...>
-
-Commands:
-  help                                  Show this help.
-  setup                                 Run interactive Terrapod Setup.
-  configure <$preset_args>
-                                        Expand a Preset into concrete chezmoi data values.
-  status                                Explain this machine's Terrapod profile, config, stack, and tool state.
-  doctor                                Validate Terrapod prerequisites and report actionable guidance.
-  diff                                  Run chezmoi diff with Terrapod profile and stack context.
-  apply                                 Run preflight checks, chezmoi apply, and post-apply validation.
-  update                                Run chezmoi update with Terrapod profile and config context.
-  chezmoi -- <args...>                  Run raw chezmoi for advanced maintenance.
-
-Examples:
-  terrapod setup
-  terrapod configure development
-  tpod status
-  tpod doctor
-  tpod diff
-  tpod apply
-  tpod update
-  terrapod chezmoi -- status
-
-Alias:
-  tpod is the short day-to-day alias for terrapod.
-EOF
+  print_title "Terrapod - a small landing pod for your dotfiles"
+  printf '%s\n' "Uses chezmoi underneath; keeps package-manager upgrades outside its scope."
+  printf '\n'
+  print_section "Usage:"
+  printf '%s\n' "  tpod [help|--help|-h]"
+  printf '%s\n' "  tpod setup"
+  printf '%s\n' "  tpod configure <$preset_args>"
+  printf '%s\n' "  tpod status"
+  printf '%s\n' "  tpod doctor"
+  printf '%s\n' "  tpod diff"
+  printf '%s\n' "  tpod apply"
+  printf '%s\n' "  tpod update"
+  printf '%s\n' "  tpod chezmoi -- <args...>"
+  printf '\n'
+  print_section "Commands:"
+  printf '%s\n' "  help                                  Show this help."
+  printf '%s\n' "  setup                                 Run interactive Terrapod Setup."
+  printf '%s\n' "  configure <$preset_args>"
+  printf '%s\n' "                                        Expand a Preset into concrete chezmoi data values."
+  printf '%s\n' "  status                                Explain this machine's Terrapod profile, config, stack, and tool state."
+  printf '%s\n' "  doctor                                Validate Terrapod prerequisites and report actionable guidance."
+  printf '%s\n' "  diff                                  Run chezmoi diff with Terrapod profile and stack context."
+  printf '%s\n' "  apply                                 Run preflight checks, chezmoi apply, and post-apply validation."
+  printf '%s\n' "  update                                Run chezmoi update with Terrapod profile and config context."
+  printf '%s\n' "  chezmoi -- <args...>                  Run raw chezmoi for advanced maintenance."
+  printf '\n'
+  print_section "Examples:"
+  printf '%s\n' "  tpod setup"
+  printf '%s\n' "  tpod configure development"
+  printf '%s\n' "  tpod status"
+  printf '%s\n' "  tpod doctor"
+  printf '%s\n' "  tpod diff"
+  printf '%s\n' "  tpod apply"
+  printf '%s\n' "  tpod update"
+  printf '%s\n' "  tpod chezmoi -- status"
+  printf '\n'
+  print_section "Note:"
+  printf '%s\n' "  terrapod also works as the full command."
 }
 
 fail_usage() {
   printf '%s\n' "terrapod: $1" >&2
-  printf '%s\n' "Run 'terrapod help' for usage." >&2
+  printf '%s\n' "Run 'tpod help' for usage." >&2
   exit 64
 }
 
@@ -237,13 +321,13 @@ require_gum_setup() {
 
   if [ ! -t 0 ] || [ ! -t 2 ] || [ -z "${TERM:-}" ] || [ "${TERM:-}" = "dumb" ] || [ -n "${CI:-}" ]; then
     printf '%s\n' "terrapod: Terrapod Setup requires an interactive terminal supported by gum" >&2
-    printf '%s\n' "Run 'terrapod setup' from a real terminal with TERM set, stdin/stderr attached to a TTY, and CI unset." >&2
+    printf '%s\n' "Run 'tpod setup' from a real terminal with TERM set, stdin/stderr attached to a TTY, and CI unset." >&2
     exit 1
   fi
 }
 
 fatal_gum_setup_failure() {
-  fatal "gum failed during Terrapod Setup; fix gum and rerun 'terrapod setup'"
+  fatal "gum failed during Terrapod Setup; fix gum and rerun 'tpod setup'"
 }
 
 setup_style() {
@@ -709,22 +793,18 @@ missing_tools() {
   printf '%s\n' "$missing"
 }
 
-tool_phrase() {
-  missing="$(missing_tools "$@")"
-  if [ -n "$missing" ]; then
-    printf '%s\n' "missing tools: $missing"
-  else
-    printf '%s\n' "tools available: $(join_tools "$@")"
-  fi
-}
-
 print_stack_status() {
   label="$1"
   enabled="$2"
   shift 2
 
   if is_enabled "$enabled"; then
-    printf '  %s: enabled (%s)\n' "$label" "$(tool_phrase "$@")"
+    missing="$(missing_tools "$@")"
+    if [ -n "$missing" ]; then
+      print_indented_colon_state_line "$label" "enabled" "(missing tools: $missing)"
+    else
+      print_indented_colon_state_line "$label" "enabled" "(tools available: $(join_tools "$@"))"
+    fi
   else
     printf '  %s: disabled\n' "$label"
   fi
@@ -736,7 +816,7 @@ print_optional_setting_status() {
   detail="$3"
 
   if is_enabled "$enabled"; then
-    printf '  %s: enabled (%s)\n' "$label" "$detail"
+    print_indented_colon_state_line "$label" "enabled" "($detail)"
   else
     printf '  %s: disabled\n' "$label"
   fi
@@ -751,29 +831,29 @@ print_macos_app_group_status() {
     return
   fi
 
-  printf '%s\n' "macOS App Groups:"
+  print_section "macOS App Groups:"
   if is_enabled "$(config_data_bool "$config_file" enableMacosAppGroupTerminalApps)"; then
-    printf '%s\n' "  terminal-apps: enabled (Ghostty)"
+    print_indented_colon_state_line "terminal-apps" "enabled" "(Ghostty)"
   else
     printf '%s\n' "  terminal-apps: disabled"
   fi
   if is_enabled "$(config_data_bool "$config_file" enableMacosAppGroupAutomation)"; then
-    printf '%s\n' "  automation: enabled (Hammerspoon and Karabiner-Elements)"
+    print_indented_colon_state_line "automation" "enabled" "(Hammerspoon and Karabiner-Elements)"
   else
     printf '%s\n' "  automation: disabled"
   fi
   if is_enabled "$(config_data_bool "$config_file" enableMacosAppGroupLauncher)"; then
-    printf '%s\n' "  launcher: enabled (Raycast and 1Password CLI)"
+    print_indented_colon_state_line "launcher" "enabled" "(Raycast and 1Password CLI)"
   else
     printf '%s\n' "  launcher: disabled"
   fi
   if is_enabled "$(config_data_bool "$config_file" enableMacosAppGroupMonitoring)"; then
-    printf '%s\n' "  monitoring: enabled (iStat Menus)"
+    print_indented_colon_state_line "monitoring" "enabled" "(iStat Menus)"
   else
     printf '%s\n' "  monitoring: disabled"
   fi
   if is_enabled "$(config_data_bool "$config_file" enableMacosAppGroupAiApps)"; then
-    printf '%s\n' "  ai-apps: enabled (Claude Desktop, Codex Desktop, Antigravity 2.0, and Antigravity IDE)"
+    print_indented_colon_state_line "ai-apps" "enabled" "(Claude Desktop, Codex Desktop, Antigravity 2.0, and Antigravity IDE)"
   else
     printf '%s\n' "  ai-apps: disabled"
   fi
@@ -782,28 +862,28 @@ print_macos_app_group_status() {
 print_key_tool_status() {
   profile="$1"
 
-  printf '%s\n' "Key tools:"
+  print_section "Key tools:"
   for tool in chezmoi git zsh mise nvim zellij; do
     if command -v "$tool" >/dev/null 2>&1; then
-      printf '  %s: available\n' "$tool"
+      print_indented_colon_state_line "$tool" "available"
     else
-      printf '  %s: missing\n' "$tool"
+      print_indented_colon_state_line "$tool" "missing"
     fi
   done
 
   case "$profile" in
     macos-terminal)
       if command -v brew >/dev/null 2>&1; then
-        printf '%s\n' "  brew: available"
+        print_indented_colon_state_line "brew" "available"
       else
-        printf '%s\n' "  brew: missing"
+        print_indented_colon_state_line "brew" "missing"
       fi
       ;;
     vps-shell)
       if command -v apt >/dev/null 2>&1; then
-        printf '%s\n' "  apt: available"
+        print_indented_colon_state_line "apt" "available"
       else
-        printf '%s\n' "  apt: missing"
+        print_indented_colon_state_line "apt" "missing"
       fi
       ;;
   esac
@@ -834,7 +914,7 @@ status_key_tool_warnings() {
   fi
 
   if [ -n "$missing" ]; then
-    printf '%s\n' "Warning: missing key tools: $missing"
+    print_warning_line "missing key tools: $missing"
     return 0
   fi
 
@@ -847,7 +927,7 @@ print_status_warnings() {
   printed=0
 
   if [ "$profile" = "unsupported" ]; then
-    printf '%s\n' "Warning: $(unsupported_profile_reason)"
+    print_warning_line "$(unsupported_profile_reason)"
     printed=1
   fi
 
@@ -858,13 +938,15 @@ print_status_warnings() {
   if is_enabled "$(effective_ai_cli_tools_enabled "$config_file")"; then
     missing="$(missing_tools agy claude codex)"
     if [ -n "$missing" ]; then
-      printf '%s\n' "Warning: Optional AI Tool Stack is enabled but missing tools: $missing"
+      print_warning_line "Optional AI Tool Stack is enabled but missing tools: $missing"
       printed=1
     fi
   fi
 
   if [ "$printed" -eq 0 ]; then
-    printf '%s\n' "Warnings: none"
+    printf '%s: ' "Warnings"
+    print_state_word "none"
+    printf '\n'
   fi
 }
 
@@ -876,10 +958,10 @@ run_status() {
   config_file="$(chezmoi_config_file)"
   profile="$(current_profile)"
 
-  printf '%s\n' "Terrapod status"
-  printf '%s\n' "Profile: $(profile_context_label)"
+  print_title "Terrapod status"
+  print_section_value "Profile:" "$(profile_context_label)"
   show_config_context "$config_file"
-  printf '%s\n' "Optional stacks:"
+  print_section "Optional stacks:"
   print_optional_setting_status "Optional Editor Stack" "$(effective_editor_stack_enabled "$config_file")" "rich Neovim configuration"
   print_stack_status "Optional AI Tool Stack" "$(effective_ai_cli_tools_enabled "$config_file")" agy claude codex
   print_optional_setting_status "Optional Development Workspace" "$(config_data_bool "$config_file" enableDevelopmentWorkspace)" "development Zellij layouts"
@@ -892,32 +974,53 @@ show_config_context() {
   config_file="$1"
 
   if [ -f "$config_file" ]; then
-    printf '%s\n' "Config: $config_file (present)"
+    print_styled "36" "Config:"
+    printf ' %s (' "$config_file"
+    print_state_word "present"
+    printf ')\n'
   else
-    printf '%s\n' "Config: $config_file (missing; chezmoi defaults apply)"
+    print_styled "36" "Config:"
+    printf ' %s (' "$config_file"
+    print_state_word "missing"
+    printf '; chezmoi defaults apply)\n'
   fi
+}
+
+print_named_state_line() {
+  label="$1"
+  state="$2"
+
+  print_colon_state_line "$label" "$state"
 }
 
 show_stack_context() {
   config_file="$1"
   profile="$2"
 
-  printf '%s\n' "Optional stacks:"
-  printf '%s\n' "Optional Editor Stack: $(effective_optional_stack_state_label "$config_file" enableEditorStack)"
-  printf '%s\n' "Optional AI Tool Stack: $(effective_optional_stack_state_label "$config_file" enableAiCliTools)"
-  printf '%s\n' "Optional Development Workspace: $(config_bool_state_label "$config_file" enableDevelopmentWorkspace)"
+  print_section "Optional stacks:"
+  editor_state="$(effective_optional_stack_state_label "$config_file" enableEditorStack)"
+  ai_state="$(effective_optional_stack_state_label "$config_file" enableAiCliTools)"
+  workspace_state="$(config_bool_state_label "$config_file" enableDevelopmentWorkspace)"
+  print_named_state_line "Optional Editor Stack" "$editor_state"
+  print_named_state_line "Optional AI Tool Stack" "$ai_state"
+  print_named_state_line "Optional Development Workspace" "$workspace_state"
 
   if [ "$profile" != "macos-terminal" ]; then
     printf '%s\n' "macOS App Groups: not applicable for $(profile_context_label)"
     return
   fi
 
-  printf '%s\n' "macOS App Groups:"
-  printf '%s\n' "terminal-apps: $(config_bool_state_label "$config_file" enableMacosAppGroupTerminalApps)"
-  printf '%s\n' "automation: $(config_bool_state_label "$config_file" enableMacosAppGroupAutomation)"
-  printf '%s\n' "launcher: $(config_bool_state_label "$config_file" enableMacosAppGroupLauncher)"
-  printf '%s\n' "monitoring: $(config_bool_state_label "$config_file" enableMacosAppGroupMonitoring)"
-  printf '%s\n' "ai-apps: $(config_bool_state_label "$config_file" enableMacosAppGroupAiApps)"
+  print_section "macOS App Groups:"
+  terminal_apps_state="$(config_bool_state_label "$config_file" enableMacosAppGroupTerminalApps)"
+  automation_state="$(config_bool_state_label "$config_file" enableMacosAppGroupAutomation)"
+  launcher_state="$(config_bool_state_label "$config_file" enableMacosAppGroupLauncher)"
+  monitoring_state="$(config_bool_state_label "$config_file" enableMacosAppGroupMonitoring)"
+  ai_apps_state="$(config_bool_state_label "$config_file" enableMacosAppGroupAiApps)"
+  print_named_state_line "terminal-apps" "$terminal_apps_state"
+  print_named_state_line "automation" "$automation_state"
+  print_named_state_line "launcher" "$launcher_state"
+  print_named_state_line "monitoring" "$monitoring_state"
+  print_named_state_line "ai-apps" "$ai_apps_state"
 }
 
 render_chezmoi_command() {
@@ -946,8 +1049,8 @@ show_diff_context() {
   config_file="$(chezmoi_config_file)"
   profile="$(current_profile)"
 
-  printf '%s\n' "Terrapod diff"
-  printf '%s\n' "Profile: $(profile_context_label)"
+  print_title "Terrapod diff"
+  print_section_value "Profile:" "$(profile_context_label)"
   show_config_context "$config_file"
   show_stack_context "$config_file" "$profile"
   printf '%s\n' "Delegating declared-state diff to: $(render_chezmoi_command diff)"
@@ -966,19 +1069,28 @@ run_apply_preflight() {
   config_file="$1"
 
   if ! command -v chezmoi >/dev/null 2>&1; then
-    fatal "chezmoi is required before apply; install it or run the Terrapod installer, then rerun 'terrapod apply'"
+    fatal "chezmoi is required before apply; install it or run the Terrapod installer, then rerun 'tpod apply'"
   fi
 
-  printf '%s\n' "Preflight: chezmoi is available"
+  print_styled "36" "Preflight:"
+  printf ' chezmoi is '
+  print_state_word "available"
+  printf '\n'
 
   if [ -e "$config_file" ] || [ -L "$config_file" ]; then
     if [ ! -f "$config_file" ] || [ ! -r "$config_file" ]; then
       fatal "config path is not a readable file: $config_file"
     fi
 
-    printf '%s\n' "Preflight: config file is readable"
+    print_styled "36" "Preflight:"
+    printf ' config file is '
+    print_state_word "readable"
+    printf '\n'
   else
-    printf '%s\n' "Preflight: config file is missing; chezmoi defaults will apply"
+    print_styled "36" "Preflight:"
+    printf ' config file is '
+    print_state_word "missing"
+    printf '; chezmoi defaults will apply\n'
   fi
 }
 
@@ -988,7 +1100,10 @@ validate_managed_target() {
   label="$3"
 
   if printf '%s\n' "$managed_output" | grep -Fx "$target" >/dev/null; then
-    printf '%s\n' "Post-apply validation: $label is managed"
+    print_styled "36" "Post-apply validation:"
+    printf ' %s is ' "$label"
+    print_state_word "managed"
+    printf '\n'
     return 0
   fi
 
@@ -999,9 +1114,9 @@ validate_managed_target() {
 
 print_post_apply_validation_guidance() {
   if [ -n "${TERRAPOD_CHEZMOI_CONFIG:-}" ]; then
-    printf '%s\n' "Run 'terrapod chezmoi -- --config $TERRAPOD_CHEZMOI_CONFIG managed' to inspect managed targets, then rerun 'terrapod apply'." >&2
+    printf '%s\n' "Run 'tpod chezmoi -- --config $TERRAPOD_CHEZMOI_CONFIG managed' to inspect managed targets, then rerun 'tpod apply'." >&2
   else
-    printf '%s\n' "Run 'terrapod chezmoi -- managed' to inspect managed targets, then rerun 'terrapod apply'." >&2
+    printf '%s\n' "Run 'tpod chezmoi -- managed' to inspect managed targets, then rerun 'tpod apply'." >&2
   fi
 }
 
@@ -1026,8 +1141,8 @@ show_apply_context() {
   config_file="$1"
   profile="$(current_profile)"
 
-  printf '%s\n' "Terrapod apply"
-  printf '%s\n' "Profile: $(profile_context_label)"
+  print_title "Terrapod apply"
+  print_section_value "Profile:" "$(profile_context_label)"
   show_config_context "$config_file"
   show_stack_context "$config_file" "$profile"
   printf '%s\n' "Delegating declared-state apply to: $(render_chezmoi_command apply)"
@@ -1043,7 +1158,7 @@ run_apply() {
   run_apply_preflight "$config_file"
 
   if ! run_chezmoi_command apply; then
-    printf '%s\n' "terrapod: chezmoi apply failed; fix the error above, then rerun 'terrapod apply'." >&2
+    printf '%s\n' "terrapod: chezmoi apply failed; fix the error above, then rerun 'tpod apply'." >&2
     return 1
   fi
 
@@ -1054,17 +1169,21 @@ doctor_failed=0
 doctor_guidance_printed=0
 
 doctor_ok() {
-  printf '  ok - %s\n' "$1"
+  printf '  '
+  print_state_word "ok"
+  printf ' - %s\n' "$1"
 }
 
 doctor_warn() {
-  printf '  warn - %s\n' "$1"
+  printf '  '
+  print_state_word "warn"
+  printf ' - %s\n' "$1"
   doctor_failed=1
 }
 
 doctor_guidance() {
   if [ "$doctor_guidance_printed" -eq 0 ]; then
-    printf '%s\n' "Guidance:"
+    print_section "Guidance:"
     doctor_guidance_printed=1
   fi
   printf '  - %s\n' "$1"
@@ -1123,14 +1242,14 @@ run_doctor() {
   config_file="$(chezmoi_config_file)"
   profile="$(current_profile)"
 
-  printf '%s\n' "Terrapod doctor"
-  printf '%s\n' "Profile: $(profile_context_label)"
+  print_title "Terrapod doctor"
+  print_section_value "Profile:" "$(profile_context_label)"
   show_config_context "$config_file"
-  printf '%s\n' "Checks:"
+  print_section "Checks:"
 
   if [ "$profile" = "unsupported" ]; then
     doctor_warn "$(unsupported_profile_reason)"
-    doctor_guidance "Run Terrapod on macOS or Ubuntu 24.04, or use 'terrapod chezmoi -- <args>' as an advanced escape hatch on unsupported systems."
+    doctor_guidance "Run Terrapod on macOS or Ubuntu 24.04, or use 'tpod chezmoi -- <args>' as an advanced escape hatch on unsupported systems."
   else
     doctor_ok "Profile is supported: $(profile_context_label)"
   fi
@@ -1156,7 +1275,7 @@ run_doctor() {
   doctor_check_optional_stack \
     "Optional AI Tool Stack" \
     "$(effective_ai_cli_tools_enabled "$config_file")" \
-    "Run terrapod chezmoi -- apply after enabling Optional AI Tool Stack, or install/apply the configured tools before relying on them." \
+    "Run tpod chezmoi -- apply after enabling Optional AI Tool Stack, or install/apply the configured tools before relying on them." \
     agy claude codex
 
   doctor_check_optional_setting \
@@ -1165,7 +1284,10 @@ run_doctor() {
     "development Zellij layouts"
 
   if [ "$doctor_guidance_printed" -eq 0 ]; then
-    printf '%s\n' "Guidance: none"
+    print_styled "36" "Guidance:"
+    printf ' '
+    print_state_word "none"
+    printf '\n'
   fi
 
   if [ "$doctor_failed" -ne 0 ]; then
@@ -1176,8 +1298,8 @@ run_doctor() {
 show_update_context() {
   config_file="$(chezmoi_config_file)"
 
-  printf '%s\n' "Terrapod update"
-  printf '%s\n' "Profile: $(profile_context_label)"
+  print_title "Terrapod update"
+  print_section_value "Profile:" "$(profile_context_label)"
   show_config_context "$config_file"
   printf '%s\n' "Delegating source update to: $(render_chezmoi_command update --exclude scripts)"
 }

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -230,6 +230,39 @@ run_setup_in_pty() {
   fi
 }
 
+run_command_in_pty() {
+  term="$1"
+  no_color_mode="$2"
+  shift 2
+
+  command_text="TERM=$(shell_quote "$term"); export TERM; TERRAPOD_PROFILE=macos-terminal; export TERRAPOD_PROFILE"
+  case "$no_color_mode" in
+    unset)
+      command_text="$command_text; unset NO_COLOR"
+      ;;
+    empty)
+      command_text="$command_text; NO_COLOR=; export NO_COLOR"
+      ;;
+    set)
+      command_text="$command_text; NO_COLOR=1; export NO_COLOR"
+      ;;
+    *)
+      fail "unknown NO_COLOR mode: $no_color_mode"
+      ;;
+  esac
+
+  command_text="$command_text;"
+  for arg do
+    command_text="$command_text $(shell_quote "$arg")"
+  done
+
+  if script --version >/dev/null 2>&1; then
+    script -q -e -c "$command_text" /dev/null
+  else
+    script -q /dev/null sh -c "$command_text"
+  fi
+}
+
 assert_contains() {
   haystack="$1"
   needle="$2"
@@ -266,11 +299,72 @@ assert_no_ansi_escape() {
   pass "$message"
 }
 
+assert_has_ansi_escape() {
+  haystack="$1"
+  message="$2"
+  escape_char="$(printf '\033')"
+
+  if ! printf '%s\n' "$haystack" | grep -F "$escape_char" >/dev/null; then
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
+assert_not_contains_ansi_before() {
+  haystack="$1"
+  text="$2"
+  message="$3"
+  escape_char="$(printf '\033')"
+
+  if printf '%s\n' "$haystack" | grep -F "$escape_char$text" >/dev/null; then
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
+assert_not_contains_ansi_after() {
+  haystack="$1"
+  text="$2"
+  message="$3"
+  escape_char="$(printf '\033')"
+
+  if printf '%s\n' "$haystack" | grep -F "$text$escape_char" >/dev/null; then
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
+assert_not_contains_colored_phrase() {
+  haystack="$1"
+  text="$2"
+  message="$3"
+
+  if printf '%s\n' "$haystack" | grep -F "m$text" >/dev/null; then
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
 assert_no_rich_setup_emoji() {
   haystack="$1"
   message="$2"
 
   if printf '%s\n' "$haystack" | grep -E '🌱|✨|▸' >/dev/null; then
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
+assert_no_routine_emoji() {
+  haystack="$1"
+  message="$2"
+
+  if printf '%s\n' "$haystack" | grep -E '🌱|✨|▸|✅|⚠|❌|🚀|🔴|🟢|🟡' >/dev/null; then
     fail "$message"
   fi
 
@@ -536,28 +630,98 @@ assert_contains \
 
 assert_contains \
   "$help_output" \
-  "terrapod chezmoi -- <args...>" \
+  "tpod [help|--help|-h]" \
+  "Terrapod help documents short help command"
+
+assert_contains \
+  "$help_output" \
+  "tpod setup" \
+  "Terrapod help documents short setup command"
+
+assert_contains \
+  "$help_output" \
+  "tpod configure <minimal|development|workstation>" \
+  "Terrapod help documents short Preset configuration"
+
+assert_contains \
+  "$help_output" \
+  "tpod status" \
+  "Terrapod help documents short status command"
+
+assert_contains \
+  "$help_output" \
+  "tpod doctor" \
+  "Terrapod help documents short doctor command"
+
+assert_contains \
+  "$help_output" \
+  "tpod diff" \
+  "Terrapod help documents short diff command"
+
+assert_contains \
+  "$help_output" \
+  "tpod apply" \
+  "Terrapod help documents short apply command"
+
+assert_contains \
+  "$help_output" \
+  "tpod update" \
+  "Terrapod help documents short update command"
+
+assert_contains \
+  "$help_output" \
+  "tpod chezmoi -- <args...>" \
   "Terrapod help documents the raw chezmoi escape hatch"
 
 assert_contains \
   "$help_output" \
-  "terrapod configure <minimal|development|workstation>" \
-  "Terrapod help documents Preset configuration"
+  "terrapod also works as the full command." \
+  "Terrapod help documents the full command note"
 
-assert_contains \
+assert_not_contains \
   "$help_output" \
   "terrapod setup" \
-  "Terrapod help lists setup"
+  "Terrapod help does not use old setup copyable command"
 
-assert_contains \
+assert_not_contains \
   "$help_output" \
-  "tpod is the short day-to-day alias for terrapod." \
-  "Terrapod help documents tpod as the day-to-day alias"
+  "terrapod configure <minimal|development|workstation>" \
+  "Terrapod help does not use old configure copyable command"
 
 assert_contains \
   "$help_output" \
   "tpod apply" \
   "Terrapod help examples lead with the short apply command"
+
+assert_not_contains \
+  "$help_output" \
+  "terrapod status" \
+  "Terrapod help does not use old status copyable command"
+
+assert_not_contains \
+  "$help_output" \
+  "terrapod doctor" \
+  "Terrapod help does not use old doctor copyable command"
+
+assert_not_contains \
+  "$help_output" \
+  "terrapod diff" \
+  "Terrapod help does not use old diff copyable command"
+
+assert_not_contains \
+  "$help_output" \
+  "terrapod apply" \
+  "Terrapod help does not use old apply copyable command"
+
+assert_not_contains \
+  "$help_output" \
+  "terrapod update" \
+  "Terrapod help does not use old update copyable command"
+
+assert_not_contains \
+  "$help_output" \
+  "terrapod chezmoi -- <args...>" \
+  "Terrapod help does not use old raw chezmoi copyable command"
 
 assert_contains \
   "$help_output" \
@@ -566,26 +730,47 @@ assert_contains \
 
 assert_contains \
   "$help_output" \
-  "terrapod status" \
+  "status" \
   "Terrapod help documents status"
 
 assert_contains \
   "$help_output" \
-  "terrapod doctor" \
+  "doctor" \
   "Terrapod help documents doctor"
+
+assert_no_ansi_escape "$help_output" "captured Terrapod help is plain without ANSI escapes"
+assert_no_routine_emoji "$help_output" "captured Terrapod help has no routine emoji"
+
+tty_help_output="$(run_command_in_pty xterm unset sh "$terrapod" help)"
+assert_has_ansi_escape "$tty_help_output" "TTY Terrapod help uses ANSI visual treatment when supported"
+
+tty_status_output="$(run_command_in_pty xterm unset sh "$terrapod" status)"
+assert_has_ansi_escape "$tty_status_output" "TTY Terrapod status uses ANSI visual treatment when supported"
+assert_not_contains_ansi_before "$tty_status_output" "macOS Terminal Profile" "TTY Terrapod status keeps profile value neutral"
+assert_not_contains_ansi_after "$tty_status_output" "macOS Terminal Profile" "TTY Terrapod status does not color through profile value"
+assert_not_contains_colored_phrase "$tty_status_output" "Profile: macOS Terminal Profile" "TTY Terrapod status does not color profile label and value as one phrase"
+
+no_color_tty_help_output="$(run_command_in_pty xterm set sh "$terrapod" help)"
+assert_no_ansi_escape "$no_color_tty_help_output" "TTY Terrapod help is plain when NO_COLOR is set"
+
+empty_no_color_tty_help_output="$(run_command_in_pty xterm empty sh "$terrapod" help)"
+assert_no_ansi_escape "$empty_no_color_tty_help_output" "TTY Terrapod help is plain when NO_COLOR is set to an empty value"
+
+dumb_help_output="$(TERM=dumb TERRAPOD_PROFILE=macos-terminal sh "$terrapod" help)"
+assert_no_ansi_escape "$dumb_help_output" "TERM=dumb Terrapod help is plain without ANSI escapes"
 
 macos_help_output="$(TERRAPOD_PROFILE=macos-terminal sh "$terrapod" help)"
 
 assert_contains \
   "$macos_help_output" \
-  "terrapod configure <minimal|development|workstation>" \
+  "tpod configure <minimal|development|workstation>" \
   "macOS Terminal Profile help exposes workstation Preset"
 
 vps_help_output="$(TERRAPOD_PROFILE=vps-shell sh "$terrapod" help)"
 
 assert_contains \
   "$vps_help_output" \
-  "terrapod configure <minimal|development>" \
+  "tpod configure <minimal|development>" \
   "VPS Shell Profile help hides workstation Preset"
 
 assert_not_contains \
@@ -768,7 +953,8 @@ pass "setup fails when gum returns an operational error"
 
 gum_error_output_text="$(cat "$gum_error_output")"
 assert_contains "$gum_error_output_text" "gum failed during Terrapod Setup" "gum operational error explains gum failure"
-assert_contains "$gum_error_output_text" "rerun 'terrapod setup'" "gum operational error gives rerun guidance"
+assert_contains "$gum_error_output_text" "rerun 'tpod setup'" "gum operational error gives rerun guidance with tpod"
+assert_not_contains "$gum_error_output_text" "rerun 'terrapod setup'" "gum operational error avoids old rerun command"
 assert_not_contains "$gum_error_output_text" "setup cancelled" "gum operational error is not reported as cancellation"
 
 if [ -e "$gum_error_config" ]; then
@@ -886,7 +1072,7 @@ assert_contains \
 
 assert_contains \
   "$unknown_error" \
-  "Run 'terrapod help' for usage." \
+  "Run 'tpod help' for usage." \
   "unknown Terrapod subcommands point to help"
 
 export CHEZMOI_CALL_FILE="$tmp_dir/chezmoi.args"
@@ -975,6 +1161,17 @@ assert_no_ansi_escape "$help_output" "Terrapod help does not use setup ANSI pres
 assert_no_rich_setup_emoji "$help_output" "Terrapod help does not use setup emoji presentation"
 assert_no_ansi_escape "$macos_status_output" "Terrapod status does not use setup ANSI presentation"
 assert_no_rich_setup_emoji "$macos_status_output" "Terrapod status does not use setup emoji presentation"
+assert_no_routine_emoji "$macos_status_output" "captured Terrapod status has no routine emoji"
+
+tty_macos_status_output="$(
+  run_command_in_pty xterm unset env TERRAPOD_CHEZMOI_CONFIG="$status_config" PATH="$macos_status_path" /bin/sh "$terrapod" status
+)"
+assert_has_ansi_escape "$tty_macos_status_output" "TTY Terrapod status with config uses ANSI visual treatment"
+assert_not_contains_colored_phrase "$tty_macos_status_output" "Profile: macOS Terminal Profile" "TTY Terrapod status keeps profile value out of the section style"
+assert_not_contains_colored_phrase "$tty_macos_status_output" "Config: $status_config" "TTY Terrapod status keeps config path neutral"
+assert_not_contains_colored_phrase "$tty_macos_status_output" "Optional Editor Stack: enabled (rich Neovim configuration)" "TTY Terrapod status does not color optional-stack detail as one phrase"
+assert_not_contains_colored_phrase "$tty_macos_status_output" "Optional AI Tool Stack: enabled (tools available: agy, claude, codex)" "TTY Terrapod status does not color optional-stack tool list as one phrase"
+assert_not_contains_colored_phrase "$tty_macos_status_output" "chezmoi: available" "TTY Terrapod status does not color tool names with state words"
 
 status_dotted_config="$tmp_dir/status-dotted.toml"
 cat >"$status_dotted_config" <<'TOML'
@@ -1129,6 +1326,13 @@ assert_contains "$doctor_ok_output" "ok - Optional Editor Stack is disabled" "Te
 assert_contains "$doctor_ok_output" "ok - Optional AI Tool Stack is disabled" "Terrapod doctor treats disabled Optional AI Tool Stack as valid"
 assert_contains "$doctor_ok_output" "ok - Optional Development Workspace is disabled" "Terrapod doctor treats disabled Optional Development Workspace as valid"
 assert_contains "$doctor_ok_output" "Guidance: none" "Terrapod doctor prints no guidance when checks pass"
+assert_no_ansi_escape "$doctor_ok_output" "captured Terrapod doctor is plain without ANSI escapes"
+assert_no_routine_emoji "$doctor_ok_output" "captured Terrapod doctor has no routine emoji"
+
+tty_doctor_output="$(
+  run_command_in_pty xterm unset env TERRAPOD_PROFILE= TERRAPOD_OS_RELEASE_FILE="$doctor_os_release" TERRAPOD_CHEZMOI_CONFIG="$doctor_config" PATH="$doctor_ok_path" /bin/sh "$terrapod" doctor
+)"
+assert_has_ansi_escape "$tty_doctor_output" "TTY Terrapod doctor uses ANSI visual treatment"
 
 doctor_missing_key_path="$(status_doctor_path doctor-missing-key git zsh mise nvim zellij apt)"
 write_stub "$doctor_missing_key_path/uname" 'printf "%s\n" "Linux"'
@@ -1179,7 +1383,8 @@ doctor_missing_output="$(cat "$tmp_dir/doctor-missing.out")"
 assert_contains "$doctor_missing_output" "ok - Optional Editor Stack is enabled (rich Neovim configuration)" "Terrapod doctor reports enabled Optional Editor Stack as rich config state"
 assert_contains "$doctor_missing_output" "warn - Optional AI Tool Stack is enabled but missing tools: agy, claude, codex" "Terrapod doctor warns about missing enabled AI tools"
 assert_contains "$doctor_missing_output" "ok - Optional Development Workspace is enabled (development Zellij layouts)" "Terrapod doctor reports enabled Optional Development Workspace as layout state"
-assert_contains "$doctor_missing_output" "Run terrapod chezmoi -- apply after enabling Optional AI Tool Stack, or install/apply the configured tools before relying on them." "Terrapod doctor gives actionable missing optional-stack guidance"
+assert_contains "$doctor_missing_output" "Run tpod chezmoi -- apply after enabling Optional AI Tool Stack, or install/apply the configured tools before relying on them." "Terrapod doctor gives actionable missing optional-stack guidance with tpod"
+assert_not_contains "$doctor_missing_output" "Run terrapod chezmoi -- apply" "Terrapod doctor avoids old optional-stack guidance command"
 
 doctor_unsupported_os_release="$tmp_dir/doctor-unsupported-os-release"
 write_os_release "$doctor_unsupported_os_release" debian 12 "Debian GNU/Linux 12"
@@ -1304,6 +1509,15 @@ assert_contains \
   "$update_output" \
   "Delegating source update to: chezmoi update --exclude scripts" \
   "Terrapod update explains the delegated command"
+
+assert_no_ansi_escape "$update_output" "captured Terrapod update is plain without ANSI escapes"
+assert_no_routine_emoji "$update_output" "captured Terrapod update has no routine emoji"
+
+tty_update_output="$(
+  run_command_in_pty xterm unset env HOME="$update_home" XDG_CONFIG_HOME="$update_xdg" PATH="$tmp_dir/bin:/usr/bin:/bin" sh "$terrapod" update
+)"
+assert_has_ansi_escape "$tty_update_output" "TTY Terrapod update uses ANSI visual treatment"
+assert_not_contains_colored_phrase "$tty_update_output" "Delegating source update to: chezmoi update --exclude scripts" "TTY Terrapod update keeps delegated command text neutral"
 
 if [ -e "$BROAD_UPGRADE_CALL_FILE" ]; then
   printf '%s\n' "unexpected broad upgrade command calls:" >&2
@@ -1510,6 +1724,14 @@ assert_contains \
   "stub diff output" \
   "Terrapod diff includes delegated chezmoi diff output"
 
+assert_no_ansi_escape "$diff_output" "captured Terrapod diff is plain without ANSI escapes"
+assert_no_routine_emoji "$diff_output" "captured Terrapod diff has no routine emoji"
+
+tty_diff_output="$(
+  run_command_in_pty xterm unset env HOME="$diff_home" XDG_CONFIG_HOME="$diff_xdg" PATH="$tmp_dir/bin:/usr/bin:/bin" sh "$terrapod" diff
+)"
+assert_has_ansi_escape "$tty_diff_output" "TTY Terrapod diff uses ANSI visual treatment"
+
 if [ -e "$BROAD_UPGRADE_CALL_FILE" ]; then
   printf '%s\n' "unexpected broad upgrade command calls during diff:" >&2
   sed 's/^/  /' "$BROAD_UPGRADE_CALL_FILE" >&2
@@ -1711,6 +1933,14 @@ assert_contains \
   "Post-apply validation: tpod alias is managed" \
   "Terrapod apply validates the tpod alias managed target"
 
+assert_no_ansi_escape "$apply_output" "captured Terrapod apply is plain without ANSI escapes"
+assert_no_routine_emoji "$apply_output" "captured Terrapod apply has no routine emoji"
+
+tty_apply_output="$(
+  run_command_in_pty xterm unset env HOME="$diff_home" XDG_CONFIG_HOME="$diff_xdg" PATH="$tmp_dir/bin:/usr/bin:/bin" sh "$terrapod" apply
+)"
+assert_has_ansi_escape "$tty_apply_output" "TTY Terrapod apply uses ANSI visual treatment"
+
 if [ -e "$BROAD_UPGRADE_CALL_FILE" ]; then
   printf '%s\n' "unexpected broad upgrade command calls during apply:" >&2
   sed 's/^/  /' "$BROAD_UPGRADE_CALL_FILE" >&2
@@ -1738,6 +1968,74 @@ if [ -e "$CHEZMOI_APPLY_INVOKED_FILE" ]; then
 fi
 
 pass "Terrapod apply rejects extra arguments before calling chezmoi apply"
+
+write_stub "$tmp_dir/bin/chezmoi" \
+  'command_name=' \
+  'for arg do' \
+  '  case "$arg" in' \
+  '    apply|managed)' \
+  '      command_name="$arg"' \
+  '      ;;' \
+  '  esac' \
+  'done' \
+  'case "$command_name" in' \
+  '  apply)' \
+  '    printf "%s\n" invoked >"$CHEZMOI_APPLY_INVOKED_FILE"' \
+  '    printf "%s\n" "simulated apply failure" >&2' \
+  '    exit 91' \
+  '    ;;' \
+  'esac' \
+  'printf "%s\n" "unexpected chezmoi command: $*" >&2' \
+  'exit 92'
+
+if HOME="$diff_home" XDG_CONFIG_HOME="$diff_xdg" PATH="$tmp_dir/bin:/usr/bin:/bin" \
+  sh "$terrapod" apply >"$tmp_dir/apply-failure.out" 2>"$tmp_dir/apply-failure.err"; then
+  fail "Terrapod apply fails when delegated chezmoi apply fails"
+fi
+
+apply_failure_error="$(cat "$tmp_dir/apply-failure.err")"
+
+assert_contains \
+  "$apply_failure_error" \
+  "terrapod: chezmoi apply failed; fix the error above, then rerun 'tpod apply'." \
+  "Terrapod apply failure guidance uses tpod"
+
+assert_not_contains \
+  "$apply_failure_error" \
+  "rerun 'terrapod apply'" \
+  "Terrapod apply failure avoids old rerun command"
+
+write_stub "$tmp_dir/bin/chezmoi" \
+  'command_name=' \
+  'for arg do' \
+  '  case "$arg" in' \
+  '    apply|managed)' \
+  '      command_name="$arg"' \
+  '      ;;' \
+  '  esac' \
+  'done' \
+  'case "$command_name" in' \
+  '  apply)' \
+  '    printf "%s\n" invoked >"$CHEZMOI_APPLY_INVOKED_FILE"' \
+  '    : >"$CHEZMOI_APPLY_ARGS_FILE"' \
+  '    for arg do' \
+  '      printf "%s\n" "$arg" >>"$CHEZMOI_APPLY_ARGS_FILE"' \
+  '    done' \
+  '    printf "%s\n" "stub apply output"' \
+  '    exit 0' \
+  '    ;;' \
+  '  managed)' \
+  '    : >"$CHEZMOI_MANAGED_ARGS_FILE"' \
+  '    for arg do' \
+  '      printf "%s\n" "$arg" >>"$CHEZMOI_MANAGED_ARGS_FILE"' \
+  '    done' \
+  '    printf "%s\n" ".local/bin/terrapod"' \
+  '    printf "%s\n" ".local/bin/tpod"' \
+  '    exit 0' \
+  '    ;;' \
+  'esac' \
+  'printf "%s\n" "unexpected chezmoi command: $*" >&2' \
+  'exit 91'
 
 rm -f "$CHEZMOI_APPLY_ARGS_FILE" "$CHEZMOI_APPLY_INVOKED_FILE" "$CHEZMOI_MANAGED_ARGS_FILE"
 
@@ -1847,8 +2145,13 @@ assert_contains \
 
 assert_contains \
   "$apply_validation_error" \
-  "Run 'terrapod chezmoi -- managed' to inspect managed targets, then rerun 'terrapod apply'." \
-  "Terrapod apply gives actionable post-apply validation guidance"
+  "Run 'tpod chezmoi -- managed' to inspect managed targets, then rerun 'tpod apply'." \
+  "Terrapod apply gives actionable post-apply validation guidance with tpod"
+
+assert_not_contains \
+  "$apply_validation_error" \
+  "Run 'terrapod chezmoi -- managed'" \
+  "Terrapod apply avoids old post-apply validation inspection command"
 
 rm -f "$CHEZMOI_APPLY_ARGS_FILE" "$CHEZMOI_APPLY_INVOKED_FILE" "$CHEZMOI_MANAGED_ARGS_FILE"
 
@@ -1866,5 +2169,10 @@ assert_contains \
 
 assert_contains \
   "$apply_override_validation_error" \
-  "Run 'terrapod chezmoi -- --config $diff_config managed' to inspect managed targets, then rerun 'terrapod apply'." \
-  "Terrapod apply gives config-aware post-apply validation guidance"
+  "Run 'tpod chezmoi -- --config $diff_config managed' to inspect managed targets, then rerun 'tpod apply'." \
+  "Terrapod apply gives config-aware post-apply validation guidance with tpod"
+
+assert_not_contains \
+  "$apply_override_validation_error" \
+  "Run 'terrapod chezmoi -- --config $diff_config managed'" \
+  "Terrapod apply avoids old config-aware post-apply validation command"

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -1145,16 +1145,16 @@ macos_status_output="$(
 assert_contains "$macos_status_output" "Terrapod status" "Terrapod status prints a command heading"
 assert_contains "$macos_status_output" "Profile: macOS Terminal Profile" "Terrapod status reports macOS Terminal Profile context"
 assert_contains "$macos_status_output" "Config: $status_config (present)" "Terrapod status reports explicit config path"
-assert_contains "$macos_status_output" "Optional Editor Stack: enabled (rich Neovim configuration)" "Terrapod status reports enabled Optional Editor Stack state"
-assert_contains "$macos_status_output" "Optional AI Tool Stack: enabled (tools available: agy, claude, codex)" "Terrapod status reports enabled Optional AI Tool Stack tool state"
+assert_contains "$macos_status_output" "Optional Editor Stack         : enabled (rich Neovim configuration)" "Terrapod status reports enabled Optional Editor Stack state"
+assert_contains "$macos_status_output" "Optional AI Tool Stack        : enabled (tools available: agy, claude, codex)" "Terrapod status reports enabled Optional AI Tool Stack tool state"
 assert_contains "$macos_status_output" "Optional Development Workspace: enabled (development Zellij layouts)" "Terrapod status reports enabled Optional Development Workspace state"
-assert_contains "$macos_status_output" "terminal-apps: enabled (Ghostty)" "Terrapod status reports enabled Ghostty-only terminal-apps macOS App Group"
-assert_contains "$macos_status_output" "automation: disabled" "Terrapod status reports disabled automation macOS App Group"
-assert_contains "$macos_status_output" "launcher: enabled (Raycast and 1Password CLI)" "Terrapod status reports enabled launcher macOS App Group"
-assert_contains "$macos_status_output" "monitoring: disabled" "Terrapod status reports disabled monitoring macOS App Group"
-assert_contains "$macos_status_output" "ai-apps: enabled (Claude Desktop, Codex Desktop, Antigravity 2.0, and Antigravity IDE)" "Terrapod status reports enabled ai-apps macOS App Group"
-assert_contains "$macos_status_output" "chezmoi: available" "Terrapod status reports chezmoi availability"
-assert_contains "$macos_status_output" "brew: available" "Terrapod status reports macOS Bootstrap Package Manager availability"
+assert_contains "$macos_status_output" "terminal-apps                 : enabled (Ghostty)" "Terrapod status reports enabled Ghostty-only terminal-apps macOS App Group"
+assert_contains "$macos_status_output" "automation                    : disabled" "Terrapod status reports disabled automation macOS App Group"
+assert_contains "$macos_status_output" "launcher                      : enabled (Raycast and 1Password CLI)" "Terrapod status reports enabled launcher macOS App Group"
+assert_contains "$macos_status_output" "monitoring                    : disabled" "Terrapod status reports disabled monitoring macOS App Group"
+assert_contains "$macos_status_output" "ai-apps                       : enabled (Claude Desktop, Codex Desktop, Antigravity 2.0, and Antigravity IDE)" "Terrapod status reports enabled ai-apps macOS App Group"
+assert_contains "$macos_status_output" "chezmoi                       : available" "Terrapod status reports chezmoi availability"
+assert_contains "$macos_status_output" "brew                          : available" "Terrapod status reports macOS Bootstrap Package Manager availability"
 assert_contains "$macos_status_output" "Warnings: none" "Terrapod status reports no warnings when enabled tools are present"
 assert_not_contains "$macos_status_output" "Warning:" "Terrapod status emits no warning lines when enabled tools are present"
 assert_no_ansi_escape "$help_output" "Terrapod help does not use setup ANSI presentation"
@@ -1169,9 +1169,9 @@ tty_macos_status_output="$(
 assert_has_ansi_escape "$tty_macos_status_output" "TTY Terrapod status with config uses ANSI visual treatment"
 assert_not_contains_colored_phrase "$tty_macos_status_output" "Profile: macOS Terminal Profile" "TTY Terrapod status keeps profile value out of the section style"
 assert_not_contains_colored_phrase "$tty_macos_status_output" "Config: $status_config" "TTY Terrapod status keeps config path neutral"
-assert_not_contains_colored_phrase "$tty_macos_status_output" "Optional Editor Stack: enabled (rich Neovim configuration)" "TTY Terrapod status does not color optional-stack detail as one phrase"
-assert_not_contains_colored_phrase "$tty_macos_status_output" "Optional AI Tool Stack: enabled (tools available: agy, claude, codex)" "TTY Terrapod status does not color optional-stack tool list as one phrase"
-assert_not_contains_colored_phrase "$tty_macos_status_output" "chezmoi: available" "TTY Terrapod status does not color tool names with state words"
+assert_not_contains_colored_phrase "$tty_macos_status_output" "Optional Editor Stack         : enabled (rich Neovim configuration)" "TTY Terrapod status does not color optional-stack detail as one phrase"
+assert_not_contains_colored_phrase "$tty_macos_status_output" "Optional AI Tool Stack        : enabled (tools available: agy, claude, codex)" "TTY Terrapod status does not color optional-stack tool list as one phrase"
+assert_not_contains_colored_phrase "$tty_macos_status_output" "chezmoi                       : available" "TTY Terrapod status does not color tool names with state words"
 
 status_dotted_config="$tmp_dir/status-dotted.toml"
 cat >"$status_dotted_config" <<'TOML'
@@ -1189,10 +1189,10 @@ dotted_status_output="$(
     /bin/sh "$terrapod" status
 )"
 
-assert_contains "$dotted_status_output" "Optional Editor Stack: enabled (rich Neovim configuration)" "Terrapod status reads root dotted data keys for effective editor stack state"
-assert_contains "$dotted_status_output" "Optional AI Tool Stack: enabled (tools available: agy, claude, codex)" "Terrapod status reads root dotted data keys for effective AI stack state"
-assert_contains "$dotted_status_output" "terminal-apps: enabled (Ghostty)" "Terrapod status reads root dotted data keys for Ghostty-only macOS App Groups"
-assert_contains "$dotted_status_output" "ai-apps: enabled (Claude Desktop, Codex Desktop, Antigravity 2.0, and Antigravity IDE)" "Terrapod status reads root dotted data keys for ai-apps macOS App Group"
+assert_contains "$dotted_status_output" "Optional Editor Stack         : enabled (rich Neovim configuration)" "Terrapod status reads root dotted data keys for effective editor stack state"
+assert_contains "$dotted_status_output" "Optional AI Tool Stack        : enabled (tools available: agy, claude, codex)" "Terrapod status reads root dotted data keys for effective AI stack state"
+assert_contains "$dotted_status_output" "terminal-apps                 : enabled (Ghostty)" "Terrapod status reads root dotted data keys for Ghostty-only macOS App Groups"
+assert_contains "$dotted_status_output" "ai-apps                       : enabled (Claude Desktop, Codex Desktop, Antigravity 2.0, and Antigravity IDE)" "Terrapod status reads root dotted data keys for ai-apps macOS App Group"
 assert_contains "$dotted_status_output" "Warnings: none" "Terrapod status has no warnings for root dotted data keys when tools are present"
 
 status_ubuntu_config="$tmp_dir/status-ubuntu.toml"
@@ -1219,11 +1219,11 @@ ubuntu_status_output="$(
 )"
 
 assert_contains "$ubuntu_status_output" "Profile: VPS Shell Profile" "Terrapod status reports VPS Shell Profile context on Ubuntu 24.04"
-assert_contains "$ubuntu_status_output" "Optional Editor Stack: disabled" "Terrapod status reports disabled Optional Editor Stack without treating nvim as missing"
-assert_contains "$ubuntu_status_output" "Optional AI Tool Stack: disabled" "Terrapod status reports disabled Optional AI Tool Stack without missing-tool warnings"
+assert_contains "$ubuntu_status_output" "Optional Editor Stack         : disabled" "Terrapod status reports disabled Optional Editor Stack without treating nvim as missing"
+assert_contains "$ubuntu_status_output" "Optional AI Tool Stack        : disabled" "Terrapod status reports disabled Optional AI Tool Stack without missing-tool warnings"
 assert_contains "$ubuntu_status_output" "Optional Development Workspace: disabled" "Terrapod status reports disabled Optional Development Workspace without missing-tool warnings"
 assert_contains "$ubuntu_status_output" "macOS App Groups: not applicable for VPS Shell Profile" "Terrapod status omits macOS App Group details on VPS Shell Profile"
-assert_contains "$ubuntu_status_output" "apt: available" "Terrapod status reports Ubuntu Bootstrap Package Manager availability"
+assert_contains "$ubuntu_status_output" "apt                           : available" "Terrapod status reports Ubuntu Bootstrap Package Manager availability"
 assert_contains "$ubuntu_status_output" "Warnings: none" "Terrapod status has no warnings for disabled optional stacks"
 assert_not_contains "$ubuntu_status_output" "Warning:" "Terrapod status emits no warning lines for disabled optional stacks"
 assert_not_contains "$ubuntu_status_output" "missing tools: nvim" "Terrapod status distinguishes disabled Optional Editor Stack from missing tools"
@@ -1237,10 +1237,10 @@ core_missing_status_output="$(
     /bin/sh "$terrapod" status
 )"
 
-assert_contains "$core_missing_status_output" "Optional Editor Stack: disabled" "Terrapod status keeps disabled Optional Editor Stack separate from missing core Neovim"
+assert_contains "$core_missing_status_output" "Optional Editor Stack         : disabled" "Terrapod status keeps disabled Optional Editor Stack separate from missing core Neovim"
 assert_contains "$core_missing_status_output" "Optional Development Workspace: disabled" "Terrapod status keeps disabled Optional Development Workspace separate from missing core Zellij"
-assert_contains "$core_missing_status_output" "nvim: missing" "Terrapod status reports missing plain Neovim as a key tool"
-assert_contains "$core_missing_status_output" "zellij: missing" "Terrapod status reports missing Zellij as a key tool"
+assert_contains "$core_missing_status_output" "nvim                          : missing" "Terrapod status reports missing plain Neovim as a key tool"
+assert_contains "$core_missing_status_output" "zellij                        : missing" "Terrapod status reports missing Zellij as a key tool"
 assert_contains "$core_missing_status_output" "Warning: missing key tools: nvim, zellij" "Terrapod status warns about missing core Neovim and Zellij even when optional stacks are disabled"
 
 status_missing_config="$tmp_dir/status-missing.toml"
@@ -1259,8 +1259,8 @@ missing_status_output="$(
     /bin/sh "$terrapod" status
 )"
 
-assert_contains "$missing_status_output" "Optional Editor Stack: enabled (rich Neovim configuration)" "Terrapod status reports enabled Optional Editor Stack as rich config state"
-assert_contains "$missing_status_output" "Optional AI Tool Stack: enabled (missing tools: agy, claude, codex)" "Terrapod status reports missing tools only for enabled Optional AI Tool Stack"
+assert_contains "$missing_status_output" "Optional Editor Stack         : enabled (rich Neovim configuration)" "Terrapod status reports enabled Optional Editor Stack as rich config state"
+assert_contains "$missing_status_output" "Optional AI Tool Stack        : enabled (missing tools: agy, claude, codex)" "Terrapod status reports missing tools only for enabled Optional AI Tool Stack"
 assert_contains "$missing_status_output" "Optional Development Workspace: enabled (development Zellij layouts)" "Terrapod status reports enabled Optional Development Workspace as layout state"
 assert_contains "$missing_status_output" "Warning: Optional AI Tool Stack is enabled but missing tools: agy, claude, codex" "Terrapod status warns for enabled missing AI tools"
 
@@ -1280,8 +1280,8 @@ workspace_bundle_status_output="$(
     /bin/sh "$terrapod" status
 )"
 
-assert_contains "$workspace_bundle_status_output" "Optional Editor Stack: enabled (rich Neovim configuration)" "Terrapod status treats Optional Development Workspace as enabling Optional Editor Stack"
-assert_contains "$workspace_bundle_status_output" "Optional AI Tool Stack: enabled (missing tools: agy, claude, codex)" "Terrapod status treats Optional Development Workspace as enabling Optional AI Tool Stack"
+assert_contains "$workspace_bundle_status_output" "Optional Editor Stack         : enabled (rich Neovim configuration)" "Terrapod status treats Optional Development Workspace as enabling Optional Editor Stack"
+assert_contains "$workspace_bundle_status_output" "Optional AI Tool Stack        : enabled (missing tools: agy, claude, codex)" "Terrapod status treats Optional Development Workspace as enabling Optional AI Tool Stack"
 assert_contains "$workspace_bundle_status_output" "Optional Development Workspace: enabled (development Zellij layouts)" "Terrapod status reports enabled Optional Development Workspace"
 assert_contains "$workspace_bundle_status_output" "Warning: Optional AI Tool Stack is enabled but missing tools: agy, claude, codex" "Terrapod status warns when workspace-enabled Optional AI Tool Stack tools are missing"
 
@@ -1671,12 +1671,12 @@ assert_contains \
 
 assert_contains \
   "$diff_output" \
-  "Optional Editor Stack: enabled" \
+  "Optional Editor Stack         : enabled" \
   "Terrapod diff prints effective enabled Optional Editor Stack state"
 
 assert_contains \
   "$diff_output" \
-  "Optional AI Tool Stack: enabled" \
+  "Optional AI Tool Stack        : enabled" \
   "Terrapod diff prints effective enabled Optional AI Tool Stack state"
 
 assert_contains \
@@ -1691,27 +1691,27 @@ assert_contains \
 
 assert_contains \
   "$diff_output" \
-  "terminal-apps: enabled" \
+  "terminal-apps                 : enabled" \
   "Terrapod diff prints enabled terminal-apps macOS App Group state"
 
 assert_contains \
   "$diff_output" \
-  "automation: disabled" \
+  "automation                    : disabled" \
   "Terrapod diff prints disabled automation macOS App Group state"
 
 assert_contains \
   "$diff_output" \
-  "launcher: enabled" \
+  "launcher                      : enabled" \
   "Terrapod diff prints enabled launcher macOS App Group state"
 
 assert_contains \
   "$diff_output" \
-  "monitoring: disabled" \
+  "monitoring                    : disabled" \
   "Terrapod diff prints disabled monitoring macOS App Group state"
 
 assert_contains \
   "$diff_output" \
-  "ai-apps: enabled" \
+  "ai-apps                       : enabled" \
   "Terrapod diff prints enabled ai-apps macOS App Group state"
 
 assert_contains \
@@ -1865,12 +1865,12 @@ assert_contains \
 
 assert_contains \
   "$apply_output" \
-  "Optional Editor Stack: enabled" \
+  "Optional Editor Stack         : enabled" \
   "Terrapod apply prints effective enabled Optional Editor Stack state"
 
 assert_contains \
   "$apply_output" \
-  "Optional AI Tool Stack: enabled" \
+  "Optional AI Tool Stack        : enabled" \
   "Terrapod apply prints effective enabled Optional AI Tool Stack state"
 
 assert_contains \
@@ -1880,27 +1880,27 @@ assert_contains \
 
 assert_contains \
   "$apply_output" \
-  "terminal-apps: enabled" \
+  "terminal-apps                 : enabled" \
   "Terrapod apply prints enabled terminal-apps macOS App Group state"
 
 assert_contains \
   "$apply_output" \
-  "automation: disabled" \
+  "automation                    : disabled" \
   "Terrapod apply prints disabled automation macOS App Group state"
 
 assert_contains \
   "$apply_output" \
-  "launcher: enabled" \
+  "launcher                      : enabled" \
   "Terrapod apply prints enabled launcher macOS App Group state"
 
 assert_contains \
   "$apply_output" \
-  "monitoring: disabled" \
+  "monitoring                    : disabled" \
   "Terrapod apply prints disabled monitoring macOS App Group state"
 
 assert_contains \
   "$apply_output" \
-  "ai-apps: enabled" \
+  "ai-apps                       : enabled" \
   "Terrapod apply prints enabled ai-apps macOS App Group state"
 
 assert_contains \


### PR DESCRIPTION
## Summary

- Documented the routine-output direction in the Terrapod domain context.
- Improved routine command output for `help`, `status`, `doctor`, `diff`, `apply`, and `update` with cleaner headings, sections, conditional ANSI color, and `tpod`-first help text.
- Aligned state columns for optional stacks, macOS App Groups, and key tool availability so values like `enabled` and `available` scan cleanly.

## Why

The command output was hard to scan during routine use: help still foregrounded longer command spellings, status/diff state words did not align, and routine commands lacked the visual hierarchy expected from a day-to-day CLI surface.

## Impact

Users get clearer routine output while setup keeps its existing gum UI. Non-TTY output stays plain and script-friendly, and `terrapod` remains documented as the full command.

## Validation

- `git diff --check`
- `for test in tests/*_test.sh; do sh "$test"; done`
- `zsh tests/zshrc_zoxide_test.zsh`