### PR TITLE
Add first-run warning completion

### DIFF
--- a/.chezmoiscripts/run_before_01-retry-homebrew-desktop-apps.sh.tmpl
+++ b/.chezmoiscripts/run_before_01-retry-homebrew-desktop-apps.sh.tmpl
@@ -24,7 +24,7 @@ mark_install_warning() {
   summary="$2"
   guidance="$3"
 
-  terrapod_install_warning_write "$category" "$summary" "$guidance" || true
+  terrapod_install_warning_write "$category" "$summary" "$guidance"
 }
 
 clear_install_warning() {
@@ -197,7 +197,8 @@ if [ -z "$brew_bin" ]; then
   mark_install_warning \
     homebrew-desktop-apps \
     "Homebrew desktop app install needs attention" \
-    "Install Homebrew from https://brew.sh, then rerun tpod apply."
+    "Install Homebrew from https://brew.sh, then rerun tpod apply." ||
+    exit 1
   exit 0
 fi
 
@@ -205,7 +206,8 @@ if ! brew_shellenv="$("$brew_bin" shellenv)"; then
   mark_install_warning \
     homebrew-desktop-apps \
     "Homebrew desktop app install needs attention" \
-    "Fix Homebrew shellenv, then rerun tpod apply."
+    "Fix Homebrew shellenv, then rerun tpod apply." ||
+    exit 1
   exit 0
 fi
 eval "$brew_shellenv"
@@ -229,7 +231,8 @@ if [ -s "$desktop_brewfile" ]; then
     mark_install_warning \
       homebrew-desktop-apps \
       "Homebrew desktop app install needs attention" \
-      "$desktop_app_failure_guidance_text"
+      "$desktop_app_failure_guidance_text" ||
+      exit 1
   fi
 else
   clear_install_warning homebrew-desktop-apps

--- a/.chezmoiscripts/run_onchange_after_20-install-mise-tools.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_20-install-mise-tools.sh.tmpl
@@ -9,14 +9,26 @@ if [ -f "$install_warnings_lib" ]; then
   . "$install_warnings_lib"
 fi
 
+INSTALL_WARNING_RECORDED=0
+
 mark_install_warning() {
   category="$1"
   summary="$2"
   guidance="$3"
+  INSTALL_WARNING_RECORDED=0
 
-  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ]; then
-    terrapod_install_warning_write "$category" "$summary" "$guidance" || true
+  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ] &&
+    terrapod_install_warning_write "$category" "$summary" "$guidance"; then
+    INSTALL_WARNING_RECORDED=1
   fi
+}
+
+exit_after_install_warning() {
+  if [ "${TERRAPOD_FIRST_RUN_APPLY:-}" = "1" ] && [ "$INSTALL_WARNING_RECORDED" -eq 1 ]; then
+    exit 0
+  fi
+
+  exit 1
 }
 
 clear_install_warning() {
@@ -51,7 +63,7 @@ setup_mise() {
       mise-tools \
       "mise tool install needs attention" \
       "Run the Homebrew Brewfile bundle or fix mise on PATH, then rerun tpod apply."
-    exit 1
+    exit_after_install_warning
   fi
 {{ else }}
   echo "mise is required. The Ubuntu bootstrap script should install mise from the official APT repository." >&2
@@ -59,7 +71,7 @@ setup_mise() {
     mise-tools \
     "mise tool install needs attention" \
     "Run the Ubuntu bootstrap script or fix mise on PATH, then rerun tpod apply."
-  exit 1
+  exit_after_install_warning
 {{ end }}
 }
 
@@ -69,7 +81,7 @@ if ! mise install --yes -C "$HOME"; then
     mise-tools \
     "mise tool install needs attention" \
     "Review mise install output, fix tool installation issues, then rerun tpod apply."
-  exit 1
+  exit_after_install_warning
 fi
 
 if mise exec --yes -C "$HOME" -- sh -c 'command -v corepack' >/dev/null 2>&1; then
@@ -78,7 +90,7 @@ if mise exec --yes -C "$HOME" -- sh -c 'command -v corepack' >/dev/null 2>&1; th
       mise-tools \
       "mise tool install needs attention" \
       "Review corepack enable output, then rerun tpod apply."
-    exit 1
+    exit_after_install_warning
   fi
 fi
 

--- a/.chezmoiscripts/run_onchange_before_00-bootstrap-homebrew.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_00-bootstrap-homebrew.sh.tmpl
@@ -15,14 +15,29 @@ if [ -f "$install_warnings_lib" ]; then
   . "$install_warnings_lib"
 fi
 
+INSTALL_WARNING_RECORDED=0
+
 mark_install_warning() {
   category="$1"
   summary="$2"
   guidance="$3"
+  INSTALL_WARNING_RECORDED=0
 
-  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ]; then
-    terrapod_install_warning_write "$category" "$summary" "$guidance" || true
+  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ] &&
+    terrapod_install_warning_write "$category" "$summary" "$guidance"; then
+    INSTALL_WARNING_RECORDED=1
+    return 0
   fi
+
+  return 1
+}
+
+exit_after_install_warning() {
+  if [ "${TERRAPOD_FIRST_RUN_APPLY:-}" = "1" ] && [ "$INSTALL_WARNING_RECORDED" -eq 1 ]; then
+    exit 0
+  fi
+
+  exit 1
 }
 
 clear_install_warning() {
@@ -193,7 +208,7 @@ if [ -z "$brew_bin" ]; then
       homebrew-core \
       "Homebrew core install needs attention" \
       "Install Homebrew from https://brew.sh, then rerun tpod apply."
-    exit 1
+    exit_after_install_warning
   fi
   if ! NONINTERACTIVE=1 /bin/bash "$homebrew_installer"; then
     rm -f "$homebrew_installer"
@@ -201,7 +216,7 @@ if [ -z "$brew_bin" ]; then
       homebrew-core \
       "Homebrew core install needs attention" \
       "Install Homebrew from https://brew.sh, then rerun tpod apply."
-    exit 1
+    exit_after_install_warning
   fi
   rm -f "$homebrew_installer"
   brew_bin="$(find_brew || true)"
@@ -213,7 +228,7 @@ if [ -z "$brew_bin" ]; then
     homebrew-core \
     "Homebrew core install needs attention" \
     "Install Homebrew from https://brew.sh, then rerun tpod apply."
-  exit 1
+  exit_after_install_warning
 fi
 
 eval "$("$brew_bin" shellenv)"
@@ -230,7 +245,7 @@ if [ -f "$core_brewfile" ]; then
       homebrew-core \
       "Homebrew core install needs attention" \
       "Review Homebrew bundle output, fix package access, then rerun tpod apply."
-    exit 1
+    exit_after_install_warning
   fi
 fi
 
@@ -253,7 +268,8 @@ if [ -s "$desktop_brewfile" ]; then
     mark_install_warning \
       homebrew-desktop-apps \
       "Homebrew desktop app install needs attention" \
-      "$desktop_app_failure_guidance_text"
+      "$desktop_app_failure_guidance_text" ||
+      exit 1
     exit 0
   fi
 fi

--- a/.chezmoiscripts/run_onchange_before_00-bootstrap-ubuntu.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_00-bootstrap-ubuntu.sh.tmpl
@@ -8,14 +8,26 @@ if [ -f "$install_warnings_lib" ]; then
   . "$install_warnings_lib"
 fi
 
+INSTALL_WARNING_RECORDED=0
+
 mark_install_warning() {
   category="$1"
   summary="$2"
   guidance="$3"
+  INSTALL_WARNING_RECORDED=0
 
-  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ]; then
-    terrapod_install_warning_write "$category" "$summary" "$guidance" || true
+  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ] &&
+    terrapod_install_warning_write "$category" "$summary" "$guidance"; then
+    INSTALL_WARNING_RECORDED=1
   fi
