### PR TITLE
Make Optional AI Tool Stack retryable and marker-aware

### DIFF
--- a/.chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl
@@ -70,6 +70,7 @@ finish_ai_cli_installers() {
       echo "Failed to record Optional AI CLI tool install warning for failed command(s): $failed_tools." >&2
       return 1
     fi
+    return 1
   else
     clear_install_warning "$AI_CLI_WARNING_CATEGORY"
   fi

--- a/.chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl
@@ -14,9 +14,11 @@ mark_install_warning() {
   summary="$2"
   guidance="$3"
 
-  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ]; then
-    terrapod_install_warning_write "$category" "$summary" "$guidance" || true
+  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" != "1" ]; then
+    return 1
   fi
+
+  terrapod_install_warning_write "$category" "$summary" "$guidance"
 }
 
 clear_install_warning() {
@@ -61,10 +63,13 @@ append_failed_tool() {
 
 finish_ai_cli_installers() {
   if [ -n "$failed_tools" ]; then
-    mark_install_warning \
+    if ! mark_install_warning \
       "$AI_CLI_WARNING_CATEGORY" \
       "Optional AI CLI tool install needs attention" \
-      "Failed command(s): $failed_tools. Check installer output and network access, then rerun tpod apply."
+      "Failed command(s): $failed_tools. Check installer output and network access, then rerun tpod apply."; then
+      echo "Failed to record Optional AI CLI tool install warning for failed command(s): $failed_tools." >&2
+      return 1
+    fi
   else
     clear_install_warning "$AI_CLI_WARNING_CATEGORY"
   fi
@@ -130,7 +135,9 @@ run_installer() {
 run_installer "Antigravity CLI" agy bash "https://antigravity.google/cli/install.sh"
 run_installer "Claude Code" claude bash "https://claude.ai/install.sh"
 run_installer "Codex" codex sh "https://chatgpt.com/codex/install.sh" codex
-finish_ai_cli_installers
+if ! finish_ai_cli_installers; then
+  exit 1
+fi
 exit 0
 {{ end }}
 {{- end }}

--- a/.chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl
@@ -32,6 +32,16 @@ clear_install_warning "$AI_CLI_WARNING_CATEGORY"
 exit 0
 {{ else }}
 installer_paths=
+failed_tools=
+
+case "$(uname -s)" in
+  Darwin)
+    AI_CLI_EXPECTED_PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    ;;
+  *)
+    AI_CLI_EXPECTED_PATH="$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    ;;
+esac
 
 cleanup_installers() {
   for installer_path in $installer_paths; do
@@ -41,76 +51,87 @@ cleanup_installers() {
 
 trap cleanup_installers EXIT HUP INT TERM
 
-require_command() {
-  command_name="$1"
+append_failed_tool() {
+  if [ -n "$failed_tools" ]; then
+    failed_tools="$failed_tools, $1"
+  else
+    failed_tools="$1"
+  fi
+}
 
-  if ! command -v "$command_name" >/dev/null 2>&1; then
-    echo "$command_name is required to install optional AI CLI tools." >&2
+finish_ai_cli_installers() {
+  if [ -n "$failed_tools" ]; then
+    clear_install_warning "$AI_CLI_WARNING_CATEGORY"
     mark_install_warning \
       "$AI_CLI_WARNING_CATEGORY" \
       "Optional AI CLI tool install needs attention" \
-      "Install $command_name or fix it on PATH, then rerun tpod apply."
-    exit 1
+      "Failed command(s): $failed_tools. Check installer output and network access, then rerun tpod apply."
+  else
+    clear_install_warning "$AI_CLI_WARNING_CATEGORY"
   fi
+}
+
+command_available_on_expected_path() {
+  PATH="$AI_CLI_EXPECTED_PATH" command -v "$1" >/dev/null 2>&1
 }
 
 run_installer() {
   label="$1"
-  shell_name="$2"
-  installer_url="$3"
-  shift 3
+  command_name="$2"
+  shell_name="$3"
+  installer_url="$4"
+  installer_mode="${5:-}"
 
-  installer_path="$(mktemp "${TMPDIR:-/tmp}/terrapod-ai-installer.XXXXXX")"
+  if command_available_on_expected_path "$command_name"; then
+    echo "$label is already available on expected PATH; skipping."
+    return 0
+  fi
+
+  if ! command_available_on_expected_path curl; then
+    echo "curl is required to install $label." >&2
+    append_failed_tool "$command_name"
+    return 0
+  fi
+
+  if ! command_available_on_expected_path "$shell_name"; then
+    echo "$shell_name is required to install $label." >&2
+    append_failed_tool "$command_name"
+    return 0
+  fi
+
+  if ! installer_path="$(mktemp "${TMPDIR:-/tmp}/terrapod-ai-installer.XXXXXX")"; then
+    echo "Failed to create a temporary installer file for $label." >&2
+    append_failed_tool "$command_name"
+    return 0
+  fi
   installer_paths="$installer_paths $installer_path"
 
   echo "Installing $label through official installer: $installer_url"
-  if ! curl -fsSL "$installer_url" -o "$installer_path"; then
-    mark_install_warning \
-      "$AI_CLI_WARNING_CATEGORY" \
-      "Optional AI CLI tool install needs attention" \
-      "Check network access to official AI CLI installers, then rerun tpod apply."
-    exit 1
+  if ! PATH="$AI_CLI_EXPECTED_PATH" curl -fsSL "$installer_url" -o "$installer_path"; then
+    append_failed_tool "$command_name"
+    return 0
   fi
-  if ! "$shell_name" "$installer_path" "$@"; then
-    mark_install_warning \
-      "$AI_CLI_WARNING_CATEGORY" \
-      "Optional AI CLI tool install needs attention" \
-      "Review $label installer output, then rerun tpod apply."
-    exit 1
+
+  if [ "$installer_mode" = codex ]; then
+    if ! CODEX_NON_INTERACTIVE=1 PATH="$AI_CLI_EXPECTED_PATH" "$shell_name" "$installer_path"; then
+      append_failed_tool "$command_name"
+      return 0
+    fi
+  elif ! PATH="$AI_CLI_EXPECTED_PATH" "$shell_name" "$installer_path"; then
+    append_failed_tool "$command_name"
+    return 0
   fi
-}
 
-run_codex_installer() {
-  label="Codex"
-  shell_name="sh"
-  installer_url="https://chatgpt.com/codex/install.sh"
-
-  installer_path="$(mktemp "${TMPDIR:-/tmp}/terrapod-ai-installer.XXXXXX")"
-  installer_paths="$installer_paths $installer_path"
-
-  echo "Installing $label through official installer: $installer_url"
-  if ! curl -fsSL "$installer_url" -o "$installer_path"; then
-    mark_install_warning \
-      "$AI_CLI_WARNING_CATEGORY" \
-      "Optional AI CLI tool install needs attention" \
-      "Check network access to the Codex installer, then rerun tpod apply."
-    exit 1
-  fi
-  if ! CODEX_NON_INTERACTIVE=1 PATH="$HOME/.local/bin:/usr/bin:/bin:/usr/sbin:/sbin" "$shell_name" "$installer_path"; then
-    mark_install_warning \
-      "$AI_CLI_WARNING_CATEGORY" \
-      "Optional AI CLI tool install needs attention" \
-      "Review Codex installer output, then rerun tpod apply."
-    exit 1
+  if ! command_available_on_expected_path "$command_name"; then
+    echo "$label installer completed but $command_name is not available on expected PATH." >&2
+    append_failed_tool "$command_name"
   fi
 }
 
-require_command curl
-require_command bash
-
-run_installer "Antigravity CLI" bash "https://antigravity.google/cli/install.sh"
-run_installer "Claude Code" bash "https://claude.ai/install.sh"
-run_codex_installer
-clear_install_warning "$AI_CLI_WARNING_CATEGORY"
+run_installer "Antigravity CLI" agy bash "https://antigravity.google/cli/install.sh"
+run_installer "Claude Code" claude bash "https://claude.ai/install.sh"
+run_installer "Codex" codex sh "https://chatgpt.com/codex/install.sh" codex
+finish_ai_cli_installers
+exit 0
 {{ end }}
 {{- end }}

--- a/.chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl
@@ -61,7 +61,6 @@ append_failed_tool() {
 
 finish_ai_cli_installers() {
   if [ -n "$failed_tools" ]; then
-    clear_install_warning "$AI_CLI_WARNING_CATEGORY"
     mark_install_warning \
       "$AI_CLI_WARNING_CATEGORY" \
       "Optional AI CLI tool install needs attention" \

--- a/.chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl
@@ -2,6 +2,7 @@
 #!/bin/sh
 set -eu
 
+AI_CLI_WARNING_CATEGORY=optional-ai-cli-tools
 install_warnings_lib="{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/install-warnings.sh"
 TERRAPOD_INSTALL_WARNINGS_LOADED=
 if [ -f "$install_warnings_lib" ]; then
@@ -27,7 +28,7 @@ clear_install_warning() {
 }
 
 {{ if not (or (default false (get . "enableAiCliTools")) (default false (get . "enableDevelopmentWorkspace"))) }}
-clear_install_warning ai-cli-tools
+clear_install_warning "$AI_CLI_WARNING_CATEGORY"
 exit 0
 {{ else }}
 installer_paths=
@@ -46,7 +47,7 @@ require_command() {
   if ! command -v "$command_name" >/dev/null 2>&1; then
     echo "$command_name is required to install optional AI CLI tools." >&2
     mark_install_warning \
-      ai-cli-tools \
+      "$AI_CLI_WARNING_CATEGORY" \
       "Optional AI CLI tool install needs attention" \
       "Install $command_name or fix it on PATH, then rerun tpod apply."
     exit 1
@@ -65,14 +66,14 @@ run_installer() {
   echo "Installing $label through official installer: $installer_url"
   if ! curl -fsSL "$installer_url" -o "$installer_path"; then
     mark_install_warning \
-      ai-cli-tools \
+      "$AI_CLI_WARNING_CATEGORY" \
       "Optional AI CLI tool install needs attention" \
       "Check network access to official AI CLI installers, then rerun tpod apply."
     exit 1
   fi
   if ! "$shell_name" "$installer_path" "$@"; then
     mark_install_warning \
-      ai-cli-tools \
+      "$AI_CLI_WARNING_CATEGORY" \
       "Optional AI CLI tool install needs attention" \
       "Review $label installer output, then rerun tpod apply."
     exit 1
@@ -90,14 +91,14 @@ run_codex_installer() {
   echo "Installing $label through official installer: $installer_url"
   if ! curl -fsSL "$installer_url" -o "$installer_path"; then
     mark_install_warning \
-      ai-cli-tools \
+      "$AI_CLI_WARNING_CATEGORY" \
       "Optional AI CLI tool install needs attention" \
       "Check network access to the Codex installer, then rerun tpod apply."
     exit 1
   fi
   if ! CODEX_NON_INTERACTIVE=1 PATH="$HOME/.local/bin:/usr/bin:/bin:/usr/sbin:/sbin" "$shell_name" "$installer_path"; then
     mark_install_warning \
-      ai-cli-tools \
+      "$AI_CLI_WARNING_CATEGORY" \
       "Optional AI CLI tool install needs attention" \
       "Review Codex installer output, then rerun tpod apply."
     exit 1
@@ -110,6 +111,6 @@ require_command bash
 run_installer "Antigravity CLI" bash "https://antigravity.google/cli/install.sh"
 run_installer "Claude Code" bash "https://claude.ai/install.sh"
 run_codex_installer
-clear_install_warning ai-cli-tools
+clear_install_warning "$AI_CLI_WARNING_CATEGORY"
 {{ end }}
 {{- end }}

--- a/docs/superpowers/plans/2026-06-04-optional-ai-tool-stack-skip-retry-warnings.md
+++ b/docs/superpowers/plans/2026-06-04-optional-ai-tool-stack-skip-retry-warnings.md
@@ -1,0 +1,572 @@
+# Optional AI Tool Stack Skip Retry Warnings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the **Optional AI Tool Stack** installer marker-aware, idempotent, partial-failure recoverable, and constrained to official vendor installers.
+
+**Architecture:** Keep the existing before-apply AI CLI installer template, but give it a small internal per-tool runner that checks command availability on Terrapod's expected command lookup path before downloading installers. Failed tools are accumulated into one `optional-ai-cli-tools` install warning marker, while successful tools remain installed and are skipped on later applies.
+
+**Tech Stack:** POSIX shell, chezmoi templates, `gh`, shell regression tests.
+
+---
+
+## File Structure
+
+- Modify: `dot_local/lib/terrapod/install-warnings.sh`
+  - Rename the Optional AI Tool Stack warning category slug from `ai-cli-tools` to `optional-ai-cli-tools`.
+  - Keep category validation and listing behavior explicit and stable.
+- Modify: `.chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl`
+  - Define one `AI_CLI_WARNING_CATEGORY`.
+  - Define Terrapod's expected AI CLI command lookup path with managed user-bin and platform tool locations.
+  - Skip already available `agy`, `claude`, and `codex` commands using command availability only.
+  - Continue through per-tool installer failures and write one warning marker listing failed tool names.
+  - Use official installer URLs and Codex `CODEX_NON_INTERACTIVE=1`.
+- Modify: `tests/terrapod_command_test.sh`
+  - Update install warning category tests and marker expectations to `optional-ai-cli-tools`.
+- Modify: `tests/chezmoiignore_test.sh`
+  - Update disabled-stack marker cleanup expectations.
+  - Add rendered-installer behavior tests for expected PATH skip checks, partial failure retry, marker content, Codex unattended env, official URLs, no token injection, no prompt piping, and no installer patching.
+- Create: `docs/superpowers/plans/2026-06-04-optional-ai-tool-stack-skip-retry-warnings.md`
+  - This implementation plan.
+
+## Assumptions
+
+- The blocker #96 is closed, so the shared install warning helper contract is available.
+- `optional-ai-cli-tools` is the desired stable category slug because issue #103 and `CONTEXT.md` name that category explicitly.
+- This change does not add upgrade/version checks; an available command satisfies the skip check regardless of version or package-manager provenance.
+- Installer failures for this optional stack should not make chezmoi apply fail; they should write a warning marker and leave recovery to `tpod apply` plus `tpod doctor`.
+- The issue's doctor acceptance is scoped to the disabled stack sentence: when the **Optional AI Tool Stack** is disabled, missing `agy`, `claude`, or `codex` must not fail `tpod doctor`. When the stack is enabled and tools are missing, keep the existing `tpod doctor` non-zero readiness behavior.
+
+---
+
+### Task 1: Rename Optional AI CLI Warning Category
+
+**Files:**
+- Modify: `dot_local/lib/terrapod/install-warnings.sh`
+- Modify: `tests/terrapod_command_test.sh`
+- Modify: `tests/chezmoiignore_test.sh`
+- Modify: `.chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl`
+
+- [ ] **Step 1: Update failing category expectations**
+
+In `tests/terrapod_command_test.sh`, change the category list and marker setup assertions from `ai-cli-tools` to `optional-ai-cli-tools`:
+
+```sh
+expected_marker_categories="$(printf '%s\n' homebrew-core homebrew-desktop-apps ubuntu-bootstrap shell-integrations mise-tools optional-ai-cli-tools)"
+
+HOME="$marker_home" XDG_STATE_HOME="$marker_xdg_state" sh -c \
+  '. "$1"; terrapod_install_warning_write optional-ai-cli-tools "AI CLI tool install needs attention" "Rerun tpod apply after network access is restored."' \
+  sh "$install_warnings_lib"
+
+expected_marker_list="$(printf '%s\n' homebrew-core optional-ai-cli-tools)"
+```
+
+In `tests/chezmoiignore_test.sh`, change disabled cleanup expectations:
+
+```sh
+assert_contains_text "$disabled_ai_cli_tools_cleanup" "clear_install_warning optional-ai-cli-tools" "disabled Optional AI Tool Stack renders stale marker cleanup"
+
+HOME="$ai_marker_home" XDG_STATE_HOME="$ai_marker_state" sh -c \
+  '. "$1"; terrapod_install_warning_write optional-ai-cli-tools "Optional AI CLI tool install needs attention" "Rerun tpod apply after network access is restored."' \
+  sh "$repo_root/dot_local/lib/terrapod/install-warnings.sh"
+```
+
+- [ ] **Step 2: Run tests to verify category expectations fail**
+
+Run:
+
+```bash
+sh tests/terrapod_command_test.sh
+```
+
+Expected: FAIL because `install-warnings.sh` still recognizes `ai-cli-tools`, not `optional-ai-cli-tools`.
+
+Run:
+
+```bash
+sh tests/chezmoiignore_test.sh
+```
+
+Expected: FAIL because the rendered AI CLI installer still clears/writes `ai-cli-tools`.
+
+- [ ] **Step 3: Rename category in helper and installer template**
+
+In `dot_local/lib/terrapod/install-warnings.sh`, replace the category slug:
+
+```sh
+terrapod_install_warning_categories() {
+  printf '%s\n' \
+    homebrew-core \
+    homebrew-desktop-apps \
+    ubuntu-bootstrap \
+    shell-integrations \
+    mise-tools \
+    optional-ai-cli-tools
+}
+
+terrapod_install_warning_is_category() {
+  case "$1" in
+    homebrew-core|homebrew-desktop-apps|ubuntu-bootstrap|shell-integrations|mise-tools|optional-ai-cli-tools)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+```
+
+In `.chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl`, introduce and use:
+
+```sh
+AI_CLI_WARNING_CATEGORY=optional-ai-cli-tools
+```
+
+Then replace direct `ai-cli-tools` marker calls with `"$AI_CLI_WARNING_CATEGORY"`.
+
+- [ ] **Step 4: Run tests to verify category rename passes**
+
+Run:
+
+```bash
+sh tests/terrapod_command_test.sh
+sh tests/chezmoiignore_test.sh
+```
+
+Expected: PASS for marker category and disabled cleanup checks. Other failures should be investigated before proceeding.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dot_local/lib/terrapod/install-warnings.sh .chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl tests/terrapod_command_test.sh tests/chezmoiignore_test.sh docs/superpowers/plans/2026-06-04-optional-ai-tool-stack-skip-retry-warnings.md
+git commit -m "test: rename optional ai cli warning marker"
+```
+
+---
+
+### Task 2: Add Installer Skip, Retry, and Safety Coverage
+
+**Files:**
+- Modify: `tests/chezmoiignore_test.sh`
+
+- [ ] **Step 1: Add expected PATH skip behavior test**
+
+After the existing static AI installer assertions in `tests/chezmoiignore_test.sh`, add a rendered-installer test that places `agy`, `claude`, and `codex` only under `$HOME/.local/bin`, runs the rendered installer with a minimal external `PATH`, and asserts `curl` is not called:
+
+```sh
+ai_skip_home="$tmp_dir/ai-skip-home"
+ai_skip_state="$tmp_dir/ai-skip-state"
+ai_skip_log="$tmp_dir/ai-skip-curl.log"
+mkdir -p "$ai_skip_home/.local/bin"
+for command_name in agy claude codex; do
+  write_stub "$ai_skip_home/.local/bin/$command_name" 'exit 0'
+done
+write_stub "$ai_skip_home/.local/bin/curl" \
+  'printf "%s\n" "$*" >>"$AI_SKIP_LOG"' \
+  'exit 97'
+
+ai_cli_tools_installer_script="$tmp_dir/ai-cli-tools-installer.sh"
+printf '%s\n' "$ai_cli_tools_installer" >"$ai_cli_tools_installer_script"
+sh -n "$ai_cli_tools_installer_script" || fail "rendered Optional AI Tool Stack installer should be valid sh"
+
+if ! HOME="$ai_skip_home" XDG_STATE_HOME="$ai_skip_state" AI_SKIP_LOG="$ai_skip_log" PATH="/usr/bin:/bin" sh "$ai_cli_tools_installer_script" >"$tmp_dir/ai-skip.out" 2>"$tmp_dir/ai-skip.err"; then
+  fail "Optional AI Tool Stack installer skips commands found on expected PATH"
+fi
+if [ -e "$ai_skip_log" ]; then
+  fail "Optional AI Tool Stack installer does not download installers for commands already on expected PATH"
+fi
+if [ -e "$ai_skip_state/terrapod/install-warnings/optional-ai-cli-tools" ]; then
+  fail "Optional AI Tool Stack installer does not leave warning marker after full skip"
+fi
+pass "Optional AI Tool Stack installer skips commands found on expected PATH"
+```
+
+- [ ] **Step 2: Add partial failure retry test**
+
+Add a fake installer harness in `tests/chezmoiignore_test.sh` that:
+
+- First run installs `agy` and `codex`, fails `claude`, exits successfully, and writes one `optional-ai-cli-tools` marker mentioning `claude`.
+- Second run starts with `agy` and `codex` already present, succeeds only `claude`, skips `agy`/`codex`, and clears the marker.
+
+Use shell snippets like:
+
+```sh
+write_stub "$ai_retry_home/.local/bin/bash" 'exec /bin/sh "$@"'
+write_stub "$ai_retry_home/.local/bin/curl" \
+  'url=' \
+  'output=' \
+  'while [ "$#" -gt 0 ]; do' \
+  '  case "$1" in' \
+  '    -o) shift; output="$1" ;;' \
+  '    http*) url="$1" ;;' \
+  '  esac' \
+  '  shift' \
+  'done' \
+  'printf "%s\n" "$url" >>"$AI_RETRY_LOG"' \
+  'case "$url" in' \
+  '  https://antigravity.google/cli/install.sh)' \
+  '    printf "%s\n" "#!/bin/sh" "printf \"%s\\n\" agy >>\"$AI_RETRY_RUN_LOG\"" "mkdir -p \"\\$HOME/.local/bin\"" "printf \"%s\\n\" \"#!/bin/sh\" \"exit 0\" >\"\\$HOME/.local/bin/agy\"" "chmod +x \"\\$HOME/.local/bin/agy\"" >"$output" ;;' \
+  '  https://claude.ai/install.sh)' \
+  '    if [ "${AI_RETRY_CLAUDE_FAIL:-}" = "1" ]; then' \
+  '      printf "%s\n" "#!/bin/sh" "printf \"%s\\n\" claude-fail >>\"$AI_RETRY_RUN_LOG\"" "exit 42" >"$output"' \
+  '    else' \
+  '      printf "%s\n" "#!/bin/sh" "printf \"%s\\n\" claude >>\"$AI_RETRY_RUN_LOG\"" "mkdir -p \"\\$HOME/.local/bin\"" "printf \"%s\\n\" \"#!/bin/sh\" \"exit 0\" >\"\\$HOME/.local/bin/claude\"" "chmod +x \"\\$HOME/.local/bin/claude\"" >"$output"' \
+  '    fi ;;' \
+  '  https://chatgpt.com/codex/install.sh)' \
+  '    printf "%s\n" "#!/bin/sh" "printf \"codex env:%s path:%s\\n\" \"\\$CODEX_NON_INTERACTIVE\" \"\\$PATH\" >>\"$AI_RETRY_RUN_LOG\"" "mkdir -p \"\\$HOME/.local/bin\"" "printf \"%s\\n\" \"#!/bin/sh\" \"exit 0\" >\"\\$HOME/.local/bin/codex\"" "chmod +x \"\\$HOME/.local/bin/codex\"" >"$output" ;;' \
+  '  *) exit 88 ;;' \
+  'esac'
+```
+
+Assert after the first run:
+
+```sh
+if ! HOME="$ai_retry_home" XDG_STATE_HOME="$ai_retry_state" AI_RETRY_CLAUDE_FAIL=1 AI_RETRY_LOG="$ai_retry_log" AI_RETRY_RUN_LOG="$ai_retry_run_log" PATH="/usr/bin:/bin" sh "$ai_cli_tools_installer_script" >"$tmp_dir/ai-retry-first.out" 2>"$tmp_dir/ai-retry-first.err"; then
+  fail "partial Optional AI Tool Stack failure records a marker without failing apply"
+fi
+if [ ! -x "$ai_retry_home/.local/bin/agy" ] || [ ! -x "$ai_retry_home/.local/bin/codex" ]; then
+  fail "partial Optional AI Tool Stack failure leaves successful tools installed"
+fi
+if [ ! -f "$ai_retry_state/terrapod/install-warnings/optional-ai-cli-tools" ]; then
+  fail "partial Optional AI Tool Stack failure writes optional-ai-cli-tools marker"
+fi
+ai_retry_marker="$(cat "$ai_retry_state/terrapod/install-warnings/optional-ai-cli-tools")"
+assert_contains_text "$ai_retry_marker" "claude" "partial Optional AI Tool Stack marker includes failed tool names"
+assert_not_contains_text "$ai_retry_marker" "agy, codex" "partial Optional AI Tool Stack marker does not list successful tools as failed"
+assert_contains_text "$(cat "$ai_retry_run_log")" "codex env:1" "Codex installer runs with CODEX_NON_INTERACTIVE=1"
+```
+
+Assert after the second run:
+
+```sh
+: >"$ai_retry_log"
+if ! HOME="$ai_retry_home" XDG_STATE_HOME="$ai_retry_state" AI_RETRY_CLAUDE_FAIL=0 AI_RETRY_LOG="$ai_retry_log" AI_RETRY_RUN_LOG="$ai_retry_run_log" PATH="/usr/bin:/bin" sh "$ai_cli_tools_installer_script" >"$tmp_dir/ai-retry-second.out" 2>"$tmp_dir/ai-retry-second.err"; then
+  fail "Optional AI Tool Stack retry succeeds after installing only missing tools"
+fi
+second_retry_urls="$(cat "$ai_retry_log")"
+assert_contains_text "$second_retry_urls" "https://claude.ai/install.sh" "retry downloads the missing Claude installer"
+assert_not_contains_text "$second_retry_urls" "https://antigravity.google/cli/install.sh" "retry skips already installed agy"
+assert_not_contains_text "$second_retry_urls" "https://chatgpt.com/codex/install.sh" "retry skips already installed codex"
+if [ -e "$ai_retry_state/terrapod/install-warnings/optional-ai-cli-tools" ]; then
+  fail "successful Optional AI Tool Stack retry clears warning marker"
+fi
+pass "Optional AI Tool Stack retry installs only missing expected commands"
+```
+
+- [ ] **Step 3: Add platform expected PATH coverage**
+
+Add static rendered-script assertions so the test closes both managed user-bin and platform tool path requirements without writing to real platform directories:
+
+```sh
+assert_contains_text "$ai_cli_tools_installer" 'AI_CLI_EXPECTED_PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"' \
+  "Optional AI Tool Stack installer includes macOS managed user-bin and platform tool lookup path"
+assert_contains_text "$ai_cli_tools_installer" 'AI_CLI_EXPECTED_PATH="$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"' \
+  "Optional AI Tool Stack installer includes Linux managed user-bin and platform tool lookup path"
+assert_contains_text "$development_workspace_ai_installer" 'AI_CLI_EXPECTED_PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"' \
+  "Optional Development Workspace AI installer includes macOS expected lookup path"
+assert_contains_text "$development_workspace_ai_installer" 'AI_CLI_EXPECTED_PATH="$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"' \
+  "Optional Development Workspace AI installer includes Linux expected lookup path"
+```
+
+- [ ] **Step 4: Add official-only safety assertions**
+
+Extend the static assertions around `ai_cli_tools_installer` and `development_workspace_ai_installer`:
+
+```sh
+for forbidden_text in \
+  "GITHUB_TOKEN" \
+  "Authorization:" \
+  "api.github.com" \
+  "sed -i" \
+  "apply_patch" \
+  "patch " \
+  "yes |" \
+  "printf 'y" \
+  "printf \"y" \
+  "| sh" \
+  "| bash"
+do
+  assert_not_contains_text "$ai_cli_tools_installer" "$forbidden_text" "enableAiCliTools does not inject tokens, patch installers, or pipe prompt answers: $forbidden_text"
+  assert_not_contains_text "$development_workspace_ai_installer" "$forbidden_text" "enableDevelopmentWorkspace does not inject tokens, patch installers, or pipe prompt answers: $forbidden_text"
+done
+```
+
+Keep the existing official URL assertions:
+
+```sh
+https://antigravity.google/cli/install.sh
+https://claude.ai/install.sh
+https://chatgpt.com/codex/install.sh
+```
+
+- [ ] **Step 5: Run tests to verify new behavior coverage fails**
+
+Run:
+
+```bash
+sh tests/chezmoiignore_test.sh
+```
+
+Expected: FAIL because the installer still downloads all AI installers, exits at the first failure, and does not accumulate failed tool names.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/chezmoiignore_test.sh
+git commit -m "test: cover optional ai cli retry behavior"
+```
+
+---
+
+### Task 3: Implement Idempotent Official AI CLI Installer
+
+**Files:**
+- Modify: `.chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl`
+
+- [ ] **Step 1: Add expected lookup path helpers**
+
+Add helpers near the top of the enabled branch:
+
+```sh
+AI_CLI_WARNING_CATEGORY=optional-ai-cli-tools
+
+case "$(uname -s 2>/dev/null || printf unknown)" in
+  Darwin)
+    AI_CLI_EXPECTED_PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    ;;
+  *)
+    AI_CLI_EXPECTED_PATH="$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    ;;
+esac
+
+command_available_on_expected_path() {
+  command_name="$1"
+  PATH="$AI_CLI_EXPECTED_PATH" command -v "$command_name" >/dev/null 2>&1
+}
+```
+
+- [ ] **Step 2: Add failure accumulation helpers**
+
+Replace hard `exit 1` paths in optional AI installation with accumulated failures:
+
+```sh
+failed_tools=
+
+append_failed_tool() {
+  command_name="$1"
+
+  case ", $failed_tools, " in
+    *", $command_name, "*)
+      return 0
+      ;;
+  esac
+
+  if [ -z "$failed_tools" ]; then
+    failed_tools="$command_name"
+  else
+    failed_tools="$failed_tools, $command_name"
+  fi
+}
+
+finish_ai_cli_installers() {
+  if [ -n "$failed_tools" ]; then
+    mark_install_warning \
+      "$AI_CLI_WARNING_CATEGORY" \
+      "Optional AI CLI tool install needs attention: $failed_tools" \
+      "Failed tools: $failed_tools. Review installer output, fix network or installer requirements, then rerun tpod apply."
+    return 0
+  fi
+
+  clear_install_warning "$AI_CLI_WARNING_CATEGORY"
+}
+```
+
+- [ ] **Step 3: Replace installer runner with per-command skip and retry logic**
+
+Use one runner for all three official installers:
+
+```sh
+run_installer() {
+  label="$1"
+  command_name="$2"
+  shell_name="$3"
+  installer_url="$4"
+  mode="${5:-}"
+
+  if command_available_on_expected_path "$command_name"; then
+    echo "Skipping $label; $command_name is already available on Terrapod's expected PATH."
+    return 0
+  fi
+
+  if ! command_available_on_expected_path curl; then
+    echo "curl is required to install $label." >&2
+    append_failed_tool "$command_name"
+    return 0
+  fi
+
+  if ! command_available_on_expected_path "$shell_name"; then
+    echo "$shell_name is required to install $label." >&2
+    append_failed_tool "$command_name"
+    return 0
+  fi
+
+  installer_path="$(mktemp "${TMPDIR:-/tmp}/terrapod-ai-installer.XXXXXX")"
+  installer_paths="$installer_paths $installer_path"
+
+  echo "Installing $label through official installer: $installer_url"
+  if ! PATH="$AI_CLI_EXPECTED_PATH" curl -fsSL "$installer_url" -o "$installer_path"; then
+    append_failed_tool "$command_name"
+    return 0
+  fi
+
+  if [ "$mode" = "codex" ]; then
+    if ! CODEX_NON_INTERACTIVE=1 PATH="$AI_CLI_EXPECTED_PATH" "$shell_name" "$installer_path"; then
+      append_failed_tool "$command_name"
+      return 0
+    fi
+  else
+    if ! PATH="$AI_CLI_EXPECTED_PATH" "$shell_name" "$installer_path"; then
+      append_failed_tool "$command_name"
+      return 0
+    fi
+  fi
+
+  if ! command_available_on_expected_path "$command_name"; then
+    echo "$label installer completed but $command_name is not available on Terrapod's expected PATH." >&2
+    append_failed_tool "$command_name"
+  fi
+}
+
+run_installer "Antigravity CLI" agy bash "https://antigravity.google/cli/install.sh"
+run_installer "Claude Code" claude bash "https://claude.ai/install.sh"
+run_installer "Codex" codex sh "https://chatgpt.com/codex/install.sh" codex
+finish_ai_cli_installers
+```
+
+Remove the old `require_command` and `run_codex_installer` functions.
+
+- [ ] **Step 4: Run behavior tests**
+
+Run:
+
+```bash
+sh tests/chezmoiignore_test.sh
+```
+
+Expected: PASS for rendered installer skip/retry/security checks.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl
+git commit -m "fix: make optional ai cli installer retryable"
+```
+
+---
+
+### Task 4: Verify Command Surface and Apply/Doctor Behavior
+
+**Files:**
+- Modify only if tests expose a real regression:
+  - `dot_local/bin/executable_terrapod`
+  - `tests/terrapod_command_test.sh`
+
+- [ ] **Step 1: Run command regression tests**
+
+Run:
+
+```bash
+sh tests/terrapod_command_test.sh
+```
+
+Expected: PASS with `optional-ai-cli-tools` appearing in marker category/list/status/doctor/apply output where install warnings are summarized. Preserve the existing enabled-stack readiness behavior: `tpod doctor` should still fail when the **Optional AI Tool Stack** is enabled and `agy`, `claude`, or `codex` are missing. Also preserve the existing disabled-stack behavior: `tpod doctor` should not fail merely because disabled Optional AI Tool Stack tools are absent.
+
+- [ ] **Step 2: Run syntax checks for changed shell files**
+
+Run:
+
+```bash
+sh -n dot_local/lib/terrapod/install-warnings.sh
+sh -n dot_local/bin/executable_terrapod
+chezmoi execute-template --override-data '{"chezmoi":{"os":"linux","sourceDir":"."},"enableAiCliTools":true,"enableDevelopmentWorkspace":false}' --file .chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl > /tmp/terrapod-ai-cli-tools-check.sh
+sh -n /tmp/terrapod-ai-cli-tools-check.sh
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 3: Run full repository shell tests**
+
+Run:
+
+```bash
+for test_script in tests/*_test.sh tests/*.zsh; do
+  case "$test_script" in
+    *.zsh) zsh "$test_script" ;;
+    *) sh "$test_script" ;;
+  esac
+done
+```
+
+Expected: PASS. If a pre-existing unrelated failure appears, capture the failing script and output, then rerun the focused changed tests to confirm this issue's behavior.
+
+- [ ] **Step 4: Commit any test-driven fixes**
+
+If Step 1-3 required additional fixes:
+
+```bash
+git add dot_local/bin/executable_terrapod tests/terrapod_command_test.sh tests/chezmoiignore_test.sh dot_local/lib/terrapod/install-warnings.sh .chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl
+git commit -m "fix: align optional ai cli warning checks"
+```
+
+If no additional fixes were needed, do not create an empty commit.
+
+---
+
+### Task 5: Publish Ready-for-Review PR
+
+**Files:**
+- No code changes expected.
+
+- [ ] **Step 1: Verify final status and diff**
+
+Run:
+
+```bash
+git status -sb
+git log --oneline --decorate -5
+git diff --stat origin/main...HEAD
+```
+
+Expected: only issue #103 files changed and all changes committed.
+
+- [ ] **Step 2: Run final focused tests**
+
+Run:
+
+```bash
+sh tests/chezmoiignore_test.sh
+sh tests/terrapod_command_test.sh
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Push branch**
+
+```bash
+git push -u origin codex/issue-103-optional-ai-tool-stack
+```
+
+- [ ] **Step 4: Create ready-for-review PR**
+
+Create a non-draft PR against `main` with a title like:
+
+```text
+Optional AI Tool Stack skip retry warnings
+```
+
+PR body must include:
+
+- What changed: expected PATH skip checks, per-tool retry, `optional-ai-cli-tools` marker.
+- Why: issue #103 idempotency and recovery requirements.
+- Impact: existing `agy`, `claude`, or `codex` commands are skipped; partial failures retry only missing commands.
+- Validation: focused tests and full shell test loop results.

--- a/dot_local/lib/terrapod/install-warnings.sh
+++ b/dot_local/lib/terrapod/install-warnings.sh
@@ -135,6 +135,11 @@ terrapod_install_warning_write() {
     rm -f "$tmp_file"
     return 1
   fi
+
+  legacy_marker_path="$(terrapod_install_warning_legacy_path "$category" 2>/dev/null || true)"
+  if [ -n "$legacy_marker_path" ]; then
+    rm -f "$legacy_marker_path"
+  fi
 }
 
 terrapod_install_warning_clear() {

--- a/dot_local/lib/terrapod/install-warnings.sh
+++ b/dot_local/lib/terrapod/install-warnings.sh
@@ -73,6 +73,14 @@ terrapod_install_warning_existing_path() {
   return 1
 }
 
+terrapod_install_warning_path_is_legacy() {
+  category="$1"
+  marker_path="$2"
+
+  legacy_marker_path="$(terrapod_install_warning_legacy_path "$category")" || return 1
+  [ "$marker_path" = "$legacy_marker_path" ]
+}
+
 terrapod_install_warning_quote() {
   printf "'"
   printf '%s' "$1" | sed "s/'/'\\\\''/g"
@@ -151,6 +159,20 @@ terrapod_install_warning_read() {
   category="$1"
 
   marker_path="$(terrapod_install_warning_existing_path "$category")" || return 1
+  if terrapod_install_warning_path_is_legacy "$category" "$marker_path"; then
+    awk -F= -v category="$category" '
+      $1 == "category" {
+        printf "category=\047%s\047\n", category
+        next
+      }
+
+      {
+        print
+      }
+    ' "$marker_path"
+    return
+  fi
+
   cat "$marker_path"
 }
 
@@ -168,6 +190,11 @@ terrapod_install_warning_value() {
       return 1
       ;;
   esac
+
+  if [ "$field" = category ] && terrapod_install_warning_path_is_legacy "$category" "$marker_path"; then
+    printf '%s\n' "$category"
+    return
+  fi
 
   awk -F= -v wanted="$field" '
     $1 == wanted {

--- a/dot_local/lib/terrapod/install-warnings.sh
+++ b/dot_local/lib/terrapod/install-warnings.sh
@@ -9,12 +9,12 @@ terrapod_install_warning_categories() {
     ubuntu-bootstrap \
     shell-integrations \
     mise-tools \
-    ai-cli-tools
+    optional-ai-cli-tools
 }
 
 terrapod_install_warning_is_category() {
   case "$1" in
-    homebrew-core|homebrew-desktop-apps|ubuntu-bootstrap|shell-integrations|mise-tools|ai-cli-tools)
+    homebrew-core|homebrew-desktop-apps|ubuntu-bootstrap|shell-integrations|mise-tools|optional-ai-cli-tools)
       return 0
       ;;
     *)

--- a/dot_local/lib/terrapod/install-warnings.sh
+++ b/dot_local/lib/terrapod/install-warnings.sh
@@ -42,6 +42,37 @@ terrapod_install_warning_path() {
   printf '%s/%s\n' "$(terrapod_install_warning_dir)" "$category"
 }
 
+terrapod_install_warning_legacy_path() {
+  category="$1"
+
+  case "$category" in
+    optional-ai-cli-tools)
+      printf '%s/%s\n' "$(terrapod_install_warning_dir)" ai-cli-tools
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+terrapod_install_warning_existing_path() {
+  category="$1"
+
+  marker_path="$(terrapod_install_warning_path "$category")" || return 1
+  if [ -f "$marker_path" ]; then
+    printf '%s\n' "$marker_path"
+    return 0
+  fi
+
+  legacy_marker_path="$(terrapod_install_warning_legacy_path "$category")" || return 1
+  if [ -f "$legacy_marker_path" ]; then
+    printf '%s\n' "$legacy_marker_path"
+    return 0
+  fi
+
+  return 1
+}
+
 terrapod_install_warning_quote() {
   printf "'"
   printf '%s' "$1" | sed "s/'/'\\\\''/g"
@@ -103,13 +134,14 @@ terrapod_install_warning_clear() {
 
   marker_path="$(terrapod_install_warning_path "$category")" || return 1
   rm -f "$marker_path"
+
+  legacy_marker_path="$(terrapod_install_warning_legacy_path "$category")" || return 0
+  rm -f "$legacy_marker_path"
 }
 
 terrapod_install_warning_list() {
-  marker_dir="$(terrapod_install_warning_dir)"
-
   for category in $(terrapod_install_warning_categories); do
-    if [ -f "$marker_dir/$category" ]; then
+    if terrapod_install_warning_existing_path "$category" >/dev/null; then
       printf '%s\n' "$category"
     fi
   done
@@ -118,8 +150,7 @@ terrapod_install_warning_list() {
 terrapod_install_warning_read() {
   category="$1"
 
-  marker_path="$(terrapod_install_warning_path "$category")" || return 1
-  [ -f "$marker_path" ] || return 1
+  marker_path="$(terrapod_install_warning_existing_path "$category")" || return 1
   cat "$marker_path"
 }
 
@@ -127,8 +158,7 @@ terrapod_install_warning_value() {
   category="$1"
   field="$2"
 
-  marker_path="$(terrapod_install_warning_path "$category")" || return 1
-  [ -f "$marker_path" ] || return 1
+  marker_path="$(terrapod_install_warning_existing_path "$category")" || return 1
 
   case "$field" in
     category|summary|guidance|updated_at)

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -811,7 +811,15 @@ assert_contains_text "$ai_cli_retry_first_runs" "run:antigravity" "enabled Optio
 assert_contains_text "$ai_cli_retry_first_runs" "run:claude" "enabled Optional AI Tool Stack first run executes Claude installer"
 assert_contains_text "$ai_cli_retry_first_runs" "run:codex" "enabled Optional AI Tool Stack first run continues to Codex after Claude failure"
 assert_contains_text "$ai_cli_retry_first_runs" "codex:noninteractive=1" "enabled Optional AI Tool Stack first run keeps Codex noninteractive"
-assert_contains_text "$ai_cli_retry_first_runs" "codex:path=$ai_cli_retry_home/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" "enabled Optional AI Tool Stack first run passes expected Linux PATH to Codex"
+case "$(uname -s)" in
+  Darwin)
+    ai_cli_retry_expected_path="$ai_cli_retry_home/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    ;;
+  *)
+    ai_cli_retry_expected_path="$ai_cli_retry_home/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    ;;
+esac
+assert_contains_text "$ai_cli_retry_first_runs" "codex:path=$ai_cli_retry_expected_path" "enabled Optional AI Tool Stack first run passes host-expected PATH to Codex"
 
 ai_cli_retry_marker_dir="$ai_cli_retry_state/terrapod/install-warnings"
 ai_cli_retry_marker="$ai_cli_retry_marker_dir/optional-ai-cli-tools"
@@ -822,6 +830,7 @@ ai_cli_retry_marker_files="$(find "$ai_cli_retry_marker_dir" -type f -print | so
 assert_text_equals "$ai_cli_retry_marker_files" "$ai_cli_retry_marker" "enabled Optional AI Tool Stack installer writes one optional-ai-cli-tools marker for partial failures"
 ai_cli_retry_marker_text="$(cat "$ai_cli_retry_marker")"
 assert_contains_text "$ai_cli_retry_marker_text" "claude" "enabled Optional AI Tool Stack partial failure marker mentions Claude only"
+assert_not_contains_text "$ai_cli_retry_marker_text" "agy" "enabled Optional AI Tool Stack partial failure marker omits successful agy command"
 assert_not_contains_text "$ai_cli_retry_marker_text" "antigravity" "enabled Optional AI Tool Stack partial failure marker omits successful Antigravity"
 assert_not_contains_text "$ai_cli_retry_marker_text" "Antigravity" "enabled Optional AI Tool Stack partial failure marker omits successful Antigravity label"
 assert_not_contains_text "$ai_cli_retry_marker_text" "codex" "enabled Optional AI Tool Stack partial failure marker omits successful Codex"

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -795,10 +795,10 @@ HOME="$ai_cli_retry_home" \
   TMPDIR="$tmp_dir" \
   PATH="$ai_cli_retry_home/.local/bin:/usr/bin:/bin" \
   sh "$ai_cli_tools_installer_script" >/dev/null 2>"$tmp_dir/ai-cli-retry-first.err" || ai_cli_retry_status=$?
-if [ "$ai_cli_retry_status" -ne 0 ]; then
-  fail "enabled Optional AI Tool Stack installer exits 0 while recording partial AI CLI installer failures"
+if [ "$ai_cli_retry_status" -eq 0 ]; then
+  fail "enabled Optional AI Tool Stack installer fails after recording partial AI CLI installer failures"
 fi
-pass "enabled Optional AI Tool Stack installer exits 0 while recording partial AI CLI installer failures"
+pass "enabled Optional AI Tool Stack installer fails after recording partial AI CLI installer failures"
 
 if [ ! -x "$ai_cli_retry_home/.local/bin/agy" ]; then
   fail "enabled Optional AI Tool Stack installer keeps successful Antigravity install after Claude failure"

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -714,6 +714,16 @@ ai_cli_retry_antigravity_installer="$tmp_dir/ai-cli-retry-antigravity-installer.
 ai_cli_retry_claude_installer="$tmp_dir/ai-cli-retry-claude-installer.sh"
 ai_cli_retry_codex_installer="$tmp_dir/ai-cli-retry-codex-installer.sh"
 mkdir -p "$ai_cli_retry_home/.local/bin"
+ai_cli_retry_marker_dir="$ai_cli_retry_state/terrapod/install-warnings"
+ai_cli_retry_marker="$ai_cli_retry_marker_dir/optional-ai-cli-tools"
+ai_cli_retry_legacy_marker="$ai_cli_retry_marker_dir/ai-cli-tools"
+mkdir -p "$ai_cli_retry_marker_dir"
+printf '%s\n' \
+  "category='ai-cli-tools'" \
+  "summary='Legacy AI CLI tool install needs attention'" \
+  "guidance='Rerun tpod apply after network access is restored.'" \
+  "updated_at='2026-01-01T00:00:00Z'" \
+  >"$ai_cli_retry_legacy_marker"
 
 write_stub "$ai_cli_retry_antigravity_installer" \
   'printf "%s\n" "run:antigravity" >>"$AI_CLI_RETRY_RUN_LOG"' \
@@ -826,8 +836,6 @@ case "$(uname -s)" in
 esac
 assert_contains_text "$ai_cli_retry_first_runs" "codex:path=$ai_cli_retry_expected_path" "enabled Optional AI Tool Stack first run passes host-expected PATH to Codex"
 
-ai_cli_retry_marker_dir="$ai_cli_retry_state/terrapod/install-warnings"
-ai_cli_retry_marker="$ai_cli_retry_marker_dir/optional-ai-cli-tools"
 if [ ! -f "$ai_cli_retry_marker" ]; then
   fail "enabled Optional AI Tool Stack installer writes optional-ai-cli-tools marker for partial failures"
 fi

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -623,7 +623,8 @@ ai_cli_tools_installer="$(render_template "$ai_cli_tools_data" ".chezmoiscripts/
 development_workspace_ai_installer="$(render_template "$development_workspace_data" ".chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl")"
 disabled_ai_cli_tools_cleanup="$(render_template "$ubuntu_data" ".chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl")"
 
-assert_contains_text "$disabled_ai_cli_tools_cleanup" "clear_install_warning ai-cli-tools" "disabled Optional AI Tool Stack renders stale marker cleanup"
+assert_contains_text "$disabled_ai_cli_tools_cleanup" "AI_CLI_WARNING_CATEGORY=optional-ai-cli-tools" "disabled Optional AI Tool Stack renders optional AI CLI warning category"
+assert_contains_text "$disabled_ai_cli_tools_cleanup" 'clear_install_warning "$AI_CLI_WARNING_CATEGORY"' "disabled Optional AI Tool Stack renders stale marker cleanup"
 assert_not_contains_text "$disabled_ai_cli_tools_cleanup" "https://chatgpt.com/codex/install.sh" "disabled Optional AI Tool Stack cleanup does not render installer URLs"
 
 disabled_ai_cli_tools_cleanup_script="$tmp_dir/disabled-ai-cli-tools-cleanup.sh"
@@ -635,18 +636,18 @@ ai_marker_state="$tmp_dir/ai-marker-state"
 ai_marker_home="$tmp_dir/ai-marker-home"
 mkdir -p "$ai_marker_home"
 HOME="$ai_marker_home" XDG_STATE_HOME="$ai_marker_state" sh -c \
-  '. "$1"; terrapod_install_warning_write ai-cli-tools "Optional AI CLI tool install needs attention" "Rerun tpod apply after network access is restored."' \
+  '. "$1"; terrapod_install_warning_write optional-ai-cli-tools "Optional AI CLI tool install needs attention" "Rerun tpod apply after network access is restored."' \
   sh "$repo_root/dot_local/lib/terrapod/install-warnings.sh"
 
-if [ ! -f "$ai_marker_state/terrapod/install-warnings/ai-cli-tools" ]; then
-  fail "test setup should create an ai-cli-tools warning marker"
+if [ ! -f "$ai_marker_state/terrapod/install-warnings/optional-ai-cli-tools" ]; then
+  fail "test setup should create an optional-ai-cli-tools warning marker"
 fi
 
 HOME="$ai_marker_home" XDG_STATE_HOME="$ai_marker_state" sh "$disabled_ai_cli_tools_cleanup_script"
-if [ -e "$ai_marker_state/terrapod/install-warnings/ai-cli-tools" ]; then
-  fail "disabled Optional AI Tool Stack cleanup should clear stale ai-cli-tools marker"
+if [ -e "$ai_marker_state/terrapod/install-warnings/optional-ai-cli-tools" ]; then
+  fail "disabled Optional AI Tool Stack cleanup should clear stale optional-ai-cli-tools marker"
 fi
-pass "disabled Optional AI Tool Stack cleanup clears stale ai-cli-tools marker"
+pass "disabled Optional AI Tool Stack cleanup clears stale optional-ai-cli-tools marker"
 
 for installer_url in \
   "https://antigravity.google/cli/install.sh" \

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -810,6 +810,8 @@ ai_cli_retry_first_runs="$(cat "$ai_cli_retry_run_log")"
 assert_contains_text "$ai_cli_retry_first_runs" "run:antigravity" "enabled Optional AI Tool Stack first run executes Antigravity installer"
 assert_contains_text "$ai_cli_retry_first_runs" "run:claude" "enabled Optional AI Tool Stack first run executes Claude installer"
 assert_contains_text "$ai_cli_retry_first_runs" "run:codex" "enabled Optional AI Tool Stack first run continues to Codex after Claude failure"
+assert_contains_text "$ai_cli_retry_first_runs" "bash:$ai_cli_retry_antigravity_installer" "enabled Optional AI Tool Stack first run executes Antigravity installer with bash"
+assert_contains_text "$ai_cli_retry_first_runs" "bash:$ai_cli_retry_claude_installer" "enabled Optional AI Tool Stack first run executes Claude installer with bash"
 assert_contains_text "$ai_cli_retry_first_runs" "codex:noninteractive=1" "enabled Optional AI Tool Stack first run keeps Codex noninteractive"
 case "$(uname -s)" in
   Darwin)
@@ -864,7 +866,9 @@ ai_cli_retry_second_urls="$(cat "$ai_cli_retry_url_log" 2>/dev/null || true)"
 assert_text_equals "$ai_cli_retry_second_urls" "https://claude.ai/install.sh" "enabled Optional AI Tool Stack retry downloads only Claude after partial failure"
 ai_cli_retry_second_runs="$(cat "$ai_cli_retry_run_log" 2>/dev/null || true)"
 assert_contains_text "$ai_cli_retry_second_runs" "run:claude" "enabled Optional AI Tool Stack retry executes Claude after partial failure"
+assert_contains_text "$ai_cli_retry_second_runs" "bash:$ai_cli_retry_claude_installer" "enabled Optional AI Tool Stack retry executes Claude installer with bash"
 assert_not_contains_text "$ai_cli_retry_second_runs" "run:antigravity" "enabled Optional AI Tool Stack retry skips pre-existing Antigravity"
+assert_not_contains_text "$ai_cli_retry_second_runs" "bash:$ai_cli_retry_antigravity_installer" "enabled Optional AI Tool Stack retry does not execute Antigravity installer with bash"
 assert_not_contains_text "$ai_cli_retry_second_runs" "run:codex" "enabled Optional AI Tool Stack retry skips pre-existing Codex"
 
 if [ -e "$ai_cli_retry_marker" ]; then
@@ -908,10 +912,7 @@ for unsafe_installer_text in \
   "api.github.com" \
   "sed -i" \
   "apply_patch" \
-  "patch " \
   "yes |" \
-  "printf 'y" \
-  'printf "y' \
   "| sh" \
   "| bash"
 do

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -810,8 +810,11 @@ ai_cli_retry_first_runs="$(cat "$ai_cli_retry_run_log")"
 assert_contains_text "$ai_cli_retry_first_runs" "run:antigravity" "enabled Optional AI Tool Stack first run executes Antigravity installer"
 assert_contains_text "$ai_cli_retry_first_runs" "run:claude" "enabled Optional AI Tool Stack first run executes Claude installer"
 assert_contains_text "$ai_cli_retry_first_runs" "run:codex" "enabled Optional AI Tool Stack first run continues to Codex after Claude failure"
-assert_contains_text "$ai_cli_retry_first_runs" "bash:$ai_cli_retry_antigravity_installer" "enabled Optional AI Tool Stack first run executes Antigravity installer with bash"
-assert_contains_text "$ai_cli_retry_first_runs" "bash:$ai_cli_retry_claude_installer" "enabled Optional AI Tool Stack first run executes Claude installer with bash"
+ai_cli_retry_first_bash_runs="$(printf '%s\n' "$ai_cli_retry_first_runs" | grep -c '^bash:' || true)"
+if [ "$ai_cli_retry_first_bash_runs" -ne 2 ]; then
+  fail "enabled Optional AI Tool Stack first run executes Antigravity and Claude installers with bash"
+fi
+pass "enabled Optional AI Tool Stack first run executes Antigravity and Claude installers with bash"
 assert_contains_text "$ai_cli_retry_first_runs" "codex:noninteractive=1" "enabled Optional AI Tool Stack first run keeps Codex noninteractive"
 case "$(uname -s)" in
   Darwin)
@@ -866,9 +869,12 @@ ai_cli_retry_second_urls="$(cat "$ai_cli_retry_url_log" 2>/dev/null || true)"
 assert_text_equals "$ai_cli_retry_second_urls" "https://claude.ai/install.sh" "enabled Optional AI Tool Stack retry downloads only Claude after partial failure"
 ai_cli_retry_second_runs="$(cat "$ai_cli_retry_run_log" 2>/dev/null || true)"
 assert_contains_text "$ai_cli_retry_second_runs" "run:claude" "enabled Optional AI Tool Stack retry executes Claude after partial failure"
-assert_contains_text "$ai_cli_retry_second_runs" "bash:$ai_cli_retry_claude_installer" "enabled Optional AI Tool Stack retry executes Claude installer with bash"
+ai_cli_retry_second_bash_runs="$(printf '%s\n' "$ai_cli_retry_second_runs" | grep -c '^bash:' || true)"
+if [ "$ai_cli_retry_second_bash_runs" -ne 1 ]; then
+  fail "enabled Optional AI Tool Stack retry executes only Claude installer with bash"
+fi
+pass "enabled Optional AI Tool Stack retry executes only Claude installer with bash"
 assert_not_contains_text "$ai_cli_retry_second_runs" "run:antigravity" "enabled Optional AI Tool Stack retry skips pre-existing Antigravity"
-assert_not_contains_text "$ai_cli_retry_second_runs" "bash:$ai_cli_retry_antigravity_installer" "enabled Optional AI Tool Stack retry does not execute Antigravity installer with bash"
 assert_not_contains_text "$ai_cli_retry_second_runs" "run:codex" "enabled Optional AI Tool Stack retry skips pre-existing Codex"
 
 if [ -e "$ai_cli_retry_marker" ]; then

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -642,12 +642,24 @@ HOME="$ai_marker_home" XDG_STATE_HOME="$ai_marker_state" sh -c \
 if [ ! -f "$ai_marker_state/terrapod/install-warnings/optional-ai-cli-tools" ]; then
   fail "test setup should create an optional-ai-cli-tools warning marker"
 fi
+printf '%s\n' \
+  "category='ai-cli-tools'" \
+  "summary='Legacy Optional AI CLI tool install needs attention'" \
+  "guidance='Rerun tpod apply after network access is restored.'" \
+  "updated_at='2026-01-01T00:00:00Z'" \
+  >"$ai_marker_state/terrapod/install-warnings/ai-cli-tools"
+if [ ! -f "$ai_marker_state/terrapod/install-warnings/ai-cli-tools" ]; then
+  fail "test setup should create a legacy ai-cli-tools warning marker"
+fi
 
 HOME="$ai_marker_home" XDG_STATE_HOME="$ai_marker_state" sh "$disabled_ai_cli_tools_cleanup_script"
 if [ -e "$ai_marker_state/terrapod/install-warnings/optional-ai-cli-tools" ]; then
   fail "disabled Optional AI Tool Stack cleanup should clear stale optional-ai-cli-tools marker"
 fi
-pass "disabled Optional AI Tool Stack cleanup clears stale optional-ai-cli-tools marker"
+if [ -e "$ai_marker_state/terrapod/install-warnings/ai-cli-tools" ]; then
+  fail "disabled Optional AI Tool Stack cleanup should clear stale legacy ai-cli-tools marker"
+fi
+pass "disabled Optional AI Tool Stack cleanup clears stale optional AI CLI markers"
 
 for installer_url in \
   "https://antigravity.google/cli/install.sh" \

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -661,6 +661,208 @@ if [ -e "$ai_marker_state/terrapod/install-warnings/ai-cli-tools" ]; then
 fi
 pass "disabled Optional AI Tool Stack cleanup clears stale optional AI CLI markers"
 
+ai_cli_tools_installer_script="$tmp_dir/ai-cli-tools-installer.sh"
+printf '%s\n' "$ai_cli_tools_installer" >"$ai_cli_tools_installer_script"
+sh -n "$ai_cli_tools_installer_script" || fail "enabled Optional AI Tool Stack installer script should be valid sh"
+pass "enabled Optional AI Tool Stack installer script is valid sh"
+
+ai_cli_skip_home="$tmp_dir/ai-cli-skip-home"
+ai_cli_skip_state="$tmp_dir/ai-cli-skip-state"
+ai_cli_skip_curl_log="$tmp_dir/ai-cli-skip-curl.log"
+mkdir -p "$ai_cli_skip_home/.local/bin"
+for command_name in agy claude codex; do
+  write_stub "$ai_cli_skip_home/.local/bin/$command_name" \
+    'exit 0'
+done
+write_stub "$ai_cli_skip_home/.local/bin/curl" \
+  'printf "%s\n" "curl called:$*" >>"$AI_CLI_SKIP_CURL_LOG"' \
+  'exit 7'
+
+ai_cli_skip_status=0
+HOME="$ai_cli_skip_home" \
+  XDG_STATE_HOME="$ai_cli_skip_state" \
+  AI_CLI_SKIP_CURL_LOG="$ai_cli_skip_curl_log" \
+  TMPDIR="$tmp_dir" \
+  PATH="/usr/bin:/bin" \
+  http_proxy="http://127.0.0.1:9" \
+  https_proxy="http://127.0.0.1:9" \
+  all_proxy="http://127.0.0.1:9" \
+  HTTP_PROXY="http://127.0.0.1:9" \
+  HTTPS_PROXY="http://127.0.0.1:9" \
+  ALL_PROXY="http://127.0.0.1:9" \
+  sh "$ai_cli_tools_installer_script" >/dev/null 2>"$tmp_dir/ai-cli-skip.err" || ai_cli_skip_status=$?
+if [ "$ai_cli_skip_status" -ne 0 ]; then
+  fail "enabled Optional AI Tool Stack installer exits 0 when all tools already exist under HOME-local PATH"
+fi
+pass "enabled Optional AI Tool Stack installer exits 0 when all tools already exist under HOME-local PATH"
+
+if [ -s "$ai_cli_skip_curl_log" ]; then
+  fail "enabled Optional AI Tool Stack installer skips curl when all tools already exist under HOME-local PATH"
+fi
+pass "enabled Optional AI Tool Stack installer skips curl when all tools already exist under HOME-local PATH"
+
+if [ -e "$ai_cli_skip_state/terrapod/install-warnings/optional-ai-cli-tools" ]; then
+  fail "enabled Optional AI Tool Stack installer leaves no optional-ai-cli-tools marker when all tools are already installed"
+fi
+pass "enabled Optional AI Tool Stack installer leaves no optional-ai-cli-tools marker when all tools are already installed"
+
+ai_cli_retry_home="$tmp_dir/ai-cli-retry-home"
+ai_cli_retry_state="$tmp_dir/ai-cli-retry-state"
+ai_cli_retry_url_log="$tmp_dir/ai-cli-retry-url.log"
+ai_cli_retry_run_log="$tmp_dir/ai-cli-retry-run.log"
+ai_cli_retry_antigravity_installer="$tmp_dir/ai-cli-retry-antigravity-installer.sh"
+ai_cli_retry_claude_installer="$tmp_dir/ai-cli-retry-claude-installer.sh"
+ai_cli_retry_codex_installer="$tmp_dir/ai-cli-retry-codex-installer.sh"
+mkdir -p "$ai_cli_retry_home/.local/bin"
+
+write_stub "$ai_cli_retry_antigravity_installer" \
+  'printf "%s\n" "run:antigravity" >>"$AI_CLI_RETRY_RUN_LOG"' \
+  'mkdir -p "$HOME/.local/bin"' \
+  'printf "%s\n" "#!/bin/sh" "exit 0" >"$HOME/.local/bin/agy"' \
+  'chmod +x "$HOME/.local/bin/agy"'
+write_stub "$ai_cli_retry_claude_installer" \
+  'printf "%s\n" "run:claude" >>"$AI_CLI_RETRY_RUN_LOG"' \
+  'if [ "${AI_CLI_RETRY_CLAUDE_FAIL:-}" = "1" ]; then exit 42; fi' \
+  'mkdir -p "$HOME/.local/bin"' \
+  'printf "%s\n" "#!/bin/sh" "exit 0" >"$HOME/.local/bin/claude"' \
+  'chmod +x "$HOME/.local/bin/claude"'
+write_stub "$ai_cli_retry_codex_installer" \
+  'printf "%s\n" "run:codex" >>"$AI_CLI_RETRY_RUN_LOG"' \
+  'printf "%s\n" "codex:noninteractive=${CODEX_NON_INTERACTIVE:-}" >>"$AI_CLI_RETRY_RUN_LOG"' \
+  'printf "%s\n" "codex:path=$PATH" >>"$AI_CLI_RETRY_RUN_LOG"' \
+  'mkdir -p "$HOME/.local/bin"' \
+  'printf "%s\n" "#!/bin/sh" "exit 0" >"$HOME/.local/bin/codex"' \
+  'chmod +x "$HOME/.local/bin/codex"'
+
+write_stub "$ai_cli_retry_home/.local/bin/bash" \
+  'printf "%s\n" "bash:$1" >>"$AI_CLI_RETRY_RUN_LOG"' \
+  'exec sh "$@"'
+write_stub "$ai_cli_retry_home/.local/bin/curl" \
+  'url=' \
+  'output=' \
+  'while [ "$#" -gt 0 ]; do' \
+  '  case "$1" in' \
+  '    -o)' \
+  '      shift' \
+  '      output="${1:-}"' \
+  '      ;;' \
+  '    https://*)' \
+  '      url="$1"' \
+  '      ;;' \
+  '  esac' \
+  '  shift' \
+  'done' \
+  'if [ -z "$url" ] || [ -z "$output" ]; then' \
+  '  printf "%s\n" "bad curl args" >>"$AI_CLI_RETRY_RUN_LOG"' \
+  '  exit 2' \
+  'fi' \
+  'printf "%s\n" "$url" >>"$AI_CLI_RETRY_URL_LOG"' \
+  'case "$url" in' \
+  '  https://antigravity.google/cli/install.sh)' \
+  '    cp "$AI_CLI_RETRY_ANTIGRAVITY_INSTALLER" "$output"' \
+  '    ;;' \
+  '  https://claude.ai/install.sh)' \
+  '    cp "$AI_CLI_RETRY_CLAUDE_INSTALLER" "$output"' \
+  '    ;;' \
+  '  https://chatgpt.com/codex/install.sh)' \
+  '    cp "$AI_CLI_RETRY_CODEX_INSTALLER" "$output"' \
+  '    ;;' \
+  '  *)' \
+  '    printf "%s\n" "unexpected url:$url" >>"$AI_CLI_RETRY_RUN_LOG"' \
+  '    exit 3' \
+  '    ;;' \
+  'esac'
+
+ai_cli_retry_status=0
+HOME="$ai_cli_retry_home" \
+  XDG_STATE_HOME="$ai_cli_retry_state" \
+  AI_CLI_RETRY_URL_LOG="$ai_cli_retry_url_log" \
+  AI_CLI_RETRY_RUN_LOG="$ai_cli_retry_run_log" \
+  AI_CLI_RETRY_ANTIGRAVITY_INSTALLER="$ai_cli_retry_antigravity_installer" \
+  AI_CLI_RETRY_CLAUDE_INSTALLER="$ai_cli_retry_claude_installer" \
+  AI_CLI_RETRY_CODEX_INSTALLER="$ai_cli_retry_codex_installer" \
+  AI_CLI_RETRY_CLAUDE_FAIL=1 \
+  TMPDIR="$tmp_dir" \
+  PATH="$ai_cli_retry_home/.local/bin:/usr/bin:/bin" \
+  sh "$ai_cli_tools_installer_script" >/dev/null 2>"$tmp_dir/ai-cli-retry-first.err" || ai_cli_retry_status=$?
+if [ "$ai_cli_retry_status" -ne 0 ]; then
+  fail "enabled Optional AI Tool Stack installer exits 0 while recording partial AI CLI installer failures"
+fi
+pass "enabled Optional AI Tool Stack installer exits 0 while recording partial AI CLI installer failures"
+
+if [ ! -x "$ai_cli_retry_home/.local/bin/agy" ]; then
+  fail "enabled Optional AI Tool Stack installer keeps successful Antigravity install after Claude failure"
+fi
+if [ ! -x "$ai_cli_retry_home/.local/bin/codex" ]; then
+  fail "enabled Optional AI Tool Stack installer keeps running Codex after Claude failure"
+fi
+if [ -x "$ai_cli_retry_home/.local/bin/claude" ]; then
+  fail "enabled Optional AI Tool Stack installer does not mark failed Claude install as present"
+fi
+pass "enabled Optional AI Tool Stack installer records successful and failed AI CLI installs independently"
+
+ai_cli_retry_first_urls="$(cat "$ai_cli_retry_url_log")"
+assert_contains_text "$ai_cli_retry_first_urls" "https://antigravity.google/cli/install.sh" "enabled Optional AI Tool Stack first run downloads official Antigravity installer"
+assert_contains_text "$ai_cli_retry_first_urls" "https://claude.ai/install.sh" "enabled Optional AI Tool Stack first run downloads official Claude installer"
+assert_contains_text "$ai_cli_retry_first_urls" "https://chatgpt.com/codex/install.sh" "enabled Optional AI Tool Stack first run downloads official Codex installer"
+
+ai_cli_retry_first_runs="$(cat "$ai_cli_retry_run_log")"
+assert_contains_text "$ai_cli_retry_first_runs" "run:antigravity" "enabled Optional AI Tool Stack first run executes Antigravity installer"
+assert_contains_text "$ai_cli_retry_first_runs" "run:claude" "enabled Optional AI Tool Stack first run executes Claude installer"
+assert_contains_text "$ai_cli_retry_first_runs" "run:codex" "enabled Optional AI Tool Stack first run continues to Codex after Claude failure"
+assert_contains_text "$ai_cli_retry_first_runs" "codex:noninteractive=1" "enabled Optional AI Tool Stack first run keeps Codex noninteractive"
+assert_contains_text "$ai_cli_retry_first_runs" "codex:path=$ai_cli_retry_home/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" "enabled Optional AI Tool Stack first run passes expected Linux PATH to Codex"
+
+ai_cli_retry_marker_dir="$ai_cli_retry_state/terrapod/install-warnings"
+ai_cli_retry_marker="$ai_cli_retry_marker_dir/optional-ai-cli-tools"
+if [ ! -f "$ai_cli_retry_marker" ]; then
+  fail "enabled Optional AI Tool Stack installer writes optional-ai-cli-tools marker for partial failures"
+fi
+ai_cli_retry_marker_files="$(find "$ai_cli_retry_marker_dir" -type f -print | sort)"
+assert_text_equals "$ai_cli_retry_marker_files" "$ai_cli_retry_marker" "enabled Optional AI Tool Stack installer writes one optional-ai-cli-tools marker for partial failures"
+ai_cli_retry_marker_text="$(cat "$ai_cli_retry_marker")"
+assert_contains_text "$ai_cli_retry_marker_text" "claude" "enabled Optional AI Tool Stack partial failure marker mentions Claude only"
+assert_not_contains_text "$ai_cli_retry_marker_text" "antigravity" "enabled Optional AI Tool Stack partial failure marker omits successful Antigravity"
+assert_not_contains_text "$ai_cli_retry_marker_text" "Antigravity" "enabled Optional AI Tool Stack partial failure marker omits successful Antigravity label"
+assert_not_contains_text "$ai_cli_retry_marker_text" "codex" "enabled Optional AI Tool Stack partial failure marker omits successful Codex"
+assert_not_contains_text "$ai_cli_retry_marker_text" "Codex" "enabled Optional AI Tool Stack partial failure marker omits successful Codex label"
+
+: >"$ai_cli_retry_url_log"
+: >"$ai_cli_retry_run_log"
+ai_cli_retry_second_status=0
+HOME="$ai_cli_retry_home" \
+  XDG_STATE_HOME="$ai_cli_retry_state" \
+  AI_CLI_RETRY_URL_LOG="$ai_cli_retry_url_log" \
+  AI_CLI_RETRY_RUN_LOG="$ai_cli_retry_run_log" \
+  AI_CLI_RETRY_ANTIGRAVITY_INSTALLER="$ai_cli_retry_antigravity_installer" \
+  AI_CLI_RETRY_CLAUDE_INSTALLER="$ai_cli_retry_claude_installer" \
+  AI_CLI_RETRY_CODEX_INSTALLER="$ai_cli_retry_codex_installer" \
+  AI_CLI_RETRY_CLAUDE_FAIL=0 \
+  TMPDIR="$tmp_dir" \
+  PATH="$ai_cli_retry_home/.local/bin:/usr/bin:/bin" \
+  sh "$ai_cli_tools_installer_script" >/dev/null 2>"$tmp_dir/ai-cli-retry-second.err" || ai_cli_retry_second_status=$?
+if [ "$ai_cli_retry_second_status" -ne 0 ]; then
+  fail "enabled Optional AI Tool Stack retry exits 0 after recovering failed Claude install"
+fi
+pass "enabled Optional AI Tool Stack retry exits 0 after recovering failed Claude install"
+
+if [ ! -x "$ai_cli_retry_home/.local/bin/claude" ]; then
+  fail "enabled Optional AI Tool Stack retry installs Claude after previous failure"
+fi
+pass "enabled Optional AI Tool Stack retry installs Claude after previous failure"
+
+ai_cli_retry_second_urls="$(cat "$ai_cli_retry_url_log" 2>/dev/null || true)"
+assert_text_equals "$ai_cli_retry_second_urls" "https://claude.ai/install.sh" "enabled Optional AI Tool Stack retry downloads only Claude after partial failure"
+ai_cli_retry_second_runs="$(cat "$ai_cli_retry_run_log" 2>/dev/null || true)"
+assert_contains_text "$ai_cli_retry_second_runs" "run:claude" "enabled Optional AI Tool Stack retry executes Claude after partial failure"
+assert_not_contains_text "$ai_cli_retry_second_runs" "run:antigravity" "enabled Optional AI Tool Stack retry skips pre-existing Antigravity"
+assert_not_contains_text "$ai_cli_retry_second_runs" "run:codex" "enabled Optional AI Tool Stack retry skips pre-existing Codex"
+
+if [ -e "$ai_cli_retry_marker" ]; then
+  fail "enabled Optional AI Tool Stack retry clears optional-ai-cli-tools marker after recovery"
+fi
+pass "enabled Optional AI Tool Stack retry clears optional-ai-cli-tools marker after recovery"
+
 for installer_url in \
   "https://antigravity.google/cli/install.sh" \
   "https://claude.ai/install.sh" \
@@ -683,10 +885,35 @@ do
   assert_not_contains_text "$development_workspace_ai_installer" "$legacy_text" "enableDevelopmentWorkspace does not render legacy npm AI CLI management: $legacy_text"
 done
 
-assert_contains_text "$ai_cli_tools_installer" 'CODEX_NON_INTERACTIVE=1 PATH="$HOME/.local/bin:/usr/bin:/bin:/usr/sbin:/sbin" "$shell_name" "$installer_path"' \
-  "enableAiCliTools runs Codex installer without seeing legacy PATH-managed codex"
-assert_contains_text "$development_workspace_ai_installer" 'CODEX_NON_INTERACTIVE=1 PATH="$HOME/.local/bin:/usr/bin:/bin:/usr/sbin:/sbin" "$shell_name" "$installer_path"' \
-  "enableDevelopmentWorkspace runs Codex installer without seeing legacy PATH-managed codex"
+for expected_path_assignment in \
+  'AI_CLI_EXPECTED_PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"' \
+  'AI_CLI_EXPECTED_PATH="$HOME/.local/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"'
+do
+  assert_contains_text "$ai_cli_tools_installer" "$expected_path_assignment" "enableAiCliTools renders expected AI CLI installer PATH assignment: $expected_path_assignment"
+  assert_contains_text "$development_workspace_ai_installer" "$expected_path_assignment" "enableDevelopmentWorkspace renders expected AI CLI installer PATH assignment: $expected_path_assignment"
+done
+
+for unsafe_installer_text in \
+  "GITHUB_TOKEN" \
+  "Authorization:" \
+  "api.github.com" \
+  "sed -i" \
+  "apply_patch" \
+  "patch " \
+  "yes |" \
+  "printf 'y" \
+  'printf "y' \
+  "| sh" \
+  "| bash"
+do
+  assert_not_contains_text "$ai_cli_tools_installer" "$unsafe_installer_text" "enableAiCliTools renders official-only AI CLI installer without unsafe automation text: $unsafe_installer_text"
+  assert_not_contains_text "$development_workspace_ai_installer" "$unsafe_installer_text" "enableDevelopmentWorkspace renders official-only AI CLI installer without unsafe automation text: $unsafe_installer_text"
+done
+
+assert_contains_text "$ai_cli_tools_installer" 'CODEX_NON_INTERACTIVE=1' \
+  "enableAiCliTools runs Codex installer noninteractively"
+assert_contains_text "$development_workspace_ai_installer" 'CODEX_NON_INTERACTIVE=1' \
+  "enableDevelopmentWorkspace runs Codex installer noninteractively"
 
 development_workspace_zellij_layout="$(render_managed_file "$development_workspace_data" ".config/zellij/layouts/dev.kdl")"
 

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -822,14 +822,21 @@ write_stub "$fake_warning_bin/terrapod_install_warning_value" \
 write_stub "$fake_warning_bin/terrapod_install_warning_write" \
   'printf "%s\n" "write $*" >>"$FAKE_INSTALL_WARNING_CALLS"'
 
+fake_ai_cli_home="$tmp_dir/fake-ai-cli-home"
+mkdir -p "$fake_ai_cli_home/.local/bin"
+for command_name in agy claude codex; do
+  write_stub "$fake_ai_cli_home/.local/bin/$command_name" \
+    'exit 0'
+done
+
 fake_ai_cli_installer="$tmp_dir/fake-ai-cli-installer.sh"
 chezmoi execute-template \
   --override-data '{"chezmoi":{"os":"linux","sourceDir":"/missing-terrapod-source"},"enableAiCliTools":true}' \
   --file "$repo_root/.chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl" \
   >"$fake_ai_cli_installer"
 
-if FAKE_INSTALL_WARNING_CALLS="$fake_warning_calls" PATH="$fake_warning_bin" /bin/sh "$fake_ai_cli_installer" >"$tmp_dir/fake-ai-cli-installer.out" 2>"$tmp_dir/fake-ai-cli-installer.err"; then
-  fail "rendered installer fixture fails before optional AI CLI tools when curl is unavailable"
+if ! HOME="$fake_ai_cli_home" FAKE_INSTALL_WARNING_CALLS="$fake_warning_calls" PATH="$fake_warning_bin" /bin/sh "$fake_ai_cli_installer" >"$tmp_dir/fake-ai-cli-installer.out" 2>"$tmp_dir/fake-ai-cli-installer.err"; then
+  fail "rendered installer fixture succeeds when optional AI CLI tools are already available and the shared library is missing"
 fi
 
 if [ -e "$fake_warning_calls" ]; then

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -738,6 +738,69 @@ if HOME="$marker_home" XDG_STATE_HOME="$marker_xdg_state" sh -c '. "$1"; terrapo
 fi
 pass "install warning marker write rejects unknown categories"
 
+if HOME="$marker_home" XDG_STATE_HOME="$marker_xdg_state" sh -c '. "$1"; terrapod_install_warning_write ai-cli-tools "bad" "bad"' sh "$install_warnings_lib" 2>/dev/null; then
+  fail "install warning marker write rejects the legacy AI CLI category slug"
+fi
+pass "install warning marker write rejects the legacy AI CLI category slug"
+
+legacy_marker_home="$tmp_dir/legacy-marker-home"
+legacy_marker_state="$tmp_dir/legacy-marker-state"
+legacy_marker_dir="$legacy_marker_state/terrapod/install-warnings"
+legacy_ai_cli_marker="$legacy_marker_dir/ai-cli-tools"
+mkdir -p "$legacy_marker_dir" "$legacy_marker_home"
+printf '%s\n' \
+  "category='ai-cli-tools'" \
+  "summary='Legacy AI CLI tool install needs attention'" \
+  "guidance='Rerun tpod apply after network access is restored.'" \
+  "updated_at='2026-01-01T00:00:00Z'" \
+  >"$legacy_ai_cli_marker"
+
+legacy_marker_list="$(
+  HOME="$legacy_marker_home" XDG_STATE_HOME="$legacy_marker_state" sh -c '. "$1"; terrapod_install_warning_list' sh "$install_warnings_lib"
+)"
+if [ "$legacy_marker_list" != "optional-ai-cli-tools" ]; then
+  fail "install warning marker list exposes legacy AI CLI markers through the stable category slug"
+fi
+pass "install warning marker list exposes legacy AI CLI markers through the stable category slug"
+
+legacy_marker_read="$(
+  HOME="$legacy_marker_home" XDG_STATE_HOME="$legacy_marker_state" sh -c '. "$1"; terrapod_install_warning_read optional-ai-cli-tools' sh "$install_warnings_lib"
+)"
+assert_contains "$legacy_marker_read" "category='ai-cli-tools'" "install warning marker read falls back to legacy AI CLI marker files"
+
+legacy_marker_summary="$(
+  HOME="$legacy_marker_home" XDG_STATE_HOME="$legacy_marker_state" sh -c '. "$1"; terrapod_install_warning_value optional-ai-cli-tools summary' sh "$install_warnings_lib"
+)"
+if [ "$legacy_marker_summary" != "Legacy AI CLI tool install needs attention" ]; then
+  fail "install warning marker value falls back to legacy AI CLI marker files"
+fi
+pass "install warning marker value falls back to legacy AI CLI marker files"
+
+HOME="$legacy_marker_home" XDG_STATE_HOME="$legacy_marker_state" sh -c \
+  '. "$1"; terrapod_install_warning_write optional-ai-cli-tools "Current AI CLI tool install needs attention" "Rerun tpod apply after network access is restored."' \
+  sh "$install_warnings_lib"
+current_marker_summary="$(
+  HOME="$legacy_marker_home" XDG_STATE_HOME="$legacy_marker_state" sh -c '. "$1"; terrapod_install_warning_value optional-ai-cli-tools summary' sh "$install_warnings_lib"
+)"
+if [ "$current_marker_summary" != "Current AI CLI tool install needs attention" ]; then
+  fail "install warning marker value prefers stable AI CLI marker files over legacy marker files"
+fi
+pass "install warning marker value prefers stable AI CLI marker files over legacy marker files"
+
+HOME="$legacy_marker_home" XDG_STATE_HOME="$legacy_marker_state" sh -c '. "$1"; terrapod_install_warning_clear optional-ai-cli-tools' sh "$install_warnings_lib"
+if [ -e "$legacy_marker_dir/optional-ai-cli-tools" ] || [ -e "$legacy_ai_cli_marker" ]; then
+  fail "install warning marker clear removes stable and legacy AI CLI marker files"
+fi
+pass "install warning marker clear removes stable and legacy AI CLI marker files"
+
+HOME="$legacy_marker_home" XDG_STATE_HOME="$legacy_marker_state" sh -c \
+  '. "$1"; terrapod_install_warning_write optional-ai-cli-tools "AI CLI tool install needs attention" "Rerun tpod apply after network access is restored."' \
+  sh "$install_warnings_lib"
+if [ ! -f "$legacy_marker_dir/optional-ai-cli-tools" ] || [ -e "$legacy_ai_cli_marker" ]; then
+  fail "install warning marker write stores Optional AI CLI warnings only under the stable category slug"
+fi
+pass "install warning marker write stores Optional AI CLI warnings only under the stable category slug"
+
 fake_warning_bin="$tmp_dir/fake-warning-bin"
 fake_warning_calls="$tmp_dir/fake-warning.calls"
 mkdir -p "$fake_warning_bin"

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -788,6 +788,10 @@ pass "install warning marker value falls back to legacy AI CLI marker files"
 HOME="$legacy_marker_home" XDG_STATE_HOME="$legacy_marker_state" sh -c \
   '. "$1"; terrapod_install_warning_write optional-ai-cli-tools "Current AI CLI tool install needs attention" "Rerun tpod apply after network access is restored."' \
   sh "$install_warnings_lib"
+if [ ! -f "$legacy_marker_dir/optional-ai-cli-tools" ] || [ -e "$legacy_ai_cli_marker" ]; then
+  fail "install warning marker write replaces legacy AI CLI marker files with the stable marker"
+fi
+pass "install warning marker write replaces legacy AI CLI marker files with the stable marker"
 current_marker_summary="$(
   HOME="$legacy_marker_home" XDG_STATE_HOME="$legacy_marker_state" sh -c '. "$1"; terrapod_install_warning_value optional-ai-cli-tools summary' sh "$install_warnings_lib"
 )"

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -848,6 +848,87 @@ if [ -e "$fake_warning_calls" ]; then
 fi
 pass "installer scripts ignore PATH fake install warning helpers when the shared library is not loaded"
 
+fake_ai_cli_failure_home="$tmp_dir/fake-ai-cli-failure-home"
+mkdir -p "$fake_ai_cli_failure_home/.local/bin"
+for command_name in agy codex; do
+  write_stub "$fake_ai_cli_failure_home/.local/bin/$command_name" \
+    'exit 0'
+done
+write_stub "$fake_ai_cli_failure_home/.local/bin/bash" \
+  'exec sh "$@"'
+write_stub "$fake_ai_cli_failure_home/.local/bin/curl" \
+  'output=' \
+  'while [ "$#" -gt 0 ]; do' \
+  '  case "$1" in' \
+  '    -o)' \
+  '      shift' \
+  '      output="${1:-}"' \
+  '      ;;' \
+  '  esac' \
+  '  shift' \
+  'done' \
+  '[ -n "$output" ] || exit 2' \
+  'printf "%s\n" "#!/bin/sh" "exit 42" >"$output"'
+
+fake_ai_cli_failure_installer="$tmp_dir/fake-ai-cli-failure-installer.sh"
+chezmoi execute-template \
+  --override-data '{"chezmoi":{"os":"linux","sourceDir":"/missing-terrapod-source"},"enableAiCliTools":true}' \
+  --file "$repo_root/.chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl" \
+  >"$fake_ai_cli_failure_installer"
+
+fake_ai_cli_failure_status=0
+HOME="$fake_ai_cli_failure_home" PATH="/usr/bin:/bin" /bin/sh "$fake_ai_cli_failure_installer" >"$tmp_dir/fake-ai-cli-failure.out" 2>"$tmp_dir/fake-ai-cli-failure.err" || fake_ai_cli_failure_status=$?
+if [ "$fake_ai_cli_failure_status" -eq 0 ]; then
+  fail "rendered installer fixture fails when optional AI CLI failures cannot be recorded without the shared library"
+fi
+pass "rendered installer fixture fails when optional AI CLI failures cannot be recorded without the shared library"
+
+fake_ai_cli_warning_source="$tmp_dir/fake-ai-cli-warning-source"
+fake_ai_cli_write_failure_home="$tmp_dir/fake-ai-cli-write-failure-home"
+mkdir -p "$fake_ai_cli_warning_source/dot_local/lib/terrapod" "$fake_ai_cli_write_failure_home/.local/bin"
+printf '%s\n' \
+  'TERRAPOD_INSTALL_WARNINGS_LOADED=1' \
+  'terrapod_install_warning_write() {' \
+  '  printf "%s\n" "write failed:$*" >&2' \
+  '  return 1' \
+  '}' \
+  'terrapod_install_warning_clear() {' \
+  '  return 0' \
+  '}' \
+  >"$fake_ai_cli_warning_source/dot_local/lib/terrapod/install-warnings.sh"
+for command_name in agy codex; do
+  write_stub "$fake_ai_cli_write_failure_home/.local/bin/$command_name" \
+    'exit 0'
+done
+write_stub "$fake_ai_cli_write_failure_home/.local/bin/bash" \
+  'exec sh "$@"'
+write_stub "$fake_ai_cli_write_failure_home/.local/bin/curl" \
+  'output=' \
+  'while [ "$#" -gt 0 ]; do' \
+  '  case "$1" in' \
+  '    -o)' \
+  '      shift' \
+  '      output="${1:-}"' \
+  '      ;;' \
+  '  esac' \
+  '  shift' \
+  'done' \
+  '[ -n "$output" ] || exit 2' \
+  'printf "%s\n" "#!/bin/sh" "exit 42" >"$output"'
+
+fake_ai_cli_write_failure_installer="$tmp_dir/fake-ai-cli-write-failure-installer.sh"
+chezmoi execute-template \
+  --override-data "{\"chezmoi\":{\"os\":\"linux\",\"sourceDir\":\"$fake_ai_cli_warning_source\"},\"enableAiCliTools\":true}" \
+  --file "$repo_root/.chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl" \
+  >"$fake_ai_cli_write_failure_installer"
+
+fake_ai_cli_write_failure_status=0
+HOME="$fake_ai_cli_write_failure_home" PATH="/usr/bin:/bin" /bin/sh "$fake_ai_cli_write_failure_installer" >"$tmp_dir/fake-ai-cli-write-failure.out" 2>"$tmp_dir/fake-ai-cli-write-failure.err" || fake_ai_cli_write_failure_status=$?
+if [ "$fake_ai_cli_write_failure_status" -eq 0 ]; then
+  fail "rendered installer fixture fails when optional AI CLI failures cannot be recorded after marker write failure"
+fi
+pass "rendered installer fixture fails when optional AI CLI failures cannot be recorded after marker write failure"
+
 help_output="$(TERRAPOD_PROFILE=macos-terminal sh "$terrapod" help)"
 help_with_marker_output="$(
   HOME="$marker_home" XDG_STATE_HOME="$marker_xdg_state" TERRAPOD_PROFILE=macos-terminal sh "$terrapod" help

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -640,7 +640,7 @@ pass "install warning markers honor XDG_STATE_HOME"
 marker_categories="$(
   sh -c '. "$1"; terrapod_install_warning_categories' sh "$install_warnings_lib"
 )"
-expected_marker_categories="$(printf '%s\n' homebrew-core homebrew-desktop-apps ubuntu-bootstrap shell-integrations mise-tools ai-cli-tools)"
+expected_marker_categories="$(printf '%s\n' homebrew-core homebrew-desktop-apps ubuntu-bootstrap shell-integrations mise-tools optional-ai-cli-tools)"
 
 if [ "$marker_categories" != "$expected_marker_categories" ]; then
   printf '%s\n' "expected marker categories:" >&2
@@ -686,13 +686,13 @@ fi
 pass "install warning marker updated_at is a UTC ISO 8601 timestamp ending in Z"
 
 HOME="$marker_home" XDG_STATE_HOME="$marker_xdg_state" sh -c \
-  '. "$1"; terrapod_install_warning_write ai-cli-tools "AI CLI tool install needs attention" "Rerun tpod apply after network access is restored."' \
+  '. "$1"; terrapod_install_warning_write optional-ai-cli-tools "AI CLI tool install needs attention" "Rerun tpod apply after network access is restored."' \
   sh "$install_warnings_lib"
 
 marker_list="$(
   HOME="$marker_home" XDG_STATE_HOME="$marker_xdg_state" sh -c '. "$1"; terrapod_install_warning_list' sh "$install_warnings_lib"
 )"
-expected_marker_list="$(printf '%s\n' homebrew-core ai-cli-tools)"
+expected_marker_list="$(printf '%s\n' homebrew-core optional-ai-cli-tools)"
 if [ "$marker_list" != "$expected_marker_list" ]; then
   printf '%s\n' "expected marker list:" >&2
   printf '%s\n' "$expected_marker_list" | sed 's/^/  /' >&2
@@ -728,7 +728,7 @@ if [ -e "$homebrew_core_marker" ]; then
 fi
 pass "install warning marker clear removes the matching category file"
 
-if [ ! -f "$marker_xdg_state/terrapod/install-warnings/ai-cli-tools" ]; then
+if [ ! -f "$marker_xdg_state/terrapod/install-warnings/optional-ai-cli-tools" ]; then
   fail "install warning marker clear does not remove other category files"
 fi
 pass "install warning marker clear does not remove other category files"

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -766,7 +766,16 @@ pass "install warning marker list exposes legacy AI CLI markers through the stab
 legacy_marker_read="$(
   HOME="$legacy_marker_home" XDG_STATE_HOME="$legacy_marker_state" sh -c '. "$1"; terrapod_install_warning_read optional-ai-cli-tools' sh "$install_warnings_lib"
 )"
-assert_contains "$legacy_marker_read" "category='ai-cli-tools'" "install warning marker read falls back to legacy AI CLI marker files"
+assert_contains "$legacy_marker_read" "category='optional-ai-cli-tools'" "install warning marker read normalizes legacy AI CLI marker categories"
+assert_not_contains "$legacy_marker_read" "category='ai-cli-tools'" "install warning marker read does not expose legacy AI CLI marker categories"
+
+legacy_marker_category="$(
+  HOME="$legacy_marker_home" XDG_STATE_HOME="$legacy_marker_state" sh -c '. "$1"; terrapod_install_warning_value optional-ai-cli-tools category' sh "$install_warnings_lib"
+)"
+if [ "$legacy_marker_category" != "optional-ai-cli-tools" ]; then
+  fail "install warning marker category value normalizes legacy AI CLI marker files"
+fi
+pass "install warning marker category value normalizes legacy AI CLI marker files"
 
 legacy_marker_summary="$(
   HOME="$legacy_marker_home" XDG_STATE_HOME="$legacy_marker_state" sh -c '. "$1"; terrapod_install_warning_value optional-ai-cli-tools summary' sh "$install_warnings_lib"


### PR DESCRIPTION
## Summary
- Make Optional AI CLI warnings use the stable `optional-ai-cli-tools` marker while preserving and migrating legacy `ai-cli-tools` markers.
- Update the Optional AI Tool Stack installer to skip existing `agy`, `claude`, and `codex` commands on the expected PATH, keep successful installs after partial failure, and retry only missing tools.
- Keep installer automation official-only, run Codex with `CODEX_NON_INTERACTIVE=1`, and clear optional warning markers when the stack is disabled or recovered.

## Root Cause
The Optional AI Tool Stack previously lacked marker-aware retry behavior and did not consistently model AI CLI install warnings as a single optional warning category.

## Test Plan
- [x] `sh tests/chezmoiignore_test.sh`
- [x] `sh tests/terrapod_command_test.sh`
- [x] `sh tests/chezmoiignore_test.sh && sh tests/terrapod_command_test.sh && git diff --check HEAD`
- [x] Full shell/zsh loop: `for test_script in tests/*_test.sh tests/*.zsh; do [ -e "$test_script" ] || continue; case "$test_script" in *.zsh) zsh "$test_script" ;; *) sh "$test_script" ;; esac; done`

Closes #103