+}
+
+exit_after_install_warning() {
+  if [ "${TERRAPOD_FIRST_RUN_APPLY:-}" = "1" ] && [ "$INSTALL_WARNING_RECORDED" -eq 1 ]; then
+    exit 0
+  fi
+
+  exit 1
 }
 
 clear_install_warning() {
@@ -35,7 +47,7 @@ if [ "$os_id" != "ubuntu" ] || [ "$version_id" != "24.04" ]; then
     ubuntu-bootstrap \
     "Ubuntu bootstrap needs attention" \
     "Run Terrapod on Ubuntu 24.04, or use tpod doctor for current platform guidance."
-  exit 1
+  exit_after_install_warning
 fi
 
 if [ "$(id -u)" -eq 0 ]; then
@@ -48,7 +60,7 @@ else
     ubuntu-bootstrap \
     "Ubuntu bootstrap needs attention" \
     "Install sudo or run as root, then rerun tpod apply."
-  exit 1
+  exit_after_install_warning
 fi
 
 export DEBIAN_FRONTEND=noninteractive
@@ -59,7 +71,7 @@ if ! $sudo_cmd apt-get update -y; then
     ubuntu-bootstrap \
     "Ubuntu bootstrap needs attention" \
     "Review APT update output, fix package repository access, then rerun tpod apply."
-  exit 1
+  exit_after_install_warning
 fi
 
 if ! $sudo_cmd apt-get install -y \
@@ -86,7 +98,7 @@ if ! $sudo_cmd apt-get install -y \
     ubuntu-bootstrap \
     "Ubuntu bootstrap needs attention" \
     "Review APT install output, fix package access, then rerun tpod apply."
-  exit 1
+  exit_after_install_warning
 fi
 
 if ! $sudo_cmd install -dm 755 /etc/apt/keyrings; then
@@ -94,21 +106,21 @@ if ! $sudo_cmd install -dm 755 /etc/apt/keyrings; then
     ubuntu-bootstrap \
     "Ubuntu bootstrap needs attention" \
     "Check APT keyring permissions, then rerun tpod apply."
-  exit 1
+  exit_after_install_warning
 fi
 if ! curl -fSs https://mise.en.dev/gpg-key.pub | $sudo_cmd tee /etc/apt/keyrings/mise-archive-keyring.asc >/dev/null; then
   mark_install_warning \
     ubuntu-bootstrap \
     "Ubuntu bootstrap needs attention" \
     "Check network access to https://mise.en.dev, then rerun tpod apply."
-  exit 1
+  exit_after_install_warning
 fi
 if ! printf '%s\n' "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.asc] https://mise.en.dev/deb stable main" | $sudo_cmd tee /etc/apt/sources.list.d/mise.list >/dev/null; then
   mark_install_warning \
     ubuntu-bootstrap \
     "Ubuntu bootstrap needs attention" \
     "Check APT source list permissions, then rerun tpod apply."
-  exit 1
+  exit_after_install_warning
 fi
 charm_key_file="$(mktemp "${TMPDIR:-/tmp}/terrapod-charm-key.XXXXXX")"
 if ! curl -fsSL https://repo.charm.sh/apt/gpg.key -o "$charm_key_file"; then
@@ -118,7 +130,7 @@ if ! curl -fsSL https://repo.charm.sh/apt/gpg.key -o "$charm_key_file"; then
     "Ubuntu bootstrap needs attention" \
     "Check network access to https://repo.charm.sh, then rerun tpod apply."
   rm -f "$charm_key_file"
-  exit 1
+  exit_after_install_warning
 fi
 if ! $sudo_cmd gpg --dearmor --yes -o /etc/apt/keyrings/charm.gpg "$charm_key_file"; then
   echo "Failed to install the Charm APT signing key for gum. Check APT keyring permissions and rerun Terrapod apply." >&2
@@ -127,7 +139,7 @@ if ! $sudo_cmd gpg --dearmor --yes -o /etc/apt/keyrings/charm.gpg "$charm_key_fi
     "Ubuntu bootstrap needs attention" \
     "Check APT keyring permissions, then rerun tpod apply."
   rm -f "$charm_key_file"
-  exit 1
+  exit_after_install_warning
 fi
 rm -f "$charm_key_file"
 if ! printf '%s\n' "deb [signed-by=/etc/apt/keyrings/charm.gpg] https://repo.charm.sh/apt/ * *" | $sudo_cmd tee /etc/apt/sources.list.d/charm.list >/dev/null; then
@@ -135,7 +147,7 @@ if ! printf '%s\n' "deb [signed-by=/etc/apt/keyrings/charm.gpg] https://repo.cha
     ubuntu-bootstrap \
     "Ubuntu bootstrap needs attention" \
     "Check APT source list permissions, then rerun tpod apply."
-  exit 1
+  exit_after_install_warning
 fi
 
 if ! $sudo_cmd apt-get update -y; then
@@ -143,21 +155,21 @@ if ! $sudo_cmd apt-get update -y; then
     ubuntu-bootstrap \
     "Ubuntu bootstrap needs attention" \
     "Review APT update output after adding tool repositories, then rerun tpod apply."
-  exit 1
+  exit_after_install_warning
 fi
 if ! $sudo_cmd apt-get install -y mise; then
   mark_install_warning \
     ubuntu-bootstrap \
     "Ubuntu bootstrap needs attention" \
     "Review APT output for mise installation, then rerun tpod apply."
-  exit 1
+  exit_after_install_warning
 fi
 if ! $sudo_cmd apt-get install -y gum; then
   mark_install_warning \
     ubuntu-bootstrap \
     "Ubuntu bootstrap needs attention" \
     "Review APT output for gum installation, then rerun tpod apply."
-  exit 1
+  exit_after_install_warning
 fi
 
 target_user="$(id -un)"

--- a/.chezmoiscripts/run_onchange_before_30-install-shell-integrations.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_30-install-shell-integrations.sh.tmpl
@@ -8,14 +8,26 @@ if [ -f "$install_warnings_lib" ]; then
   . "$install_warnings_lib"
 fi
 
+INSTALL_WARNING_RECORDED=0
+
 mark_install_warning() {
   category="$1"
   summary="$2"
   guidance="$3"
+  INSTALL_WARNING_RECORDED=0
 
-  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ]; then
-    terrapod_install_warning_write "$category" "$summary" "$guidance" || true
+  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ] &&
+    terrapod_install_warning_write "$category" "$summary" "$guidance"; then
+    INSTALL_WARNING_RECORDED=1
   fi
+}
+
+exit_after_install_warning() {
+  if [ "${TERRAPOD_FIRST_RUN_APPLY:-}" = "1" ] && [ "$INSTALL_WARNING_RECORDED" -eq 1 ]; then
+    exit 0
+  fi
+
+  exit 1
 }
 
 clear_install_warning() {
@@ -56,7 +68,7 @@ setup_macos_brew() {
     shell-integrations \
     "Shell integration setup needs attention" \
     "Install Homebrew or fix brew on PATH, then rerun tpod apply."
-  exit 1
+  exit_after_install_warning
 }
 
 ensure_git() {
@@ -70,7 +82,7 @@ ensure_git() {
       shell-integrations \
       "Shell integration setup needs attention" \
       "Install git with Homebrew, then rerun tpod apply."
-    exit 1
+    exit_after_install_warning
   fi
 {{ else }}
   echo "git is required to install shell integrations." >&2
@@ -78,7 +90,7 @@ ensure_git() {
     shell-integrations \
     "Shell integration setup needs attention" \
     "Install git, then rerun tpod apply."
-  exit 1
+  exit_after_install_warning
 {{ end }}
 }
 
@@ -96,14 +108,14 @@ if [ ! -d "$HOME/.oh-my-zsh" ]; then
       shell-integrations \
       "Shell integration setup needs attention" \
       "Check network access to the Oh My Zsh installer, then rerun tpod apply."
-    exit 1
+    exit_after_install_warning
   fi
   if ! sh "$oh_my_zsh_installer" --unattended --keep-zshrc; then
     mark_install_warning \
       shell-integrations \
       "Shell integration setup needs attention" \
       "Review Oh My Zsh installer output, then rerun tpod apply."
-    exit 1
+    exit_after_install_warning
   fi
 fi
 
@@ -115,7 +127,7 @@ if [ ! -d "$HOME/.local/share/zinit/zinit.git" ]; then
       shell-integrations \
       "Shell integration setup needs attention" \
       "Review zinit git clone output, then rerun tpod apply."
-    exit 1
+    exit_after_install_warning
   fi
 fi
 
@@ -126,14 +138,14 @@ if [ ! -d "$HOME/.scm_breeze" ]; then
       shell-integrations \
       "Shell integration setup needs attention" \
       "Review SCM Breeze git clone output, then rerun tpod apply."
-    exit 1
+    exit_after_install_warning
   fi
   if ! "$HOME/.scm_breeze/install.sh"; then
     mark_install_warning \
       shell-integrations \
       "Shell integration setup needs attention" \
       "Review SCM Breeze installer output, then rerun tpod apply."
-    exit 1
+    exit_after_install_warning
   fi
 fi
 

--- a/.chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl
@@ -70,6 +70,9 @@ finish_ai_cli_installers() {
       echo "Failed to record Optional AI CLI tool install warning for failed command(s): $failed_tools." >&2
       return 1
     fi
+    if [ "${TERRAPOD_FIRST_RUN_APPLY:-}" = "1" ]; then
+      return 0
+    fi
     return 1
   else
     clear_install_warning "$AI_CLI_WARNING_CATEGORY"

--- a/docs/superpowers/plans/2026-06-05-first-run-warning-completion.md
+++ b/docs/superpowers/plans/2026-06-05-first-run-warning-completion.md
@@ -1,0 +1,605 @@
+# First-Run Warning Completion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Make first-run installation complete cleanly or with explicit marker-backed warning completion after the recovery core is valid.
+
+**Architecture:** Keep recovery-core installation and validation as the hard boundary. Run the full declared-state apply with a first-run-only environment flag so known non-blocking installer scripts can record Terrapod install-warning markers and exit 0, allowing chezmoi to continue. Snapshot markers before the full apply and print warning completion only when the full apply succeeds and a marker is newly written or updated; any aggregate non-zero full apply remains a hard failure so unknown chezmoi/template/managed-file failures cannot be masked by an unrelated marker.
+
+**Tech Stack:** POSIX `sh`, chezmoi apply stubs, Terrapod install-warning marker helper, shell test scripts.
+
+---
+
+## Scope And Assumptions
+
+- Issue: GitHub Issue #100, "First-run warning completion and final output".
+- Blockers #96, #98, and #99 are closed.
+- Do not change routine `tpod apply` failure semantics; the marker-and-success behavior is gated by `TERRAPOD_FIRST_RUN_APPLY=1`.
+- Recovery-core failures remain hard failures.
+- Full apply output must not be captured or hidden; marker files store summary/guidance only.
+- A pre-existing unchanged marker must not produce warning completion.
+- Marker writes must carry a per-write freshness field so same-second rewrites of the same category/summary/guidance are still classified as changed.
+- If `chezmoi apply` returns non-zero, `install.sh` treats it as hard failure even if some marker changed earlier in the same apply. This avoids hiding mixed failures; known first-run non-blocking installers must record a marker and exit 0.
+
+## File Structure
+
+- Modify: `install.sh`
+  - Add install-warning snapshot/read helpers near existing marker helper functions.
+  - Run full apply with `TERRAPOD_FIRST_RUN_APPLY=1`.
+  - Return clean vs warning status based on marker changes after successful full apply.
+  - Add final output helpers for `tpod` availability, clean completion, and warning completion.
+- Modify: `dot_local/lib/terrapod/install-warnings.sh`
+  - Add a per-write marker freshness field used by snapshot comparison.
+- Modify: `.chezmoiscripts/run_onchange_before_00-bootstrap-homebrew.sh.tmpl`
+  - Gate warning-marker failures to exit 0 only during first-run full apply.
+- Modify: `.chezmoiscripts/run_before_01-retry-homebrew-desktop-apps.sh.tmpl`
+  - Keep desktop app warning retries non-blocking only when marker writes succeed.
+- Modify: `.chezmoiscripts/run_onchange_before_00-bootstrap-ubuntu.sh.tmpl`
+  - Same first-run marker-and-success contract for `ubuntu-bootstrap`.
+- Modify: `.chezmoiscripts/run_onchange_before_30-install-shell-integrations.sh.tmpl`
+  - Same first-run marker-and-success contract for `shell-integrations`.
+- Modify: `.chezmoiscripts/run_onchange_after_20-install-mise-tools.sh.tmpl`
+  - Same first-run marker-and-success contract for `mise-tools`.
+- Modify: `.chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl`
+  - Same first-run marker-and-success contract for `optional-ai-cli-tools`.
+- Modify: `tests/terrapod_installer_test.sh`
+  - Extend fake source checkouts and full apply stub knobs.
+  - Add first-run clean/warning/hard-failure/stale-marker/same-second rewrite output tests.
+- Modify: relevant rendered script tests as needed:
+  - `tests/chezmoiignore_test.sh`
+  - `tests/bootstrap_ubuntu_test.sh`
+  - `tests/shell_integrations_test.sh`
+- Create: `docs/superpowers/plans/2026-06-05-first-run-warning-completion.md`
+  - This plan.
+
+---
+
+### Task 1: Add First-Run Installer Regression Tests
+
+**Files:**
+- Modify: `tests/terrapod_installer_test.sh`
+
+- [x] **Step 1: Make fake source checkouts include the warning helper**
+
+Near `repo_root`, export the helper path:
+
+```sh
+install_warnings_lib_template="$repo_root/dot_local/lib/terrapod/install-warnings.sh"
+export TERRAPOD_INSTALL_WARNINGS_LIB_TEMPLATE="$install_warnings_lib_template"
+```
+
+In `write_chezmoi_flow_stub`, after fake `init` writes `dot_local/bin/executable_terrapod`, copy the helper into the fake source checkout when the template path exists:
+
+```sh
+    if [ -f "${TERRAPOD_INSTALL_WARNINGS_LIB_TEMPLATE:-}" ]; then
+      mkdir -p "$source_dir/dot_local/lib/terrapod"
+      cp "$TERRAPOD_INSTALL_WARNINGS_LIB_TEMPLATE" "$source_dir/dot_local/lib/terrapod/install-warnings.sh"
+    fi
+```
+
+In `write_terrapod_source_checkout`, always copy the real helper:
+
+```sh
+  mkdir -p "$source_dir/dot_local/lib/terrapod"
+  cp "$repo_root/dot_local/lib/terrapod/install-warnings.sh" "$source_dir/dot_local/lib/terrapod/install-warnings.sh"
+```
+
+- [x] **Step 2: Add full apply stub controls**
+
+Inside the non-`--force` `apply)` branch of `write_chezmoi_flow_stub`, before writing the installed command stub, add:
+
+```sh
+    if [ -n "${TERRAPOD_CHEZMOI_APPLY_STUB_STDOUT:-}" ]; then
+      printf '%s\n' "$TERRAPOD_CHEZMOI_APPLY_STUB_STDOUT"
+    fi
+    if [ -n "${TERRAPOD_CHEZMOI_APPLY_STUB_STDERR:-}" ]; then
+      printf '%s\n' "$TERRAPOD_CHEZMOI_APPLY_STUB_STDERR" >&2
+    fi
+    if [ -n "${TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_CATEGORY:-}" ] && [ -f "${TERRAPOD_INSTALL_WARNINGS_LIB_TEMPLATE:-}" ]; then
+      . "$TERRAPOD_INSTALL_WARNINGS_LIB_TEMPLATE"
+      terrapod_install_warning_write \
+        "$TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_CATEGORY" \
+        "${TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_SUMMARY:-mise tool install needs attention}" \
+        "${TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_GUIDANCE:-Run tpod apply after fixing installer output.}"
+    fi
+    apply_status="${TERRAPOD_CHEZMOI_APPLY_STUB_STATUS:-0}"
+    if [ "$apply_status" != "0" ]; then
+      exit "$apply_status"
+    fi
+```
+
+- [x] **Step 3: Add clean first-run output assertions**
+
+In the existing `first_run_case` block, assert recovery-core ordering and clean final output:
+
+```sh
+assert_first_occurrence_before "$first_run_log_text" "terrapod path:$first_run_case/home/.local/bin/tpod" "chezmoi args:apply --force" "first-run validates recovery-core command surface before shell startup recovery apply"
+assert_first_occurrence_before "$first_run_log_text" "chezmoi args:apply --force" "tpod args:help" "first-run applies recovery-core shell startup files before final help"
+assert_contains "$first_run_stdout" "Terrapod command availability:" "clean first-run explains tpod availability"
+assert_contains "$first_run_stdout" "Use this absolute command now: $first_run_case/home/.local/bin/tpod" "clean first-run prints absolute tpod command"
+assert_contains "$first_run_stdout" "Open a new terminal or refresh your login shell before relying on plain 'tpod'." "clean first-run explains shell refresh guidance"
+assert_not_contains "$first_run_stdout" "$first_run_case/home/.local/bin/tpod doctor" "clean first-run does not print doctor recovery guidance"
+```
+
+- [x] **Step 4: Add marker-backed warning completion test**
+
+Add a resume case where full apply succeeds while writing a marker and emitting visible output:
+
+```sh
+warning_completion_case="$(make_case_dir warning-completion)"
+prepare_resumable_macos_case "$warning_completion_case"
+write_complete_setup_config "$warning_completion_case/xdg-config/chezmoi/chezmoi.toml"
+warning_completion_log="$warning_completion_case/command-calls"
+TERRAPOD_STUB_CALL_LOG="$warning_completion_log"
+TERRAPOD_CHEZMOI_APPLY_STUB_STDERR="simulated mise install failure"
+TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_CATEGORY=mise-tools
+TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_SUMMARY="mise tool install needs attention"
+TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_GUIDANCE="Review mise output, then rerun tpod apply."
+export TERRAPOD_STUB_CALL_LOG
+export TERRAPOD_CHEZMOI_APPLY_STUB_STDERR
+export TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_CATEGORY
+export TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_SUMMARY
+export TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_GUIDANCE
+run_installer_case "$warning_completion_case"
+unset TERRAPOD_STUB_CALL_LOG
+unset TERRAPOD_CHEZMOI_APPLY_STUB_STDERR
+unset TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_CATEGORY
+unset TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_SUMMARY
+unset TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_GUIDANCE
+assert_status "$installer_status" 0 "marker-backed full apply warning completes with installer status 0"
+warning_completion_stdout="$(cat "$warning_completion_case/stdout")"
+warning_completion_stderr="$(cat "$warning_completion_case/stderr")"
+assert_contains "$warning_completion_stderr" "simulated mise install failure" "warning completion preserves full apply output"
+assert_contains "$warning_completion_stdout" "Terrapod - a small landing pod for your dotfiles" "warning completion still prints tpod help"
+assert_contains "$warning_completion_stdout" "Terrapod first-run apply completed with warnings." "warning completion prints distinct final status"
+assert_contains "$warning_completion_stdout" "$warning_completion_case/home/.local/bin/tpod doctor" "warning completion prints absolute doctor recovery command"
+```
+
+- [x] **Step 5: Add unknown full apply hard failure test**
+
+Add a resume case with non-zero full apply and no marker:
+
+```sh
+unknown_apply_failure_case="$(make_case_dir unknown-apply-failure)"
+prepare_resumable_macos_case "$unknown_apply_failure_case"
+write_complete_setup_config "$unknown_apply_failure_case/xdg-config/chezmoi/chezmoi.toml"
+unknown_apply_failure_log="$unknown_apply_failure_case/command-calls"
+TERRAPOD_STUB_CALL_LOG="$unknown_apply_failure_log"
+TERRAPOD_CHEZMOI_APPLY_STUB_STATUS=43
+TERRAPOD_CHEZMOI_APPLY_STUB_STDERR="simulated template rendering failure"
+export TERRAPOD_STUB_CALL_LOG
+export TERRAPOD_CHEZMOI_APPLY_STUB_STATUS
+export TERRAPOD_CHEZMOI_APPLY_STUB_STDERR
+run_installer_case "$unknown_apply_failure_case"
+unset TERRAPOD_STUB_CALL_LOG
+unset TERRAPOD_CHEZMOI_APPLY_STUB_STATUS
+unset TERRAPOD_CHEZMOI_APPLY_STUB_STDERR
+assert_failure "$installer_status" "unknown full apply failure remains hard"
+unknown_apply_failure_stdout="$(cat "$unknown_apply_failure_case/stdout")"
+unknown_apply_failure_stderr="$(cat "$unknown_apply_failure_case/stderr")"
+assert_contains "$unknown_apply_failure_stderr" "simulated template rendering failure" "unknown full apply failure preserves apply output"
+assert_contains "$unknown_apply_failure_stderr" "terrapod installer: chezmoi apply failed" "unknown full apply failure keeps hard failure guidance"
+assert_not_contains "$unknown_apply_failure_stdout" "completed with warnings" "unknown full apply failure does not print warning completion"
+```
+
+- [x] **Step 6: Add mixed marker plus non-zero hard failure test**
+
+Add a resume case where the stub writes a marker and still exits non-zero:
+
+```sh
+mixed_apply_failure_case="$(make_case_dir mixed-apply-failure)"
+prepare_resumable_macos_case "$mixed_apply_failure_case"
+write_complete_setup_config "$mixed_apply_failure_case/xdg-config/chezmoi/chezmoi.toml"
+mixed_apply_failure_log="$mixed_apply_failure_case/command-calls"
+TERRAPOD_STUB_CALL_LOG="$mixed_apply_failure_log"
+TERRAPOD_CHEZMOI_APPLY_STUB_STATUS=45
+TERRAPOD_CHEZMOI_APPLY_STUB_STDERR="simulated managed-file failure after marker"
+TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_CATEGORY=mise-tools
+export TERRAPOD_STUB_CALL_LOG
+export TERRAPOD_CHEZMOI_APPLY_STUB_STATUS
+export TERRAPOD_CHEZMOI_APPLY_STUB_STDERR
+export TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_CATEGORY
+run_installer_case "$mixed_apply_failure_case"
+unset TERRAPOD_STUB_CALL_LOG
+unset TERRAPOD_CHEZMOI_APPLY_STUB_STATUS
+unset TERRAPOD_CHEZMOI_APPLY_STUB_STDERR
+unset TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_CATEGORY
+assert_failure "$installer_status" "non-zero full apply remains hard even when an unrelated marker changed"
+mixed_apply_failure_stdout="$(cat "$mixed_apply_failure_case/stdout")"
+mixed_apply_failure_stderr="$(cat "$mixed_apply_failure_case/stderr")"
+assert_contains "$mixed_apply_failure_stderr" "simulated managed-file failure after marker" "mixed full apply failure preserves output"
+assert_not_contains "$mixed_apply_failure_stdout" "completed with warnings" "mixed full apply failure does not print warning completion"
+```
+
+- [x] **Step 7: Add stale marker clean success test**
+
+Create a marker before a successful full apply and assert clean completion:
+
+```sh
+stale_marker_success_case="$(make_case_dir stale-marker-success)"
+prepare_resumable_macos_case "$stale_marker_success_case"
+write_complete_setup_config "$stale_marker_success_case/xdg-config/chezmoi/chezmoi.toml"
+HOME="$stale_marker_success_case/home" sh -c \
+  '. "$1"; terrapod_install_warning_write mise-tools "stale warning" "stale guidance"' \
+  sh "$install_warnings_lib_template"
+stale_marker_success_log="$stale_marker_success_case/command-calls"
+TERRAPOD_STUB_CALL_LOG="$stale_marker_success_log"
+export TERRAPOD_STUB_CALL_LOG
+run_installer_case "$stale_marker_success_case"
+unset TERRAPOD_STUB_CALL_LOG
+assert_status "$installer_status" 0 "unchanged stale marker does not prevent clean first-run completion"
+stale_marker_success_stdout="$(cat "$stale_marker_success_case/stdout")"
+assert_contains "$stale_marker_success_stdout" "Terrapod first-run apply complete." "stale marker success keeps clean completion"
+assert_not_contains "$stale_marker_success_stdout" "$stale_marker_success_case/home/.local/bin/tpod doctor" "stale marker success does not print doctor recovery guidance"
+```
+
+- [x] **Step 8: Run tests and verify they fail before implementation**
+
+Run: `sh tests/terrapod_installer_test.sh`
+
+Expected: FAIL on new output/classification assertions before `install.sh` changes.
+
+---
+
+### Task 2: Add First-Run Marker-And-Success Contract To Known Scripts
+
+**Files:**
+- Modify: `.chezmoiscripts/run_onchange_before_00-bootstrap-homebrew.sh.tmpl`
+- Modify: `.chezmoiscripts/run_onchange_before_00-bootstrap-ubuntu.sh.tmpl`
+- Modify: `.chezmoiscripts/run_onchange_before_30-install-shell-integrations.sh.tmpl`
+- Modify: `.chezmoiscripts/run_onchange_after_20-install-mise-tools.sh.tmpl`
+- Modify: `.chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl`
+- Modify: `.chezmoiscripts/run_before_01-retry-homebrew-desktop-apps.sh.tmpl`
+- Modify tests as needed: `tests/chezmoiignore_test.sh`, `tests/bootstrap_ubuntu_test.sh`, `tests/shell_integrations_test.sh`
+
+- [x] **Step 1: Add a shared local pattern to each known warning script**
+
+In each script except the AI CLI script, make `mark_install_warning` set a local success flag and add an exit helper:
+
+```sh
+INSTALL_WARNING_RECORDED=0
+
+mark_install_warning() {
+  category="$1"
+  summary="$2"
+  guidance="$3"
+  INSTALL_WARNING_RECORDED=0
+
+  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ] &&
+    terrapod_install_warning_write "$category" "$summary" "$guidance"; then
+    INSTALL_WARNING_RECORDED=1
+    return 0
+  fi
+
+  return 1
+}
+
+exit_after_install_warning() {
+  if [ "${TERRAPOD_FIRST_RUN_APPLY:-}" = "1" ] && [ "$INSTALL_WARNING_RECORDED" -eq 1 ]; then
+    exit 0
+  fi
+
+  exit 1
+}
+```
+
+Keep `clear_install_warning` unchanged.
+
+- [x] **Step 2: Replace warning exits in known scripts**
+
+For every `mark_install_warning ...; exit 1` block in the known scripts, replace `exit 1` with:
+
+```sh
+    exit_after_install_warning
+```
+
+Preserve any cleanup that already happens before the warning marker is recorded.
+
+- [x] **Step 3: Adjust Optional AI CLI finish path**
+
+In `run_onchange_before_60-install-ai-cli-tools.sh.tmpl`, keep `mark_install_warning` returning write status and change the failed-tools branch:
+
+```sh
+    if [ "${TERRAPOD_FIRST_RUN_APPLY:-}" = "1" ]; then
+      return 0
+    fi
+    return 1
+```
+
+only after `mark_install_warning` succeeds.
+
+- [x] **Step 4: Add or update rendered script tests**
+
+Keep existing routine tests expecting non-zero failures without `TERRAPOD_FIRST_RUN_APPLY`.
+
+Add targeted first-run assertions:
+
+```sh
+TERRAPOD_FIRST_RUN_APPLY=1 sh "$rendered"
+```
+
+Expected for simulated known category failures: exit 0 and marker file exists.
+
+Use the narrowest existing rendered-script tests:
+
+- `tests/shell_integrations_test.sh`: Oh My Zsh download failure exits 0 with `TERRAPOD_FIRST_RUN_APPLY=1`.
+- `tests/bootstrap_ubuntu_test.sh`: Charm signing key download failure exits 0 with `TERRAPOD_FIRST_RUN_APPLY=1`.
+- `tests/chezmoiignore_test.sh`: Homebrew installer failure and Optional AI CLI partial failure exit 0 with `TERRAPOD_FIRST_RUN_APPLY=1`.
+- `tests/chezmoiignore_test.sh`: Homebrew desktop app warning failures block when marker writes fail.
+
+- [x] **Step 5: Run targeted rendered script tests**
+
+Run:
+
+```bash
+sh tests/shell_integrations_test.sh
+sh tests/bootstrap_ubuntu_test.sh
+sh tests/chezmoiignore_test.sh
+```
+
+Expected: PASS.
+
+---
+
+### Task 3: Implement First-Run Warning Completion In `install.sh`
+
+**Files:**
+- Modify: `install.sh`
+
+- [x] **Step 1: Add marker snapshot helpers**
+
+Near `clear_install_warning_from_source`, add:
+
+```sh
+load_install_warnings_from_source() {
+  source_dir="$1"
+  install_warnings_lib="$source_dir/dot_local/lib/terrapod/install-warnings.sh"
+  TERRAPOD_INSTALL_WARNINGS_LOADED=
+
+  if [ -f "$install_warnings_lib" ]; then
+    . "$install_warnings_lib"
+  fi
+
+  [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ]
+}
+
+snapshot_install_warnings_from_source() {
+  source_dir="$1"
+  snapshot_dir="$2"
+
+  mkdir -p "$snapshot_dir" || return 1
+  load_install_warnings_from_source "$source_dir" || return 0
+
+  for category in $(terrapod_install_warning_categories); do
+    terrapod_install_warning_read "$category" >"$snapshot_dir/$category" 2>/dev/null || true
+  done
+}
+
+install_warning_markers_changed_since_snapshot() {
+  source_dir="$1"
+  snapshot_dir="$2"
+  changed=false
+
+  load_install_warnings_from_source "$source_dir" || return 1
+
+  for category in $(terrapod_install_warning_categories); do
+    current_file="$snapshot_dir/current-$category"
+    if terrapod_install_warning_read "$category" >"$current_file" 2>/dev/null; then
+      if [ ! -f "$snapshot_dir/$category" ] || ! cmp -s "$snapshot_dir/$category" "$current_file"; then
+        changed=true
+      fi
+    fi
+    rm -f "$current_file"
+  done
+
+  [ "$changed" = "true" ]
+}
+```
+
+- [x] **Step 2: Change `run_initial_apply` status contract**
+
+Replace the current hard-fail-only function with:
+
+```sh
+run_initial_apply() {
+  chezmoi_bin="$1"
+  source_dir="$2"
+  marker_snapshot_dir="$(mktemp -d)" ||
+    fatal "failed to create install-warning snapshot directory"
+
+  snapshot_install_warnings_from_source "$source_dir" "$marker_snapshot_dir" ||
+    fatal "failed to snapshot install warning markers"
+
+  if ! TERRAPOD_FIRST_RUN_APPLY=1 "$chezmoi_bin" apply; then
+    rm -rf "$marker_snapshot_dir"
+    fatal "chezmoi apply failed"
+  fi
+
+  if install_warning_markers_changed_since_snapshot "$source_dir" "$marker_snapshot_dir"; then
+    rm -rf "$marker_snapshot_dir"
+    return 2
+  fi
+
+  rm -rf "$marker_snapshot_dir"
+  return 0
+}
+```
+
+- [x] **Step 3: Add final output helpers**
+
+Near `show_first_run_help`, add:
+
+```sh
+print_first_run_tpod_availability() {
+  local_bin_dir="$1"
+
+  printf '\n'
+  printf '%s\n' "Terrapod command availability:"
+  printf '%s\n' "  If this shell has not reloaded Terrapod's managed PATH yet, plain 'tpod' may not resolve."
+  printf '%s\n' "  Use this absolute command now: $local_bin_dir/tpod"
+  printf '%s\n' "  Open a new terminal or refresh your login shell before relying on plain 'tpod'."
+}
+
+print_first_run_clean_completion() {
+  printf '\n'
+  printf '%s\n' "Terrapod first-run apply complete."
+}
+
+print_first_run_warning_completion() {
+  local_bin_dir="$1"
+
+  printf '\n'
+  printf '%s\n' "Terrapod first-run apply completed with warnings."
+  printf '%s\n' "Warning:"
+  printf '%s\n' "  Terrapod installed and the recovery core is valid, but machine profile readiness needs attention."
+  printf '%s\n' "  Review the full apply output above, then run:"
+  printf '%s\n' "  $local_bin_dir/tpod doctor"
+}
+```
+
+- [x] **Step 4: Wire `main` to use clean vs warning completion**
+
+Replace:
+
+```sh
+  run_initial_apply "$chezmoi_bin"
+  show_first_run_help "$profile" "$local_bin_dir"
+
+  printf '%s\n' "Terrapod first-run apply complete."
+```
+
+with:
+
+```sh
+  initial_apply_status=0
+  run_initial_apply "$chezmoi_bin" "$source_dir" || initial_apply_status="$?"
+  show_first_run_help "$profile" "$local_bin_dir"
+  print_first_run_tpod_availability "$local_bin_dir"
+
+  case "$initial_apply_status" in
+    0)
+      print_first_run_clean_completion
+      ;;
+    2)
+      print_first_run_warning_completion "$local_bin_dir"
+      ;;
+    *)
+      fatal "unexpected initial apply status: $initial_apply_status"
+      ;;
+  esac
+```
+
+- [x] **Step 5: Run targeted installer test**
+
+Run: `sh tests/terrapod_installer_test.sh`
+
+Expected: PASS.
+
+---
+
+### Task 4: Full Verification
+
+**Files:**
+- No new files unless a verification failure requires a fix.
+
+- [x] **Step 1: Run shell syntax checks**
+
+Run:
+
+```bash
+sh -n install.sh
+sh -n dot_local/bin/executable_terrapod
+sh -n dot_local/lib/terrapod/install-warnings.sh
+```
+
+Expected: all exit 0.
+
+- [x] **Step 2: Run targeted tests**
+
+Run:
+
+```bash
+sh tests/terrapod_installer_test.sh
+sh tests/terrapod_command_test.sh
+sh tests/shell_integrations_test.sh
+sh tests/bootstrap_ubuntu_test.sh
+sh tests/chezmoiignore_test.sh
+```
+
+Expected: PASS.
+
+- [x] **Step 3: Run full shell test suite**
+
+Run:
+
+```bash
+for test_file in tests/*_test.sh; do sh "$test_file"; done
+```
+
+Expected: PASS for every test file.
+
+- [x] **Step 4: Review diff for scope**
+
+Run:
+
+```bash
+git diff --stat
+git diff -- install.sh .chezmoiscripts tests docs/superpowers/plans/2026-06-05-first-run-warning-completion.md
+```
+
+Expected: only Issue #100-related changes.
+
+---
+
+### Task 5: Commit And Publish Ready PR
+
+**Files:**
+- No source changes expected.
+
+- [x] **Step 1: Commit intentionally**
+
+After all tests pass:
+
+```bash
+git add install.sh .chezmoiscripts tests docs/superpowers/plans/2026-06-05-first-run-warning-completion.md
+git commit -m "fix: add first-run warning completion"
+```
+
+- [x] **Step 2: Push branch**
+
+Run:
+
+```bash
+git push -u origin feat/issue-100-first-run-warning-completion
+```
+
+Expected: branch pushed.
+
+- [x] **Step 3: Create Ready for review PR**
+
+Use GitHub tooling with base branch from the remote default branch. PR title:
+
+```text
+First-run warning completion and final output
+```
+
+PR body:
+
+```markdown
+## Summary
+- validates recovery core before full first-run apply warning classification
+- adds first-run marker-backed warning completion with absolute doctor guidance
+- keeps unknown aggregate full apply failures hard and adds tpod availability guidance
+
+## Test Plan
+- [x] sh tests/terrapod_installer_test.sh
+- [x] sh tests/terrapod_command_test.sh
+- [x] sh tests/shell_integrations_test.sh
+- [x] sh tests/bootstrap_ubuntu_test.sh
+- [x] sh tests/chezmoiignore_test.sh
+- [x] for test_file in tests/*_test.sh; do sh "$test_file"; done
+
+Closes #100
+```
+
+Expected: PR is not draft and is ready for review.

--- a/dot_local/lib/terrapod/install-warnings.sh
+++ b/dot_local/lib/terrapod/install-warnings.sh
@@ -121,11 +121,13 @@ terrapod_install_warning_write() {
   mkdir -p "$marker_dir" || return 1
 
   tmp_file="$(mktemp "$marker_dir/.$category.XXXXXX")" || return 1
+  write_id="$$:${tmp_file##*/}"
   {
     printf 'category=%s\n' "$(terrapod_install_warning_quote "$category")"
     printf 'summary=%s\n' "$(terrapod_install_warning_quote "$summary")"
     printf 'guidance=%s\n' "$(terrapod_install_warning_quote "$guidance")"
     printf 'updated_at=%s\n' "$(terrapod_install_warning_quote "$(terrapod_install_warning_now)")"
+    printf 'write_id=%s\n' "$(terrapod_install_warning_quote "$write_id")"
   } >"$tmp_file" || {
     rm -f "$tmp_file"
     return 1

--- a/install.sh
+++ b/install.sh
@@ -964,6 +964,50 @@ clear_install_warning_from_source() {
   fi
 }
 
+load_install_warnings_from_source() {
+  source_dir="$1"
+  install_warnings_lib="$source_dir/dot_local/lib/terrapod/install-warnings.sh"
+  TERRAPOD_INSTALL_WARNINGS_LOADED=
+
+  if [ -f "$install_warnings_lib" ]; then
+    . "$install_warnings_lib"
+  fi
+
+  [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ]
+}
+
+snapshot_install_warnings_from_source() {
+  source_dir="$1"
+  snapshot_dir="$2"
+
+  mkdir -p "$snapshot_dir" || return 1
+  load_install_warnings_from_source "$source_dir" || return 0
+
+  for category in $(terrapod_install_warning_categories); do
+    terrapod_install_warning_read "$category" >"$snapshot_dir/$category" 2>/dev/null || true
+  done
+}
+
+install_warning_markers_changed_since_snapshot() {
+  source_dir="$1"
+  snapshot_dir="$2"
+  changed=false
+
+  load_install_warnings_from_source "$source_dir" || return 1
+
+  for category in $(terrapod_install_warning_categories); do
+    current_file="$snapshot_dir/current-$category"
+    if terrapod_install_warning_read "$category" >"$current_file" 2>/dev/null; then
+      if [ ! -f "$snapshot_dir/$category" ] || ! cmp -s "$snapshot_dir/$category" "$current_file"; then
+        changed=true
+      fi
+    fi
+    rm -f "$current_file"
+  done
+
+  [ "$changed" = "true" ]
+}
+
 print_setup_ui_dependency_recovery() {
   profile="$1"
   source_dir="$2"
@@ -1216,8 +1260,25 @@ apply_recovery_core_shell_startup_files() {
 
 run_initial_apply() {
   chezmoi_bin="$1"
+  source_dir="$2"
+  marker_snapshot_dir="$(mktemp -d)" ||
+    fatal "failed to create install-warning snapshot directory"
 
-  "$chezmoi_bin" apply || fatal "chezmoi apply failed"
+  snapshot_install_warnings_from_source "$source_dir" "$marker_snapshot_dir" ||
+    fatal "failed to snapshot install warning markers"
+
+  if ! TERRAPOD_FIRST_RUN_APPLY=1 "$chezmoi_bin" apply; then
+    rm -rf "$marker_snapshot_dir"
+    fatal "chezmoi apply failed"
+  fi
+
+  if install_warning_markers_changed_since_snapshot "$source_dir" "$marker_snapshot_dir"; then
+    rm -rf "$marker_snapshot_dir"
+    return 2
+  fi
+
+  rm -rf "$marker_snapshot_dir"
+  return 0
 }
 
 show_first_run_help() {
@@ -1230,6 +1291,32 @@ show_first_run_help() {
   fi
 
   TERRAPOD_PROFILE="$profile" "$tpod_bin" help || fatal "tpod help failed after initial apply"
+}
+
+print_first_run_tpod_availability() {
+  local_bin_dir="$1"
+
+  printf '\n'
+  printf '%s\n' "Terrapod command availability:"
+  printf '%s\n' "  If this shell has not reloaded Terrapod's managed PATH yet, plain 'tpod' may not resolve."
+  printf '%s\n' "  Use this absolute command now: $local_bin_dir/tpod"
+  printf '%s\n' "  Open a new terminal or refresh your login shell before relying on plain 'tpod'."
+}
+
+print_first_run_clean_completion() {
+  printf '\n'
+  printf '%s\n' "Terrapod first-run apply complete."
+}
+
+print_first_run_warning_completion() {
+  local_bin_dir="$1"
+
+  printf '\n'
+  printf '%s\n' "Terrapod first-run apply completed with warnings."
+  printf '%s\n' "Warning:"
+  printf '%s\n' "  Terrapod installed and the recovery core is valid, but machine profile readiness needs attention."
+  printf '%s\n' "  Review the full apply output above, then run:"
+  printf '%s\n' "  $local_bin_dir/tpod doctor"
 }
 
 main() {
@@ -1264,10 +1351,22 @@ main() {
   ensure_first_run_setup "$profile" "$source_dir" "$chezmoi_bin"
   apply_recovery_core_command_surface "$profile" "$source_dir" "$local_bin_dir"
   apply_recovery_core_shell_startup_files "$profile" "$chezmoi_bin"
-  run_initial_apply "$chezmoi_bin"
+  initial_apply_status=0
+  run_initial_apply "$chezmoi_bin" "$source_dir" || initial_apply_status="$?"
   show_first_run_help "$profile" "$local_bin_dir"
+  print_first_run_tpod_availability "$local_bin_dir"
 
-  printf '%s\n' "Terrapod first-run apply complete."
+  case "$initial_apply_status" in
+    0)
+      print_first_run_clean_completion
+      ;;
+    2)
+      print_first_run_warning_completion "$local_bin_dir"
+      ;;
+    *)
+      fatal "unexpected initial apply status: $initial_apply_status"
+      ;;
+  esac
 }
 
 main "$@"

--- a/tests/bootstrap_ubuntu_test.sh
+++ b/tests/bootstrap_ubuntu_test.sh
@@ -217,3 +217,18 @@ bootstrap_curl_failure_log="$(cat "$BOOTSTRAP_TEST_LOG")"
 assert_contains "$bootstrap_curl_failure_log" "curl args:-fsSL https://repo.charm.sh/apt/gpg.key -o " "Ubuntu bootstrap Charm key failure attempts to fetch the signing key"
 assert_not_contains "$bootstrap_curl_failure_log" "apt-get args:install -y gum" "Ubuntu bootstrap Charm key failure stops before installing gum"
 pass "Ubuntu bootstrap fails when the Charm signing key download fails"
+
+rm -f "$ubuntu_bootstrap_marker"
+: >"$BOOTSTRAP_TEST_LOG"
+BOOTSTRAP_CHARM_KEY_CURL_STATUS=17
+export BOOTSTRAP_CHARM_KEY_CURL_STATUS
+if ! TERRAPOD_FIRST_RUN_APPLY=1 sh "$rendered" >"$tmp_dir/bootstrap-first-run-curl-failure.out" 2>"$tmp_dir/bootstrap-first-run-curl-failure.err"; then
+  unset BOOTSTRAP_CHARM_KEY_CURL_STATUS
+  fail "first-run Ubuntu bootstrap should continue when the Charm signing key download warning is recorded"
+fi
+unset BOOTSTRAP_CHARM_KEY_CURL_STATUS
+
+if [ ! -f "$ubuntu_bootstrap_marker" ]; then
+  fail "first-run Ubuntu bootstrap should record a warning marker when the Charm signing key download fails"
+fi
+pass "first-run Ubuntu bootstrap records a warning marker when the Charm signing key download fails"

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -397,6 +397,22 @@ homebrew_installer_failure_marker_text="$(cat "$homebrew_installer_failure_marke
 assert_contains_text "$homebrew_installer_failure_marker_text" "summary='Homebrew core install needs attention'" "macOS bootstrap Homebrew installer failure marker keeps the expected summary"
 assert_contains_text "$homebrew_installer_failure_marker_text" "guidance='Install Homebrew from https://brew.sh, then rerun tpod apply.'" "macOS bootstrap Homebrew installer failure marker keeps recovery guidance"
 
+homebrew_first_run_failure_state="$tmp_dir/homebrew-first-run-failure-state"
+homebrew_first_run_failure_home="$tmp_dir/homebrew-first-run-failure-home"
+homebrew_first_run_failure_log="$tmp_dir/homebrew-first-run-failure.log"
+mkdir -p "$homebrew_first_run_failure_home"
+
+if ! HOME="$homebrew_first_run_failure_home" XDG_STATE_HOME="$homebrew_first_run_failure_state" HOMEBREW_INSTALLER_FAILURE_LOG="$homebrew_first_run_failure_log" PATH="$homebrew_installer_failure_bin:/usr/bin:/bin" \
+  TERRAPOD_FIRST_RUN_APPLY=1 sh "$homebrew_installer_failure_script" >"$tmp_dir/homebrew-first-run-failure.out" 2>"$tmp_dir/homebrew-first-run-failure.err"; then
+  fail "first-run macOS bootstrap continues when the Homebrew installer warning is recorded"
+fi
+
+homebrew_first_run_failure_marker="$homebrew_first_run_failure_state/terrapod/install-warnings/homebrew-core"
+if [ ! -f "$homebrew_first_run_failure_marker" ]; then
+  fail "first-run macOS bootstrap records homebrew-core marker when the Homebrew installer command fails"
+fi
+pass "first-run macOS bootstrap records homebrew-core marker when the Homebrew installer command fails"
+
 assert_managed_paths_exclude_prefix \
   "$macos_managed_targets" \
   "Brewfile.macos-desktop-apps" \
@@ -479,6 +495,49 @@ assert_contains_text "$terminal_launcher_marker_text" "summary='Homebrew desktop
 assert_contains_text "$terminal_launcher_marker_text" "failed casks: ghostty, raycast" "desktop app marker guidance includes only casks whose single-cask bundle failed"
 assert_contains_text "$terminal_launcher_marker_text" "App Groups: terminal-apps, launcher" "desktop app marker guidance includes enabled App Groups"
 assert_not_contains_text "$terminal_launcher_marker_text" "1password-cli" "desktop app marker excludes casks whose single-cask bundle succeeded"
+
+terminal_launcher_marker_failure_bin="$tmp_dir/terminal-launcher-marker-failure-bin"
+terminal_launcher_marker_failure_state="$tmp_dir/terminal-launcher-marker-failure-state"
+terminal_launcher_marker_failure_home="$tmp_dir/terminal-launcher-marker-failure-home"
+terminal_launcher_marker_failure_log="$tmp_dir/terminal-launcher-marker-failure-brew.log"
+mkdir -p "$terminal_launcher_marker_failure_bin" "$terminal_launcher_marker_failure_home"
+write_brew_bundle_stub "$terminal_launcher_marker_failure_bin/brew"
+: >"$terminal_launcher_marker_failure_state"
+
+if HOME="$terminal_launcher_marker_failure_home" XDG_STATE_HOME="$terminal_launcher_marker_failure_state" MACOS_BREW_LOG="$terminal_launcher_marker_failure_log" MACOS_BREW_FAIL_DESKTOP_BULK=1 MACOS_BREW_FAIL_CASKS="ghostty" PATH="$terminal_launcher_marker_failure_bin:/usr/bin:/bin" \
+  sh "$terminal_launcher_bootstrap_script" >"$tmp_dir/terminal-launcher-marker-failure.out" 2>"$tmp_dir/terminal-launcher-marker-failure.err"; then
+  fail "macOS desktop app bundle failure blocks when the warning marker cannot be recorded"
+fi
+pass "macOS desktop app bundle failure blocks when the warning marker cannot be recorded"
+
+desktop_retry_marker_failure_bin="$tmp_dir/desktop-retry-marker-failure-bin"
+desktop_retry_marker_failure_state="$tmp_dir/desktop-retry-marker-failure-state"
+desktop_retry_marker_failure_home="$tmp_dir/desktop-retry-marker-failure-home"
+desktop_retry_marker_failure_log="$tmp_dir/desktop-retry-marker-failure-brew.log"
+desktop_retry_marker_failure_dir="$desktop_retry_marker_failure_state/terrapod/install-warnings"
+mkdir -p "$desktop_retry_marker_failure_bin" "$desktop_retry_marker_failure_home"
+mkdir -p "$desktop_retry_marker_failure_dir"
+HOME="$desktop_retry_marker_failure_home" XDG_STATE_HOME="$desktop_retry_marker_failure_state" sh -c \
+  '. "$1"; terrapod_install_warning_write homebrew-desktop-apps "Homebrew desktop app install needs attention" "Retry marker write failure setup."' \
+  sh "$repo_root/dot_local/lib/terrapod/install-warnings.sh"
+write_stub "$desktop_retry_marker_failure_bin/brew" \
+  'printf "%s\n" "brew args:$*" >>"$MACOS_BREW_LOG"' \
+  'case "$1" in' \
+  '  shellenv) printf "%s\n" ":" ;;' \
+  '  analytics) exit 0 ;;' \
+  '  bundle)' \
+  '    rm -rf "$DESKTOP_RETRY_MARKER_FAILURE_DIR"' \
+  '    : >"$DESKTOP_RETRY_MARKER_FAILURE_DIR"' \
+  '    exit 42' \
+  '    ;;' \
+  '  *) exit 64 ;;' \
+  'esac'
+
+if HOME="$desktop_retry_marker_failure_home" XDG_STATE_HOME="$desktop_retry_marker_failure_state" DESKTOP_RETRY_MARKER_FAILURE_DIR="$desktop_retry_marker_failure_dir" MACOS_BREW_LOG="$desktop_retry_marker_failure_log" PATH="$desktop_retry_marker_failure_bin:/usr/bin:/bin" \
+  sh "$macos_terminal_apps_desktop_retry_script" >"$tmp_dir/desktop-retry-marker-failure.out" 2>"$tmp_dir/desktop-retry-marker-failure.err"; then
+  fail "macOS desktop retry failure blocks when the warning marker cannot be recorded"
+fi
+pass "macOS desktop retry failure blocks when the warning marker cannot be recorded"
 
 bulk_only_bootstrap_script="$tmp_dir/macos-bulk-only-bootstrap.sh"
 printf '%s\n' "$macos_terminal_launcher_apps_bootstrap" >"$bulk_only_bootstrap_script"
@@ -1033,6 +1092,32 @@ assert_not_contains_text "$ai_cli_retry_marker_text" "antigravity" "enabled Opti
 assert_not_contains_text "$ai_cli_retry_marker_text" "Antigravity" "enabled Optional AI Tool Stack partial failure marker omits successful Antigravity label"
 assert_not_contains_text "$ai_cli_retry_marker_text" "codex" "enabled Optional AI Tool Stack partial failure marker omits successful Codex"
 assert_not_contains_text "$ai_cli_retry_marker_text" "Codex" "enabled Optional AI Tool Stack partial failure marker omits successful Codex label"
+
+rm -f "$ai_cli_retry_marker"
+: >"$ai_cli_retry_url_log"
+: >"$ai_cli_retry_run_log"
+ai_cli_retry_first_run_status=0
+HOME="$ai_cli_retry_home" \
+  XDG_STATE_HOME="$ai_cli_retry_state" \
+  AI_CLI_RETRY_URL_LOG="$ai_cli_retry_url_log" \
+  AI_CLI_RETRY_RUN_LOG="$ai_cli_retry_run_log" \
+  AI_CLI_RETRY_ANTIGRAVITY_INSTALLER="$ai_cli_retry_antigravity_installer" \
+  AI_CLI_RETRY_CLAUDE_INSTALLER="$ai_cli_retry_claude_installer" \
+  AI_CLI_RETRY_CODEX_INSTALLER="$ai_cli_retry_codex_installer" \
+  AI_CLI_RETRY_CLAUDE_FAIL=1 \
+  TERRAPOD_FIRST_RUN_APPLY=1 \
+  TMPDIR="$tmp_dir" \
+  PATH="$ai_cli_retry_home/.local/bin:/usr/bin:/bin" \
+  sh "$ai_cli_tools_installer_script" >/dev/null 2>"$tmp_dir/ai-cli-retry-first-run.err" || ai_cli_retry_first_run_status=$?
+if [ "$ai_cli_retry_first_run_status" -ne 0 ]; then
+  fail "first-run Optional AI Tool Stack installer exits 0 after recording partial AI CLI installer failures"
+fi
+pass "first-run Optional AI Tool Stack installer exits 0 after recording partial AI CLI installer failures"
+
+if [ ! -f "$ai_cli_retry_marker" ]; then
+  fail "first-run Optional AI Tool Stack installer writes optional-ai-cli-tools marker for partial failures"
+fi
+pass "first-run Optional AI Tool Stack installer writes optional-ai-cli-tools marker for partial failures"
 
 : >"$ai_cli_retry_url_log"
 : >"$ai_cli_retry_run_log"

--- a/tests/shell_integrations_test.sh
+++ b/tests/shell_integrations_test.sh
@@ -112,3 +112,18 @@ assert_contains "$marker_text" "Oh My Zsh" "shell integrations marker mentions t
 test_log="$(cat "$SHELL_INTEGRATIONS_TEST_LOG")"
 assert_contains "$test_log" "curl args:-fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh" "shell integrations attempts to download the Oh My Zsh installer"
 assert_not_contains "$test_log" "git args:clone https://github.com/zdharma-continuum/zinit" "shell integrations stops before zinit when Oh My Zsh download fails"
+
+rm -f "$shell_integrations_marker"
+: >"$SHELL_INTEGRATIONS_TEST_LOG"
+SHELL_INTEGRATIONS_CURL_STATUS=23
+export SHELL_INTEGRATIONS_CURL_STATUS
+if ! TERRAPOD_FIRST_RUN_APPLY=1 sh "$rendered" >"$tmp_dir/shell-integrations-first-run-curl-failure.out" 2>"$tmp_dir/shell-integrations-first-run-curl-failure.err"; then
+  unset SHELL_INTEGRATIONS_CURL_STATUS
+  fail "first-run shell integrations should continue when the Oh My Zsh installer download warning is recorded"
+fi
+unset SHELL_INTEGRATIONS_CURL_STATUS
+
+if [ ! -f "$shell_integrations_marker" ]; then
+  fail "first-run shell integrations should record a warning marker when the Oh My Zsh installer download fails"
+fi
+pass "first-run shell integrations records a warning marker when the Oh My Zsh installer download fails"

--- a/tests/terrapod_installer_test.sh
+++ b/tests/terrapod_installer_test.sh
@@ -2,6 +2,8 @@
 set -eu
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+install_warnings_lib_template="$repo_root/dot_local/lib/terrapod/install-warnings.sh"
+export TERRAPOD_INSTALL_WARNINGS_LIB_TEMPLATE="$install_warnings_lib_template"
 tmp_dir="$(mktemp -d)"
 safe_path_dir="$tmp_dir/safe-bin"
 
@@ -20,7 +22,7 @@ pass() {
 }
 
 mkdir -p "$safe_path_dir"
-for command_name in awk cat chmod cmp cp date grep ln mkdir mktemp readlink rm; do
+for command_name in awk cat chmod cmp cp date grep ln mkdir mktemp mv readlink rm sed; do
   command_path="$(command -v "$command_name")"
   ln -s "$command_path" "$safe_path_dir/$command_name"
 done
@@ -581,6 +583,10 @@ case "${1-}" in
 esac
 TERRAPOD_STUB
     chmod +x "$source_dir/dot_local/bin/executable_terrapod"
+    if [ -f "${TERRAPOD_INSTALL_WARNINGS_LIB_TEMPLATE:-}" ]; then
+      mkdir -p "$source_dir/dot_local/lib/terrapod"
+      cp "$TERRAPOD_INSTALL_WARNINGS_LIB_TEMPLATE" "$source_dir/dot_local/lib/terrapod/install-warnings.sh"
+    fi
     ;;
   cat)
     target="${2-}"
@@ -626,6 +632,24 @@ TERRAPOD_STUB
         shift
       done
       exit 0
+    fi
+
+    if [ -n "${TERRAPOD_CHEZMOI_APPLY_STUB_STDOUT:-}" ]; then
+      printf '%s\n' "$TERRAPOD_CHEZMOI_APPLY_STUB_STDOUT"
+    fi
+    if [ -n "${TERRAPOD_CHEZMOI_APPLY_STUB_STDERR:-}" ]; then
+      printf '%s\n' "$TERRAPOD_CHEZMOI_APPLY_STUB_STDERR" >&2
+    fi
+    if [ -n "${TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_CATEGORY:-}" ] && [ -f "${TERRAPOD_INSTALL_WARNINGS_LIB_TEMPLATE:-}" ]; then
+      . "$TERRAPOD_INSTALL_WARNINGS_LIB_TEMPLATE"
+      terrapod_install_warning_write \
+        "$TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_CATEGORY" \
+        "${TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_SUMMARY:-mise tool install needs attention}" \
+        "${TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_GUIDANCE:-Run tpod apply after fixing installer output.}"
+    fi
+    apply_status="${TERRAPOD_CHEZMOI_APPLY_STUB_STATUS:-0}"
+    if [ "$apply_status" != "0" ]; then
+      exit "$apply_status"
     fi
 
     mkdir -p "$HOME/.local/bin"
@@ -733,6 +757,8 @@ write_terrapod_source_checkout() {
 GITCONFIG
   cp "$terrapod_stub" "$source_dir/dot_local/bin/executable_terrapod"
   chmod +x "$source_dir/dot_local/bin/executable_terrapod"
+  mkdir -p "$source_dir/dot_local/lib/terrapod"
+  cp "$repo_root/dot_local/lib/terrapod/install-warnings.sh" "$source_dir/dot_local/lib/terrapod/install-warnings.sh"
   : >"$source_dir/dot_local/bin/symlink_tpod"
   : >"$source_dir/dot_zshenv.tmpl"
   : >"$source_dir/dot_zprofile"
@@ -1453,15 +1479,168 @@ assert_first_occurrence_before "$first_run_log_text" "brew args:install gum" "te
 assert_first_occurrence_before "$first_run_log_text" "terrapod args:setup" "chezmoi args:apply" "setup runs before chezmoi apply"
 assert_first_occurrence_before "$first_run_log_text" "brew args:install gum" "chezmoi args:apply" "macOS setup UI gum bootstrap runs before initial apply"
 assert_contains "$first_run_log_text" "chezmoi args:apply" "chezmoi apply runs after setup"
+assert_first_occurrence_before "$first_run_log_text" "terrapod path:$first_run_case/home/.local/bin/tpod" "chezmoi args:apply --force" "first-run validates recovery-core command surface before shell startup recovery apply"
+assert_first_occurrence_before "$first_run_log_text" "chezmoi args:apply --force" "tpod args:help" "first-run applies recovery-core shell startup files before final help"
 assert_first_occurrence_before "$first_run_log_text" "chezmoi args:apply" "tpod args:help" "first-run installer shows tpod help after initial apply"
 assert_contains "$first_run_log_text" "tpod path:$first_run_case/home/.local/bin/tpod" "first-run installer invokes installed tpod from user local bin"
 assert_contains "$first_run_log_text" "tpod path_has_local_bin:yes" "tpod help receives PATH containing user local bin"
 assert_contains "$first_run_stdout" "Terrapod - a small landing pod for your dotfiles" "first-run installer prints tpod help title after initial apply"
 assert_contains "$first_run_stdout" "Usage:" "first-run installer prints tpod help usage after initial apply"
 assert_contains "$first_run_stdout" "  tpod apply" "first-run installer prints tpod apply help after initial apply"
+assert_contains "$first_run_stdout" "Terrapod command availability:" "clean first-run explains tpod availability"
+assert_contains "$first_run_stdout" "Use this absolute command now: $first_run_case/home/.local/bin/tpod" "clean first-run prints absolute tpod command"
+assert_contains "$first_run_stdout" "Open a new terminal or refresh your login shell before relying on plain 'tpod'." "clean first-run explains shell refresh guidance"
+assert_not_contains "$first_run_stdout" "$first_run_case/home/.local/bin/tpod doctor" "clean first-run does not print doctor recovery guidance"
 assert_contains "$first_run_log_text" "chezmoi path_has_local_bin:yes" "child command PATH contains user local bin"
 assert_not_contains "$first_run_log_text" "brew args:upgrade" "first-run installer does not run broad Homebrew upgrades"
 assert_not_contains "$first_run_log_text" "brew args:bundle" "first-run installer leaves Brewfile bundle to initial apply"
+
+warning_completion_case="$(make_case_dir warning-completion)"
+prepare_resumable_macos_case "$warning_completion_case"
+write_complete_setup_config "$warning_completion_case/xdg-config/chezmoi/chezmoi.toml"
+warning_completion_log="$warning_completion_case/command-calls"
+TERRAPOD_STUB_CALL_LOG="$warning_completion_log"
+TERRAPOD_CHEZMOI_APPLY_STUB_STDERR="simulated mise install failure"
+TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_CATEGORY=mise-tools
+TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_SUMMARY="mise tool install needs attention"
+TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_GUIDANCE="Review mise output, then rerun tpod apply."
+export TERRAPOD_STUB_CALL_LOG
+export TERRAPOD_CHEZMOI_APPLY_STUB_STDERR
+export TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_CATEGORY
+export TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_SUMMARY
+export TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_GUIDANCE
+run_installer_case "$warning_completion_case"
+unset TERRAPOD_STUB_CALL_LOG
+unset TERRAPOD_CHEZMOI_APPLY_STUB_STDERR
+unset TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_CATEGORY
+unset TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_SUMMARY
+unset TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_GUIDANCE
+assert_status "$installer_status" 0 "marker-backed full apply warning completes with installer status 0"
+warning_completion_stdout="$(cat "$warning_completion_case/stdout")"
+warning_completion_stderr="$(cat "$warning_completion_case/stderr")"
+assert_contains "$warning_completion_stderr" "simulated mise install failure" "warning completion preserves full apply output"
+assert_contains "$warning_completion_stdout" "Terrapod - a small landing pod for your dotfiles" "warning completion still prints tpod help"
+assert_contains "$warning_completion_stdout" "Terrapod first-run apply completed with warnings." "warning completion prints distinct final status"
+assert_contains "$warning_completion_stdout" "$warning_completion_case/home/.local/bin/tpod doctor" "warning completion prints absolute doctor recovery command"
+
+warning_marker_write_failure_case="$(make_case_dir warning-marker-write-failure)"
+prepare_resumable_macos_case "$warning_marker_write_failure_case"
+write_complete_setup_config "$warning_marker_write_failure_case/xdg-config/chezmoi/chezmoi.toml"
+mkdir -p "$warning_marker_write_failure_case/home/.local"
+: >"$warning_marker_write_failure_case/home/.local/state"
+warning_marker_write_failure_log="$warning_marker_write_failure_case/command-calls"
+TERRAPOD_STUB_CALL_LOG="$warning_marker_write_failure_log"
+TERRAPOD_CHEZMOI_APPLY_STUB_STDERR="simulated warning marker write failure"
+TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_CATEGORY=mise-tools
+export TERRAPOD_STUB_CALL_LOG
+export TERRAPOD_CHEZMOI_APPLY_STUB_STDERR
+export TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_CATEGORY
+run_installer_case "$warning_marker_write_failure_case"
+unset TERRAPOD_STUB_CALL_LOG
+unset TERRAPOD_CHEZMOI_APPLY_STUB_STDERR
+unset TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_CATEGORY
+assert_failure "$installer_status" "warning marker write failure remains a hard first-run failure"
+warning_marker_write_failure_stdout="$(cat "$warning_marker_write_failure_case/stdout")"
+warning_marker_write_failure_stderr="$(cat "$warning_marker_write_failure_case/stderr")"
+assert_contains "$warning_marker_write_failure_stderr" "simulated warning marker write failure" "warning marker write failure preserves apply output"
+assert_not_contains "$warning_marker_write_failure_stdout" "completed with warnings" "warning marker write failure does not print warning completion"
+
+unknown_apply_failure_case="$(make_case_dir unknown-apply-failure)"
+prepare_resumable_macos_case "$unknown_apply_failure_case"
+write_complete_setup_config "$unknown_apply_failure_case/xdg-config/chezmoi/chezmoi.toml"
+unknown_apply_failure_log="$unknown_apply_failure_case/command-calls"
+TERRAPOD_STUB_CALL_LOG="$unknown_apply_failure_log"
+TERRAPOD_CHEZMOI_APPLY_STUB_STATUS=43
+TERRAPOD_CHEZMOI_APPLY_STUB_STDERR="simulated template rendering failure"
+export TERRAPOD_STUB_CALL_LOG
+export TERRAPOD_CHEZMOI_APPLY_STUB_STATUS
+export TERRAPOD_CHEZMOI_APPLY_STUB_STDERR
+run_installer_case "$unknown_apply_failure_case"
+unset TERRAPOD_STUB_CALL_LOG
+unset TERRAPOD_CHEZMOI_APPLY_STUB_STATUS
+unset TERRAPOD_CHEZMOI_APPLY_STUB_STDERR
+assert_failure "$installer_status" "unknown full apply failure remains hard"
+unknown_apply_failure_stdout="$(cat "$unknown_apply_failure_case/stdout")"
+unknown_apply_failure_stderr="$(cat "$unknown_apply_failure_case/stderr")"
+assert_contains "$unknown_apply_failure_stderr" "simulated template rendering failure" "unknown full apply failure preserves apply output"
+assert_contains "$unknown_apply_failure_stderr" "terrapod installer: chezmoi apply failed" "unknown full apply failure keeps hard failure guidance"
+assert_not_contains "$unknown_apply_failure_stdout" "completed with warnings" "unknown full apply failure does not print warning completion"
+
+mixed_apply_failure_case="$(make_case_dir mixed-apply-failure)"
+prepare_resumable_macos_case "$mixed_apply_failure_case"
+write_complete_setup_config "$mixed_apply_failure_case/xdg-config/chezmoi/chezmoi.toml"
+mixed_apply_failure_log="$mixed_apply_failure_case/command-calls"
+TERRAPOD_STUB_CALL_LOG="$mixed_apply_failure_log"
+TERRAPOD_CHEZMOI_APPLY_STUB_STATUS=45
+TERRAPOD_CHEZMOI_APPLY_STUB_STDERR="simulated managed-file failure after marker"
+TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_CATEGORY=mise-tools
+export TERRAPOD_STUB_CALL_LOG
+export TERRAPOD_CHEZMOI_APPLY_STUB_STATUS
+export TERRAPOD_CHEZMOI_APPLY_STUB_STDERR
+export TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_CATEGORY
+run_installer_case "$mixed_apply_failure_case"
+unset TERRAPOD_STUB_CALL_LOG
+unset TERRAPOD_CHEZMOI_APPLY_STUB_STATUS
+unset TERRAPOD_CHEZMOI_APPLY_STUB_STDERR
+unset TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_CATEGORY
+assert_failure "$installer_status" "non-zero full apply remains hard even when an unrelated marker changed"
+mixed_apply_failure_stdout="$(cat "$mixed_apply_failure_case/stdout")"
+mixed_apply_failure_stderr="$(cat "$mixed_apply_failure_case/stderr")"
+assert_contains "$mixed_apply_failure_stderr" "simulated managed-file failure after marker" "mixed full apply failure preserves output"
+assert_not_contains "$mixed_apply_failure_stdout" "completed with warnings" "mixed full apply failure does not print warning completion"
+
+stale_marker_success_case="$(make_case_dir stale-marker-success)"
+prepare_resumable_macos_case "$stale_marker_success_case"
+write_complete_setup_config "$stale_marker_success_case/xdg-config/chezmoi/chezmoi.toml"
+HOME="$stale_marker_success_case/home" sh -c \
+  '. "$1"; terrapod_install_warning_write mise-tools "stale warning" "stale guidance"' \
+  sh "$install_warnings_lib_template"
+stale_marker_success_log="$stale_marker_success_case/command-calls"
+TERRAPOD_STUB_CALL_LOG="$stale_marker_success_log"
+export TERRAPOD_STUB_CALL_LOG
+run_installer_case "$stale_marker_success_case"
+unset TERRAPOD_STUB_CALL_LOG
+assert_status "$installer_status" 0 "unchanged stale marker does not prevent clean first-run completion"
+stale_marker_success_stdout="$(cat "$stale_marker_success_case/stdout")"
+assert_contains "$stale_marker_success_stdout" "Terrapod first-run apply complete." "stale marker success keeps clean completion"
+assert_not_contains "$stale_marker_success_stdout" "$stale_marker_success_case/home/.local/bin/tpod doctor" "stale marker success does not print doctor recovery guidance"
+
+same_second_marker_rewrite_case="$(make_case_dir same-second-marker-rewrite)"
+prepare_resumable_macos_case "$same_second_marker_rewrite_case"
+write_complete_setup_config "$same_second_marker_rewrite_case/xdg-config/chezmoi/chezmoi.toml"
+cat >"$same_second_marker_rewrite_case/bin/date" <<'EOF'
+#!/bin/sh
+case "$*" in
+  "-u +%Y-%m-%dT%H:%M:%SZ")
+    printf '%s\n' "2026-01-01T00:00:00Z"
+    ;;
+  *)
+    printf '%s\n' "20260101000000"
+    ;;
+esac
+EOF
+chmod +x "$same_second_marker_rewrite_case/bin/date"
+HOME="$same_second_marker_rewrite_case/home" PATH="$same_second_marker_rewrite_case/bin:$safe_path_dir" "$(command -v sh)" -c \
+  '. "$1"; terrapod_install_warning_write mise-tools "same warning" "same guidance"' \
+  sh "$install_warnings_lib_template"
+same_second_marker_rewrite_log="$same_second_marker_rewrite_case/command-calls"
+TERRAPOD_STUB_CALL_LOG="$same_second_marker_rewrite_log"
+TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_CATEGORY=mise-tools
+TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_SUMMARY="same warning"
+TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_GUIDANCE="same guidance"
+export TERRAPOD_STUB_CALL_LOG
+export TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_CATEGORY
+export TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_SUMMARY
+export TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_GUIDANCE
+run_installer_case "$same_second_marker_rewrite_case"
+unset TERRAPOD_STUB_CALL_LOG
+unset TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_CATEGORY
+unset TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_SUMMARY
+unset TERRAPOD_CHEZMOI_APPLY_STUB_WARNING_GUIDANCE
+assert_status "$installer_status" 0 "same-second marker rewrite keeps installer status 0"
+same_second_marker_rewrite_stdout="$(cat "$same_second_marker_rewrite_case/stdout")"
+assert_contains "$same_second_marker_rewrite_stdout" "Terrapod first-run apply completed with warnings." "same-second marker rewrite is classified as warning completion"
+assert_contains "$same_second_marker_rewrite_stdout" "$same_second_marker_rewrite_case/home/.local/bin/tpod doctor" "same-second marker rewrite prints doctor recovery command"
 
 homebrew_missing_case="$(make_case_dir homebrew-missing-macos)"
 write_uname_stub "$homebrew_missing_case" "Darwin"


### PR DESCRIPTION
## Summary
- Adds first-run warning completion after recovery-core validation, with marker-backed clean vs warning final output and current-terminal `tpod` availability guidance.
- Lets known first-run installer categories record warnings and continue only when marker writes succeed, while non-zero full apply results remain hard failures.
- Adds marker freshness and regression coverage for same-second marker rewrites, marker write failures, stale markers, unknown failures, and retry paths.

## Test Plan
- `sh -n install.sh`
- `sh -n dot_local/bin/executable_terrapod`
- `sh -n dot_local/lib/terrapod/install-warnings.sh`
- `sh tests/terrapod_installer_test.sh`
- `sh tests/terrapod_command_test.sh`
- `sh tests/shell_integrations_test.sh`
- `sh tests/bootstrap_ubuntu_test.sh`
- `sh tests/chezmoiignore_test.sh`
- `set -e; for test_file in tests/*_test.sh; do printf 'RUN %s\n' "$test_file"; sh "$test_file"; done`
- `git diff --check`

Closes #100