### PR TITLE
Recover mise and shell warning categories

### DIFF
--- a/.chezmoiscripts/run_after_21-retry-mise-tools.sh.tmpl
+++ b/.chezmoiscripts/run_after_21-retry-mise-tools.sh.tmpl
@@ -1,0 +1,119 @@
+{{- if or (eq .chezmoi.os "darwin") (eq .chezmoi.os "linux") -}}
+#!/bin/sh
+set -eu
+
+install_warnings_lib="{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/install-warnings.sh"
+TERRAPOD_INSTALL_WARNINGS_LOADED=
+if [ -f "$install_warnings_lib" ]; then
+  . "$install_warnings_lib"
+fi
+
+if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" != "1" ]; then
+  exit 0
+fi
+
+mise_tools_marker_path="$(terrapod_install_warning_path mise-tools 2>/dev/null || true)"
+if [ -z "$mise_tools_marker_path" ] || [ ! -f "$mise_tools_marker_path" ]; then
+  exit 0
+fi
+
+INSTALL_WARNING_RECORDED=0
+
+mark_install_warning() {
+  category="$1"
+  summary="$2"
+  guidance="$3"
+  INSTALL_WARNING_RECORDED=0
+
+  if terrapod_install_warning_write "$category" "$summary" "$guidance"; then
+    INSTALL_WARNING_RECORDED=1
+  fi
+}
+
+exit_after_install_warning() {
+  if [ "$INSTALL_WARNING_RECORDED" -eq 1 ]; then
+    exit 0
+  fi
+
+  exit 1
+}
+
+clear_install_warning() {
+  category="$1"
+
+  terrapod_install_warning_clear "$category" || true
+}
+
+failed_mise_steps=
+
+append_failed_mise_step() {
+  step="$1"
+
+  if [ -n "$failed_mise_steps" ]; then
+    failed_mise_steps="$failed_mise_steps, $step"
+  else
+    failed_mise_steps="$step"
+  fi
+}
+
+finish_mise_tools() {
+  if [ -n "$failed_mise_steps" ]; then
+    mark_install_warning \
+      mise-tools \
+      "mise tool install needs attention" \
+      "Failed step(s): $failed_mise_steps. Review mise output, fix tool installation issues, then rerun tpod apply. If mise aqua resolution hit GitHub API rate limits, export a temporary GITHUB_TOKEN or run gh auth login before rerunning."
+    exit_after_install_warning
+  fi
+
+  clear_install_warning mise-tools
+}
+
+setup_mise() {
+  if command -v mise >/dev/null 2>&1; then
+    return
+  fi
+
+{{ if eq .chezmoi.os "darwin" }}
+  if [ -x /opt/homebrew/bin/brew ]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+  fi
+
+  if command -v mise >/dev/null 2>&1; then
+    return
+  fi
+
+  if [ -x /usr/local/bin/brew ]; then
+    eval "$(/usr/local/bin/brew shellenv)"
+  fi
+
+  if ! command -v mise >/dev/null 2>&1; then
+    echo "mise is required. Run the Homebrew Brewfile bundle first." >&2
+    mark_install_warning \
+      mise-tools \
+      "mise tool install needs attention" \
+      "Run the Homebrew Brewfile bundle or fix mise on PATH, then rerun tpod apply."
+    exit_after_install_warning
+  fi
+{{ else }}
+  echo "mise is required. The Ubuntu bootstrap script should install mise from the official APT repository." >&2
+  mark_install_warning \
+    mise-tools \
+    "mise tool install needs attention" \
+    "Run the Ubuntu bootstrap script or fix mise on PATH, then rerun tpod apply."
+  exit_after_install_warning
+{{ end }}
+}
+
+setup_mise
+if ! mise install --yes -C "$HOME"; then
+  append_failed_mise_step "mise install"
+fi
+
+if mise exec --yes -C "$HOME" -- sh -c 'command -v corepack' >/dev/null 2>&1; then
+  if ! mise exec --yes -C "$HOME" -- corepack enable; then
+    append_failed_mise_step "corepack enable"
+  fi
+fi
+
+finish_mise_tools
+{{- end }}

--- a/.chezmoiscripts/run_before_31-retry-shell-integrations.sh.tmpl
+++ b/.chezmoiscripts/run_before_31-retry-shell-integrations.sh.tmpl
@@ -56,6 +56,51 @@ zinit_install_complete() {
   [ -f "$HOME/.local/share/zinit/zinit.git/zinit.zsh" ]
 }
 
+install_oh_my_zsh() {
+  echo "Installing Oh My Zsh..."
+  oh_my_zsh_installer="$(mktemp "${TMPDIR:-/tmp}/terrapod-oh-my-zsh-installer.XXXXXX")"
+  installer_paths="$installer_paths $oh_my_zsh_installer"
+  if ! curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh -o "$oh_my_zsh_installer"; then
+    append_failed_shell_integration "Oh My Zsh"
+  elif ! sh "$oh_my_zsh_installer" --unattended --keep-zshrc; then
+    append_failed_shell_integration "Oh My Zsh"
+  elif ! oh_my_zsh_install_complete; then
+    append_failed_shell_integration "Oh My Zsh"
+  fi
+}
+
+reinstall_partial_oh_my_zsh() {
+  if ! rm -rf "$HOME/.oh-my-zsh"; then
+    append_failed_shell_integration "Oh My Zsh"
+    return
+  fi
+
+  install_oh_my_zsh
+}
+
+install_zinit() {
+  echo "Installing zinit..."
+  if ! mkdir -p "$HOME/.local/share/zinit"; then
+    append_failed_shell_integration "zinit"
+    return
+  fi
+
+  if ! git clone https://github.com/zdharma-continuum/zinit "$HOME/.local/share/zinit/zinit.git"; then
+    append_failed_shell_integration "zinit"
+  elif ! zinit_install_complete; then
+    append_failed_shell_integration "zinit"
+  fi
+}
+
+reinstall_partial_zinit() {
+  if ! rm -rf "$HOME/.local/share/zinit/zinit.git"; then
+    append_failed_shell_integration "zinit"
+    return
+  fi
+
+  install_zinit
+}
+
 failed_shell_integrations=
 
 append_failed_shell_integration() {
@@ -142,26 +187,15 @@ setup_macos_brew
 ensure_git
 
 if [ ! -d "$HOME/.oh-my-zsh" ]; then
-  echo "Installing Oh My Zsh..."
-  oh_my_zsh_installer="$(mktemp "${TMPDIR:-/tmp}/terrapod-oh-my-zsh-installer.XXXXXX")"
-  installer_paths="$installer_paths $oh_my_zsh_installer"
-  if ! curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh -o "$oh_my_zsh_installer"; then
-    append_failed_shell_integration "Oh My Zsh"
-  elif ! sh "$oh_my_zsh_installer" --unattended --keep-zshrc; then
-    append_failed_shell_integration "Oh My Zsh"
-  fi
+  install_oh_my_zsh
 elif shell_integrations_warning_exists && ! oh_my_zsh_install_complete; then
-  append_failed_shell_integration "Oh My Zsh"
+  reinstall_partial_oh_my_zsh
 fi
 
 if [ ! -d "$HOME/.local/share/zinit/zinit.git" ]; then
-  echo "Installing zinit..."
-  mkdir -p "$HOME/.local/share/zinit"
-  if ! git clone https://github.com/zdharma-continuum/zinit "$HOME/.local/share/zinit/zinit.git"; then
-    append_failed_shell_integration "zinit"
-  fi
+  install_zinit
 elif shell_integrations_warning_exists && ! zinit_install_complete; then
-  append_failed_shell_integration "zinit"
+  reinstall_partial_zinit
 fi
 
 if [ ! -d "$HOME/.scm_breeze" ]; then

--- a/.chezmoiscripts/run_before_31-retry-shell-integrations.sh.tmpl
+++ b/.chezmoiscripts/run_before_31-retry-shell-integrations.sh.tmpl
@@ -1,0 +1,172 @@
+{{- if or (eq .chezmoi.os "darwin") (eq .chezmoi.os "linux") -}}
+#!/bin/sh
+set -eu
+
+install_warnings_lib="{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/install-warnings.sh"
+TERRAPOD_INSTALL_WARNINGS_LOADED=
+if [ -f "$install_warnings_lib" ]; then
+  . "$install_warnings_lib"
+fi
+
+if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" != "1" ]; then
+  exit 0
+fi
+
+shell_integrations_marker_path="$(terrapod_install_warning_path shell-integrations 2>/dev/null || true)"
+if [ -z "$shell_integrations_marker_path" ] || [ ! -f "$shell_integrations_marker_path" ]; then
+  exit 0
+fi
+
+INSTALL_WARNING_RECORDED=0
+
+mark_install_warning() {
+  category="$1"
+  summary="$2"
+  guidance="$3"
+  INSTALL_WARNING_RECORDED=0
+
+  if terrapod_install_warning_write "$category" "$summary" "$guidance"; then
+    INSTALL_WARNING_RECORDED=1
+  fi
+}
+
+exit_after_install_warning() {
+  if [ "$INSTALL_WARNING_RECORDED" -eq 1 ]; then
+    exit 0
+  fi
+
+  exit 1
+}
+
+clear_install_warning() {
+  category="$1"
+
+  terrapod_install_warning_clear "$category" || true
+}
+
+shell_integrations_warning_exists() {
+  terrapod_install_warning_existing_path shell-integrations >/dev/null 2>&1
+}
+
+failed_shell_integrations=
+
+append_failed_shell_integration() {
+  failed_shell_integration="$1"
+
+  if [ -n "$failed_shell_integrations" ]; then
+    failed_shell_integrations="$failed_shell_integrations, $failed_shell_integration"
+  else
+    failed_shell_integrations="$failed_shell_integration"
+  fi
+}
+
+finish_shell_integrations() {
+  if [ -n "$failed_shell_integrations" ]; then
+    mark_install_warning \
+      shell-integrations \
+      "Shell integration setup needs attention" \
+      "Failed item(s): $failed_shell_integrations. Review installer output, fix network or installer requirements, then rerun tpod apply."
+    exit_after_install_warning
+  fi
+
+  clear_install_warning shell-integrations
+}
+
+installer_paths=
+
+cleanup_installers() {
+  for installer_path in $installer_paths; do
+    rm -f "$installer_path"
+  done
+}
+
+trap cleanup_installers EXIT HUP INT TERM
+
+setup_macos_brew() {
+  if command -v brew >/dev/null 2>&1; then
+    return
+  fi
+
+  if [ -x /opt/homebrew/bin/brew ]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+    return
+  fi
+
+  if [ -x /usr/local/bin/brew ]; then
+    eval "$(/usr/local/bin/brew shellenv)"
+    return
+  fi
+
+  echo "Homebrew is required to install shell integrations." >&2
+  mark_install_warning \
+    shell-integrations \
+    "Shell integration setup needs attention" \
+    "Install Homebrew or fix brew on PATH, then rerun tpod apply."
+  exit_after_install_warning
+}
+
+ensure_git() {
+  if command -v git >/dev/null 2>&1; then
+    return
+  fi
+
+{{ if eq .chezmoi.os "darwin" }}
+  if ! brew install git; then
+    mark_install_warning \
+      shell-integrations \
+      "Shell integration setup needs attention" \
+      "Install git with Homebrew, then rerun tpod apply."
+    exit_after_install_warning
+  fi
+{{ else }}
+  echo "git is required to install shell integrations." >&2
+  mark_install_warning \
+    shell-integrations \
+    "Shell integration setup needs attention" \
+    "Install git, then rerun tpod apply."
+  exit_after_install_warning
+{{ end }}
+}
+
+{{ if eq .chezmoi.os "darwin" }}
+setup_macos_brew
+{{ end }}
+ensure_git
+
+if [ ! -d "$HOME/.oh-my-zsh" ]; then
+  echo "Installing Oh My Zsh..."
+  oh_my_zsh_installer="$(mktemp "${TMPDIR:-/tmp}/terrapod-oh-my-zsh-installer.XXXXXX")"
+  installer_paths="$installer_paths $oh_my_zsh_installer"
+  if ! curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh -o "$oh_my_zsh_installer"; then
+    append_failed_shell_integration "Oh My Zsh"
+  elif ! sh "$oh_my_zsh_installer" --unattended --keep-zshrc; then
+    append_failed_shell_integration "Oh My Zsh"
+  fi
+fi
+
+if [ ! -d "$HOME/.local/share/zinit/zinit.git" ]; then
+  echo "Installing zinit..."
+  mkdir -p "$HOME/.local/share/zinit"
+  if ! git clone https://github.com/zdharma-continuum/zinit "$HOME/.local/share/zinit/zinit.git"; then
+    append_failed_shell_integration "zinit"
+  fi
+fi
+
+if [ ! -d "$HOME/.scm_breeze" ]; then
+  echo "Installing SCM Breeze..."
+  if ! git clone https://github.com/scmbreeze/scm_breeze.git "$HOME/.scm_breeze"; then
+    append_failed_shell_integration "SCM Breeze"
+  elif ! "$HOME/.scm_breeze/install.sh"; then
+    append_failed_shell_integration "SCM Breeze"
+  fi
+elif shell_integrations_warning_exists; then
+  echo "Installing SCM Breeze..."
+  if [ ! -x "$HOME/.scm_breeze/install.sh" ]; then
+    append_failed_shell_integration "SCM Breeze"
+  elif ! "$HOME/.scm_breeze/install.sh"; then
+    append_failed_shell_integration "SCM Breeze"
+  fi
+fi
+
+finish_shell_integrations
+{{- end }}

--- a/.chezmoiscripts/run_before_31-retry-shell-integrations.sh.tmpl
+++ b/.chezmoiscripts/run_before_31-retry-shell-integrations.sh.tmpl
@@ -48,6 +48,14 @@ shell_integrations_warning_exists() {
   terrapod_install_warning_existing_path shell-integrations >/dev/null 2>&1
 }
 
+oh_my_zsh_install_complete() {
+  [ -f "$HOME/.oh-my-zsh/oh-my-zsh.sh" ]
+}
+
+zinit_install_complete() {
+  [ -f "$HOME/.local/share/zinit/zinit.git/zinit.zsh" ]
+}
+
 failed_shell_integrations=
 
 append_failed_shell_integration() {
@@ -142,6 +150,8 @@ if [ ! -d "$HOME/.oh-my-zsh" ]; then
   elif ! sh "$oh_my_zsh_installer" --unattended --keep-zshrc; then
     append_failed_shell_integration "Oh My Zsh"
   fi
+elif shell_integrations_warning_exists && ! oh_my_zsh_install_complete; then
+  append_failed_shell_integration "Oh My Zsh"
 fi
 
 if [ ! -d "$HOME/.local/share/zinit/zinit.git" ]; then
@@ -150,6 +160,8 @@ if [ ! -d "$HOME/.local/share/zinit/zinit.git" ]; then
   if ! git clone https://github.com/zdharma-continuum/zinit "$HOME/.local/share/zinit/zinit.git"; then
     append_failed_shell_integration "zinit"
   fi
+elif shell_integrations_warning_exists && ! zinit_install_complete; then
+  append_failed_shell_integration "zinit"
 fi
 
 if [ ! -d "$HOME/.scm_breeze" ]; then

--- a/.chezmoiscripts/run_onchange_after_20-install-mise-tools.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_20-install-mise-tools.sh.tmpl
@@ -24,7 +24,7 @@ mark_install_warning() {
 }
 
 exit_after_install_warning() {
-  if [ "${TERRAPOD_FIRST_RUN_APPLY:-}" = "1" ] && [ "$INSTALL_WARNING_RECORDED" -eq 1 ]; then
+  if [ "$INSTALL_WARNING_RECORDED" -eq 1 ]; then
     exit 0
   fi
 
@@ -37,6 +37,30 @@ clear_install_warning() {
   if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ]; then
     terrapod_install_warning_clear "$category" || true
   fi
+}
+
+failed_mise_steps=
+
+append_failed_mise_step() {
+  step="$1"
+
+  if [ -n "$failed_mise_steps" ]; then
+    failed_mise_steps="$failed_mise_steps, $step"
+  else
+    failed_mise_steps="$step"
+  fi
+}
+
+finish_mise_tools() {
+  if [ -n "$failed_mise_steps" ]; then
+    mark_install_warning \
+      mise-tools \
+      "mise tool install needs attention" \
+      "Failed step(s): $failed_mise_steps. Review mise output, fix tool installation issues, then rerun tpod apply. If mise aqua resolution hit GitHub API rate limits, export a temporary GITHUB_TOKEN or run gh auth login before rerunning."
+    exit_after_install_warning
+  fi
+
+  clear_install_warning mise-tools
 }
 
 setup_mise() {
@@ -77,22 +101,14 @@ setup_mise() {
 
 setup_mise
 if ! mise install --yes -C "$HOME"; then
-  mark_install_warning \
-    mise-tools \
-    "mise tool install needs attention" \
-    "Review mise install output, fix tool installation issues, then rerun tpod apply."
-  exit_after_install_warning
+  append_failed_mise_step "mise install"
 fi
 
 if mise exec --yes -C "$HOME" -- sh -c 'command -v corepack' >/dev/null 2>&1; then
   if ! mise exec --yes -C "$HOME" -- corepack enable; then
-    mark_install_warning \
-      mise-tools \
-      "mise tool install needs attention" \
-      "Review corepack enable output, then rerun tpod apply."
-    exit_after_install_warning
+    append_failed_mise_step "corepack enable"
   fi
 fi
 
-clear_install_warning mise-tools
+finish_mise_tools
 {{- end }}

--- a/.chezmoiscripts/run_onchange_before_30-install-shell-integrations.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_30-install-shell-integrations.sh.tmpl
@@ -46,6 +46,14 @@ shell_integrations_warning_exists() {
   terrapod_install_warning_existing_path shell-integrations >/dev/null 2>&1
 }
 
+oh_my_zsh_install_complete() {
+  [ -f "$HOME/.oh-my-zsh/oh-my-zsh.sh" ]
+}
+
+zinit_install_complete() {
+  [ -f "$HOME/.local/share/zinit/zinit.git/zinit.zsh" ]
+}
+
 failed_shell_integrations=
 
 append_failed_shell_integration() {
@@ -140,6 +148,8 @@ if [ ! -d "$HOME/.oh-my-zsh" ]; then
   elif ! sh "$oh_my_zsh_installer" --unattended --keep-zshrc; then
     append_failed_shell_integration "Oh My Zsh"
   fi
+elif shell_integrations_warning_exists && ! oh_my_zsh_install_complete; then
+  append_failed_shell_integration "Oh My Zsh"
 fi
 
 if [ ! -d "$HOME/.local/share/zinit/zinit.git" ]; then
@@ -148,6 +158,8 @@ if [ ! -d "$HOME/.local/share/zinit/zinit.git" ]; then
   if ! git clone https://github.com/zdharma-continuum/zinit "$HOME/.local/share/zinit/zinit.git"; then
     append_failed_shell_integration "zinit"
   fi
+elif shell_integrations_warning_exists && ! zinit_install_complete; then
+  append_failed_shell_integration "zinit"
 fi
 
 if [ ! -d "$HOME/.scm_breeze" ]; then

--- a/.chezmoiscripts/run_onchange_before_30-install-shell-integrations.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_30-install-shell-integrations.sh.tmpl
@@ -54,6 +54,51 @@ zinit_install_complete() {
   [ -f "$HOME/.local/share/zinit/zinit.git/zinit.zsh" ]
 }
 
+install_oh_my_zsh() {
+  echo "Installing Oh My Zsh..."
+  oh_my_zsh_installer="$(mktemp "${TMPDIR:-/tmp}/terrapod-oh-my-zsh-installer.XXXXXX")"
+  installer_paths="$installer_paths $oh_my_zsh_installer"
+  if ! curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh -o "$oh_my_zsh_installer"; then
+    append_failed_shell_integration "Oh My Zsh"
+  elif ! sh "$oh_my_zsh_installer" --unattended --keep-zshrc; then
+    append_failed_shell_integration "Oh My Zsh"
+  elif ! oh_my_zsh_install_complete; then
+    append_failed_shell_integration "Oh My Zsh"
+  fi
+}
+
+reinstall_partial_oh_my_zsh() {
+  if ! rm -rf "$HOME/.oh-my-zsh"; then
+    append_failed_shell_integration "Oh My Zsh"
+    return
+  fi
+
+  install_oh_my_zsh
+}
+
+install_zinit() {
+  echo "Installing zinit..."
+  if ! mkdir -p "$HOME/.local/share/zinit"; then
+    append_failed_shell_integration "zinit"
+    return
+  fi
+
+  if ! git clone https://github.com/zdharma-continuum/zinit "$HOME/.local/share/zinit/zinit.git"; then
+    append_failed_shell_integration "zinit"
+  elif ! zinit_install_complete; then
+    append_failed_shell_integration "zinit"
+  fi
+}
+
+reinstall_partial_zinit() {
+  if ! rm -rf "$HOME/.local/share/zinit/zinit.git"; then
+    append_failed_shell_integration "zinit"
+    return
+  fi
+
+  install_zinit
+}
+
 failed_shell_integrations=
 
 append_failed_shell_integration() {
@@ -140,26 +185,15 @@ setup_macos_brew
 ensure_git
 
 if [ ! -d "$HOME/.oh-my-zsh" ]; then
-  echo "Installing Oh My Zsh..."
-  oh_my_zsh_installer="$(mktemp "${TMPDIR:-/tmp}/terrapod-oh-my-zsh-installer.XXXXXX")"
-  installer_paths="$installer_paths $oh_my_zsh_installer"
-  if ! curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh -o "$oh_my_zsh_installer"; then
-    append_failed_shell_integration "Oh My Zsh"
-  elif ! sh "$oh_my_zsh_installer" --unattended --keep-zshrc; then
-    append_failed_shell_integration "Oh My Zsh"
-  fi
+  install_oh_my_zsh
 elif shell_integrations_warning_exists && ! oh_my_zsh_install_complete; then
-  append_failed_shell_integration "Oh My Zsh"
+  reinstall_partial_oh_my_zsh
 fi
 
 if [ ! -d "$HOME/.local/share/zinit/zinit.git" ]; then
-  echo "Installing zinit..."
-  mkdir -p "$HOME/.local/share/zinit"
-  if ! git clone https://github.com/zdharma-continuum/zinit "$HOME/.local/share/zinit/zinit.git"; then
-    append_failed_shell_integration "zinit"
-  fi
+  install_zinit
 elif shell_integrations_warning_exists && ! zinit_install_complete; then
-  append_failed_shell_integration "zinit"
+  reinstall_partial_zinit
 fi
 
 if [ ! -d "$HOME/.scm_breeze" ]; then

--- a/.chezmoiscripts/run_onchange_before_30-install-shell-integrations.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_30-install-shell-integrations.sh.tmpl
@@ -23,7 +23,7 @@ mark_install_warning() {
 }
 
 exit_after_install_warning() {
-  if [ "${TERRAPOD_FIRST_RUN_APPLY:-}" = "1" ] && [ "$INSTALL_WARNING_RECORDED" -eq 1 ]; then
+  if [ "$INSTALL_WARNING_RECORDED" -eq 1 ]; then
     exit 0
   fi
 
@@ -36,6 +36,38 @@ clear_install_warning() {
   if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ]; then
     terrapod_install_warning_clear "$category" || true
   fi
+}
+
+shell_integrations_warning_exists() {
+  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" != "1" ]; then
+    return 1
+  fi
+
+  terrapod_install_warning_existing_path shell-integrations >/dev/null 2>&1
+}
+
+failed_shell_integrations=
+
+append_failed_shell_integration() {
+  failed_shell_integration="$1"
+
+  if [ -n "$failed_shell_integrations" ]; then
+    failed_shell_integrations="$failed_shell_integrations, $failed_shell_integration"
+  else
+    failed_shell_integrations="$failed_shell_integration"
+  fi
+}
+
+finish_shell_integrations() {
+  if [ -n "$failed_shell_integrations" ]; then
+    mark_install_warning \
+      shell-integrations \
+      "Shell integration setup needs attention" \
+      "Failed item(s): $failed_shell_integrations. Review installer output, fix network or installer requirements, then rerun tpod apply."
+    exit_after_install_warning
+  fi
+
+  clear_install_warning shell-integrations
 }
 
 installer_paths=
@@ -104,18 +136,9 @@ if [ ! -d "$HOME/.oh-my-zsh" ]; then
   oh_my_zsh_installer="$(mktemp "${TMPDIR:-/tmp}/terrapod-oh-my-zsh-installer.XXXXXX")"
   installer_paths="$installer_paths $oh_my_zsh_installer"
   if ! curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh -o "$oh_my_zsh_installer"; then
-    mark_install_warning \
-      shell-integrations \
-      "Shell integration setup needs attention" \
-      "Check network access to the Oh My Zsh installer, then rerun tpod apply."
-    exit_after_install_warning
-  fi
-  if ! sh "$oh_my_zsh_installer" --unattended --keep-zshrc; then
-    mark_install_warning \
-      shell-integrations \
-      "Shell integration setup needs attention" \
-      "Review Oh My Zsh installer output, then rerun tpod apply."
-    exit_after_install_warning
+    append_failed_shell_integration "Oh My Zsh"
+  elif ! sh "$oh_my_zsh_installer" --unattended --keep-zshrc; then
+    append_failed_shell_integration "Oh My Zsh"
   fi
 fi
 
@@ -123,31 +146,25 @@ if [ ! -d "$HOME/.local/share/zinit/zinit.git" ]; then
   echo "Installing zinit..."
   mkdir -p "$HOME/.local/share/zinit"
   if ! git clone https://github.com/zdharma-continuum/zinit "$HOME/.local/share/zinit/zinit.git"; then
-    mark_install_warning \
-      shell-integrations \
-      "Shell integration setup needs attention" \
-      "Review zinit git clone output, then rerun tpod apply."
-    exit_after_install_warning
+    append_failed_shell_integration "zinit"
   fi
 fi
 
 if [ ! -d "$HOME/.scm_breeze" ]; then
   echo "Installing SCM Breeze..."
   if ! git clone https://github.com/scmbreeze/scm_breeze.git "$HOME/.scm_breeze"; then
-    mark_install_warning \
-      shell-integrations \
-      "Shell integration setup needs attention" \
-      "Review SCM Breeze git clone output, then rerun tpod apply."
-    exit_after_install_warning
+    append_failed_shell_integration "SCM Breeze"
+  elif ! "$HOME/.scm_breeze/install.sh"; then
+    append_failed_shell_integration "SCM Breeze"
   fi
-  if ! "$HOME/.scm_breeze/install.sh"; then
-    mark_install_warning \
-      shell-integrations \
-      "Shell integration setup needs attention" \
-      "Review SCM Breeze installer output, then rerun tpod apply."
-    exit_after_install_warning
+elif shell_integrations_warning_exists; then
+  echo "Installing SCM Breeze..."
+  if [ ! -x "$HOME/.scm_breeze/install.sh" ]; then
+    append_failed_shell_integration "SCM Breeze"
+  elif ! "$HOME/.scm_breeze/install.sh"; then
+    append_failed_shell_integration "SCM Breeze"
   fi
 fi
 
-clear_install_warning shell-integrations
+finish_shell_integrations
 {{- end }}

--- a/docs/superpowers/plans/2026-06-07-mise-shell-warning-categories.md
+++ b/docs/superpowers/plans/2026-06-07-mise-shell-warning-categories.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make `mise-tools` and `shell-integrations` installer failures marker-backed, non-blocking recovery categories for routine `tpod apply`, while clearing or replacing each marker on later reruns.
 
-**Architecture:** Keep the shared install-warning marker storage in `dot_local/lib/terrapod/install-warnings.sh` unchanged. Update the two installer templates so reliable category failures are accumulated, written to one category marker, and return success after the marker write succeeds; successful reruns clear the category marker. Tests render the templates through chezmoi and run isolated stubbed commands so no real installers or network calls execute.
+**Architecture:** Keep the shared install-warning marker storage in `dot_local/lib/terrapod/install-warnings.sh` unchanged. Update the two installer templates so reliable category failures are accumulated, written to one category marker, and return success after the marker write succeeds; successful reruns clear the category marker. Because successful `run_onchange_` scripts are not rerun by chezmoi when their content is unchanged, add marker-gated always-run retry hooks that no-op without a marker and retry only when a category marker exists. Tests render the templates through chezmoi and run isolated stubbed commands so no real installers or network calls execute.
 
 **Tech Stack:** POSIX `sh`, chezmoi templates, shell test scripts under `tests/`, GitHub Issue #102.
 
@@ -15,13 +15,17 @@
 - Modify: `.chezmoiscripts/run_onchange_after_20-install-mise-tools.sh.tmpl`
   - Owns the `mise-tools` category.
   - Should collect failed steps, write one marker on failure, exit 0 after a successful marker write, and clear the marker when `mise install` and `corepack enable` both succeed.
+- Create: `.chezmoiscripts/run_after_21-retry-mise-tools.sh.tmpl`
+  - Always runs after apply, no-ops without a `mise-tools` marker, and retries the marker-backed recovery path on later `tpod apply` runs.
 - Modify: `.chezmoiscripts/run_onchange_before_30-install-shell-integrations.sh.tmpl`
   - Owns the `shell-integrations` category.
   - Should collect failed shell integration names, keep attempting independent integrations when practical, write one marker on failure, exit 0 after a successful marker write, and clear the marker on full success.
+- Create: `.chezmoiscripts/run_before_31-retry-shell-integrations.sh.tmpl`
+  - Always runs during the before phase, no-ops without a `shell-integrations` marker, and retries the marker-backed recovery path on later `tpod apply` runs.
 - Modify: `tests/chezmoiignore_test.sh`
-  - Covers rendered `mise-tools` behavior and broad render assertions.
+  - Covers rendered `mise-tools` behavior, marker-gated retry behavior, and broad render assertions.
 - Modify: `tests/shell_integrations_test.sh`
-  - Covers rendered `shell-integrations` behavior and continuing after practical per-item failures.
+  - Covers rendered `shell-integrations` behavior, marker-gated retry behavior, and continuing after practical per-item failures.
 - Create: `docs/superpowers/plans/2026-06-07-mise-shell-warning-categories.md`
   - This implementation plan.
 

--- a/docs/superpowers/plans/2026-06-07-mise-shell-warning-categories.md
+++ b/docs/superpowers/plans/2026-06-07-mise-shell-warning-categories.md
@@ -1,0 +1,637 @@
+# Mise And Shell Warning Categories Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `mise-tools` and `shell-integrations` installer failures marker-backed, non-blocking recovery categories for routine `tpod apply`, while clearing or replacing each marker on later reruns.
+
+**Architecture:** Keep the shared install-warning marker storage in `dot_local/lib/terrapod/install-warnings.sh` unchanged. Update the two installer templates so reliable category failures are accumulated, written to one category marker, and return success after the marker write succeeds; successful reruns clear the category marker. Tests render the templates through chezmoi and run isolated stubbed commands so no real installers or network calls execute.
+
+**Tech Stack:** POSIX `sh`, chezmoi templates, shell test scripts under `tests/`, GitHub Issue #102.
+
+---
+
+## File Structure
+
+- Modify: `.chezmoiscripts/run_onchange_after_20-install-mise-tools.sh.tmpl`
+  - Owns the `mise-tools` category.
+  - Should collect failed steps, write one marker on failure, exit 0 after a successful marker write, and clear the marker when `mise install` and `corepack enable` both succeed.
+- Modify: `.chezmoiscripts/run_onchange_before_30-install-shell-integrations.sh.tmpl`
+  - Owns the `shell-integrations` category.
+  - Should collect failed shell integration names, keep attempting independent integrations when practical, write one marker on failure, exit 0 after a successful marker write, and clear the marker on full success.
+- Modify: `tests/chezmoiignore_test.sh`
+  - Covers rendered `mise-tools` behavior and broad render assertions.
+- Modify: `tests/shell_integrations_test.sh`
+  - Covers rendered `shell-integrations` behavior and continuing after practical per-item failures.
+- Create: `docs/superpowers/plans/2026-06-07-mise-shell-warning-categories.md`
+  - This implementation plan.
+
+No changes are expected in `dot_local/lib/terrapod/install-warnings.sh`: it already supports the `mise-tools` and `shell-integrations` categories, atomic replacement, `updated_at`, and marker clearing.
+
+---
+
+### Task 1: Render Failing Tests For `mise-tools`
+
+**Files:**
+- Modify: `tests/chezmoiignore_test.sh`
+
+- [ ] **Step 1: Add a `mise` installer script fixture**
+
+After the existing `mise_tools_installer` checksum assertion, add a rendered-script fixture:
+
+```sh
+mise_tools_installer_script="$tmp_dir/mise-tools-installer.sh"
+printf '%s\n' "$mise_tools_installer" >"$mise_tools_installer_script"
+sh -n "$mise_tools_installer_script" || fail "mise tool installer script should be valid sh"
+pass "mise tool installer script is valid sh"
+```
+
+- [ ] **Step 2: Add stubbed `mise` behavior**
+
+Append this setup after the rendered script fixture:
+
+```sh
+mise_tools_home="$tmp_dir/mise-tools-home"
+mise_tools_state="$tmp_dir/mise-tools-state"
+mise_tools_bin="$tmp_dir/mise-tools-bin"
+mise_tools_log="$tmp_dir/mise-tools.log"
+mkdir -p "$mise_tools_home" "$mise_tools_bin"
+
+write_stub "$mise_tools_bin/mise" \
+  'printf "%s\n" "mise args:$*" >>"$MISE_TOOLS_LOG"' \
+  'case "$1" in' \
+  '  install)' \
+  '    exit "${MISE_TOOLS_INSTALL_STATUS:-0}"' \
+  '    ;;' \
+  '  exec)' \
+  '    shift' \
+  '    while [ "$#" -gt 0 ]; do' \
+  '      case "$1" in' \
+  '        --)' \
+  '          shift' \
+  '          break' \
+  '          ;;' \
+  '      esac' \
+  '      shift' \
+  '    done' \
+  '    if [ "${1:-}" = sh ]; then' \
+  '      if [ "${MISE_TOOLS_COREPACK_PRESENT:-1}" = "1" ]; then exit 0; else exit 1; fi' \
+  '    fi' \
+  '    if [ "${1:-}" = corepack ]; then' \
+  '      exit "${MISE_TOOLS_COREPACK_STATUS:-0}"' \
+  '    fi' \
+  '    exit 64' \
+  '    ;;' \
+  'esac' \
+  'exit 64'
+```
+
+- [ ] **Step 3: Test failure marker, successful exit, and GitHub rate-limit guidance**
+
+Append this failure case:
+
+```sh
+MISE_TOOLS_INSTALL_STATUS=23
+MISE_TOOLS_COREPACK_PRESENT=1
+MISE_TOOLS_COREPACK_STATUS=0
+export MISE_TOOLS_INSTALL_STATUS MISE_TOOLS_COREPACK_PRESENT MISE_TOOLS_COREPACK_STATUS
+
+mise_tools_failure_status=0
+HOME="$mise_tools_home" \
+  XDG_STATE_HOME="$mise_tools_state" \
+  MISE_TOOLS_LOG="$mise_tools_log" \
+  PATH="$mise_tools_bin:/usr/bin:/bin" \
+  sh "$mise_tools_installer_script" >"$tmp_dir/mise-tools-failure.out" 2>"$tmp_dir/mise-tools-failure.err" || mise_tools_failure_status=$?
+
+unset MISE_TOOLS_INSTALL_STATUS MISE_TOOLS_COREPACK_PRESENT MISE_TOOLS_COREPACK_STATUS
+
+if [ "$mise_tools_failure_status" -ne 0 ]; then
+  fail "mise tool installer exits 0 after recording a mise-tools warning marker"
+fi
+pass "mise tool installer exits 0 after recording a mise-tools warning marker"
+
+mise_tools_marker="$mise_tools_state/terrapod/install-warnings/mise-tools"
+if [ ! -f "$mise_tools_marker" ]; then
+  fail "mise tool installer writes a mise-tools marker after mise install failure"
+fi
+pass "mise tool installer writes a mise-tools marker after mise install failure"
+
+mise_tools_marker_text="$(cat "$mise_tools_marker")"
+assert_contains_text "$mise_tools_marker_text" "summary='mise tool install needs attention'" "mise tools marker keeps stable summary"
+assert_contains_text "$mise_tools_marker_text" "Failed step(s): mise install" "mise tools marker guidance includes reliable failed step"
+assert_contains_text "$mise_tools_marker_text" "GITHUB_TOKEN" "mise tools marker guidance mentions temporary GITHUB_TOKEN for GitHub rate limits"
+assert_contains_text "$mise_tools_marker_text" "gh auth login" "mise tools marker guidance mentions GitHub CLI authentication for GitHub rate limits"
+```
+
+- [ ] **Step 4: Test successful rerun clears stale marker**
+
+Append this rerun case:
+
+```sh
+: >"$mise_tools_log"
+HOME="$mise_tools_home" \
+  XDG_STATE_HOME="$mise_tools_state" \
+  MISE_TOOLS_LOG="$mise_tools_log" \
+  PATH="$mise_tools_bin:/usr/bin:/bin" \
+  sh "$mise_tools_installer_script" >"$tmp_dir/mise-tools-success.out" 2>"$tmp_dir/mise-tools-success.err"
+
+if [ -e "$mise_tools_marker" ]; then
+  fail "successful mise tool rerun clears mise-tools marker"
+fi
+pass "successful mise tool rerun clears mise-tools marker"
+```
+
+- [ ] **Step 5: Test failed rerun replaces marker content**
+
+Append this replacement case:
+
+```sh
+HOME="$mise_tools_home" XDG_STATE_HOME="$mise_tools_state" sh -c \
+  '. "$1"; terrapod_install_warning_write mise-tools "stale mise warning" "stale guidance."' \
+  sh "$repo_root/dot_local/lib/terrapod/install-warnings.sh"
+
+MISE_TOOLS_INSTALL_STATUS=0
+MISE_TOOLS_COREPACK_PRESENT=1
+MISE_TOOLS_COREPACK_STATUS=44
+export MISE_TOOLS_INSTALL_STATUS MISE_TOOLS_COREPACK_PRESENT MISE_TOOLS_COREPACK_STATUS
+
+mise_tools_corepack_status=0
+HOME="$mise_tools_home" \
+  XDG_STATE_HOME="$mise_tools_state" \
+  MISE_TOOLS_LOG="$mise_tools_log" \
+  PATH="$mise_tools_bin:/usr/bin:/bin" \
+  sh "$mise_tools_installer_script" >"$tmp_dir/mise-tools-corepack.out" 2>"$tmp_dir/mise-tools-corepack.err" || mise_tools_corepack_status=$?
+
+unset MISE_TOOLS_INSTALL_STATUS MISE_TOOLS_COREPACK_PRESENT MISE_TOOLS_COREPACK_STATUS
+
+if [ "$mise_tools_corepack_status" -ne 0 ]; then
+  fail "mise tool installer exits 0 after replacing a failed corepack marker"
+fi
+pass "mise tool installer exits 0 after replacing a failed corepack marker"
+
+mise_tools_corepack_marker_text="$(cat "$mise_tools_marker")"
+assert_contains_text "$mise_tools_corepack_marker_text" "Failed step(s): corepack enable" "failed mise rerun replaces marker with current failed step"
+assert_not_contains_text "$mise_tools_corepack_marker_text" "stale guidance" "failed mise rerun replaces stale marker guidance"
+assert_contains_text "$mise_tools_corepack_marker_text" "updated_at='" "failed mise rerun writes updated_at"
+```
+
+- [ ] **Step 6: Run the new test and verify it fails before implementation**
+
+Run:
+
+```bash
+sh tests/chezmoiignore_test.sh
+```
+
+Expected: FAIL because the current `mise-tools` script still exits non-zero after marker-backed routine failures.
+
+- [ ] **Step 7: Commit the failing tests**
+
+```bash
+git add tests/chezmoiignore_test.sh docs/superpowers/plans/2026-06-07-mise-shell-warning-categories.md
+git commit -m "test: cover mise warning category recovery"
+```
+
+---
+
+### Task 2: Make `mise-tools` Marker-Backed And Non-Blocking
+
+**Files:**
+- Modify: `.chezmoiscripts/run_onchange_after_20-install-mise-tools.sh.tmpl`
+- Test: `tests/chezmoiignore_test.sh`
+
+- [ ] **Step 1: Replace the first-run-only warning exit helper**
+
+In `.chezmoiscripts/run_onchange_after_20-install-mise-tools.sh.tmpl`, replace the existing `exit_after_install_warning` body with:
+
+```sh
+exit_after_install_warning() {
+  if [ "$INSTALL_WARNING_RECORDED" -eq 1 ]; then
+    exit 0
+  fi
+
+  exit 1
+}
+```
+
+- [ ] **Step 2: Add failed-step accumulation helpers**
+
+After `clear_install_warning`, add:
+
+```sh
+failed_mise_steps=
+
+append_failed_mise_step() {
+  if [ -n "$failed_mise_steps" ]; then
+    failed_mise_steps="$failed_mise_steps, $1"
+  else
+    failed_mise_steps="$1"
+  fi
+}
+
+finish_mise_tools() {
+  if [ -n "$failed_mise_steps" ]; then
+    mark_install_warning \
+      mise-tools \
+      "mise tool install needs attention" \
+      "Failed step(s): $failed_mise_steps. Review mise output, fix tool installation issues, then rerun tpod apply. If mise aqua resolution hit GitHub API rate limits, export a temporary GITHUB_TOKEN or run gh auth login before rerunning."
+    exit_after_install_warning
+  fi
+
+  clear_install_warning mise-tools
+}
+```
+
+- [ ] **Step 3: Accumulate `mise install` failure instead of exiting immediately**
+
+Replace the current `mise install` block:
+
+```sh
+if ! mise install --yes -C "$HOME"; then
+  mark_install_warning \
+    mise-tools \
+    "mise tool install needs attention" \
+    "Review mise install output, fix tool installation issues, then rerun tpod apply."
+  exit_after_install_warning
+fi
+```
+
+with:
+
+```sh
+if ! mise install --yes -C "$HOME"; then
+  append_failed_mise_step "mise install"
+fi
+```
+
+- [ ] **Step 4: Accumulate `corepack enable` failure**
+
+Replace the current `corepack enable` block:
+
+```sh
+if mise exec --yes -C "$HOME" -- sh -c 'command -v corepack' >/dev/null 2>&1; then
+  if ! mise exec --yes -C "$HOME" -- corepack enable; then
+    mark_install_warning \
+      mise-tools \
+      "mise tool install needs attention" \
+      "Review corepack enable output, then rerun tpod apply."
+    exit_after_install_warning
+  fi
+fi
+
+clear_install_warning mise-tools
+```
+
+with:
+
+```sh
+if mise exec --yes -C "$HOME" -- sh -c 'command -v corepack' >/dev/null 2>&1; then
+  if ! mise exec --yes -C "$HOME" -- corepack enable; then
+    append_failed_mise_step "corepack enable"
+  fi
+fi
+
+finish_mise_tools
+```
+
+- [ ] **Step 5: Keep missing `mise` as a marker-backed category failure**
+
+Leave `setup_mise` calls to `mark_install_warning ...; exit_after_install_warning` in place. With the new helper, a successful marker write exits 0 in routine and first-run applies; a marker-write failure exits 1.
+
+- [ ] **Step 6: Run the targeted test**
+
+Run:
+
+```bash
+sh tests/chezmoiignore_test.sh
+```
+
+Expected: PASS for new `mise-tools` assertions and existing Optional AI / desktop app assertions.
+
+- [ ] **Step 7: Commit the implementation**
+
+```bash
+git add .chezmoiscripts/run_onchange_after_20-install-mise-tools.sh.tmpl tests/chezmoiignore_test.sh
+git commit -m "fix: make mise warnings non-blocking"
+```
+
+---
+
+### Task 3: Render Failing Tests For `shell-integrations`
+
+**Files:**
+- Modify: `tests/shell_integrations_test.sh`
+
+- [ ] **Step 1: Update the routine curl-failure expectation**
+
+Replace the current block that expects `sh "$rendered"` to fail on `SHELL_INTEGRATIONS_CURL_STATUS=23` with:
+
+```sh
+if ! sh "$rendered" >"$tmp_dir/shell-integrations-curl-failure.out" 2>"$tmp_dir/shell-integrations-curl-failure.err"; then
+  unset SHELL_INTEGRATIONS_CURL_STATUS
+  fail "shell integrations exits 0 after recording an Oh My Zsh warning marker"
+fi
+unset SHELL_INTEGRATIONS_CURL_STATUS
+pass "shell integrations exits 0 after recording an Oh My Zsh warning marker"
+```
+
+- [ ] **Step 2: Update the remaining-item assertion**
+
+Replace:
+
+```sh
+assert_not_contains "$test_log" "git args:clone https://github.com/zdharma-continuum/zinit" "shell integrations stops before zinit when Oh My Zsh download fails"
+```
+
+with:
+
+```sh
+assert_contains "$test_log" "git args:clone https://github.com/zdharma-continuum/zinit" "shell integrations continues to zinit after Oh My Zsh download fails"
+assert_contains "$test_log" "git args:clone https://github.com/scmbreeze/scm_breeze.git" "shell integrations continues to SCM Breeze after Oh My Zsh download fails"
+```
+
+- [ ] **Step 3: Add failed rerun replacement coverage**
+
+After the marker text assertions for the first failure, add:
+
+```sh
+first_marker_text="$marker_text"
+: >"$SHELL_INTEGRATIONS_TEST_LOG"
+SHELL_INTEGRATIONS_CURL_STATUS=0
+export SHELL_INTEGRATIONS_CURL_STATUS
+SHELL_INTEGRATIONS_ZINIT_STATUS=31
+export SHELL_INTEGRATIONS_ZINIT_STATUS
+if ! sh "$rendered" >"$tmp_dir/shell-integrations-zinit-failure.out" 2>"$tmp_dir/shell-integrations-zinit-failure.err"; then
+  unset SHELL_INTEGRATIONS_CURL_STATUS SHELL_INTEGRATIONS_ZINIT_STATUS
+  fail "shell integrations exits 0 after replacing a zinit warning marker"
+fi
+unset SHELL_INTEGRATIONS_CURL_STATUS SHELL_INTEGRATIONS_ZINIT_STATUS
+
+replacement_marker_text="$(cat "$shell_integrations_marker")"
+assert_contains "$replacement_marker_text" "zinit" "failed shell integration rerun replaces marker with current failed item"
+assert_not_contains "$replacement_marker_text" "Oh My Zsh" "failed shell integration rerun replaces stale failed item detail"
+assert_contains "$replacement_marker_text" "updated_at='" "failed shell integration rerun writes updated_at"
+if [ "$replacement_marker_text" = "$first_marker_text" ]; then
+  fail "failed shell integration rerun changes marker content"
+fi
+pass "failed shell integration rerun changes marker content"
+```
+
+- [ ] **Step 4: Add successful rerun clearing coverage**
+
+After the replacement coverage, add:
+
+```sh
+: >"$SHELL_INTEGRATIONS_TEST_LOG"
+if ! sh "$rendered" >"$tmp_dir/shell-integrations-success.out" 2>"$tmp_dir/shell-integrations-success.err"; then
+  fail "successful shell integrations rerun exits 0"
+fi
+
+if [ -e "$shell_integrations_marker" ]; then
+  fail "successful shell integrations rerun clears shell-integrations marker"
+fi
+pass "successful shell integrations rerun clears shell-integrations marker"
+```
+
+- [ ] **Step 5: Teach the git stub to simulate zinit failure**
+
+In the `write_stub "$tmp_dir/bin/git"` block, replace the zinit clone handler:
+
+```sh
+if [ "$1" = clone ] && [ "$2" = https://github.com/zdharma-continuum/zinit ]; then
+  mkdir -p "$3"
+  exit 0
+fi
+```
+
+with:
+
+```sh
+if [ "$1" = clone ] && [ "$2" = https://github.com/zdharma-continuum/zinit ]; then
+  if [ "${SHELL_INTEGRATIONS_ZINIT_STATUS:-0}" != "0" ]; then
+    exit "$SHELL_INTEGRATIONS_ZINIT_STATUS"
+  fi
+  mkdir -p "$3"
+  exit 0
+fi
+```
+
+- [ ] **Step 6: Run the new test and verify it fails before implementation**
+
+Run:
+
+```bash
+sh tests/shell_integrations_test.sh
+```
+
+Expected: FAIL because the current script exits after the first Oh My Zsh failure and does not continue to zinit or SCM Breeze.
+
+- [ ] **Step 7: Commit the failing tests**
+
+```bash
+git add tests/shell_integrations_test.sh
+git commit -m "test: cover shell integration warning recovery"
+```
+
+---
+
+### Task 4: Make `shell-integrations` Marker-Backed And Non-Blocking
+
+**Files:**
+- Modify: `.chezmoiscripts/run_onchange_before_30-install-shell-integrations.sh.tmpl`
+- Test: `tests/shell_integrations_test.sh`
+
+- [ ] **Step 1: Replace the first-run-only warning exit helper**
+
+In `.chezmoiscripts/run_onchange_before_30-install-shell-integrations.sh.tmpl`, replace the existing `exit_after_install_warning` body with:
+
+```sh
+exit_after_install_warning() {
+  if [ "$INSTALL_WARNING_RECORDED" -eq 1 ]; then
+    exit 0
+  fi
+
+  exit 1
+}
+```
+
+- [ ] **Step 2: Add failure accumulation helpers**
+
+After `clear_install_warning`, add:
+
+```sh
+failed_shell_integrations=
+
+append_failed_shell_integration() {
+  if [ -n "$failed_shell_integrations" ]; then
+    failed_shell_integrations="$failed_shell_integrations, $1"
+  else
+    failed_shell_integrations="$1"
+  fi
+}
+
+finish_shell_integrations() {
+  if [ -n "$failed_shell_integrations" ]; then
+    mark_install_warning \
+      shell-integrations \
+      "Shell integration setup needs attention" \
+      "Failed item(s): $failed_shell_integrations. Review installer output, fix network or installer requirements, then rerun tpod apply."
+    exit_after_install_warning
+  fi
+
+  clear_install_warning shell-integrations
+}
+```
+
+- [ ] **Step 3: Convert Oh My Zsh install to accumulated failure**
+
+Replace the current Oh My Zsh block with:
+
+```sh
+if [ ! -d "$HOME/.oh-my-zsh" ]; then
+  echo "Installing Oh My Zsh..."
+  oh_my_zsh_installer="$(mktemp "${TMPDIR:-/tmp}/terrapod-oh-my-zsh-installer.XXXXXX")"
+  installer_paths="$installer_paths $oh_my_zsh_installer"
+  if curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh -o "$oh_my_zsh_installer"; then
+    if ! sh "$oh_my_zsh_installer" --unattended --keep-zshrc; then
+      append_failed_shell_integration "Oh My Zsh"
+    fi
+  else
+    append_failed_shell_integration "Oh My Zsh"
+  fi
+fi
+```
+
+- [ ] **Step 4: Convert zinit install to accumulated failure**
+
+Replace the current zinit block with:
+
+```sh
+if [ ! -d "$HOME/.local/share/zinit/zinit.git" ]; then
+  echo "Installing zinit..."
+  mkdir -p "$HOME/.local/share/zinit"
+  if ! git clone https://github.com/zdharma-continuum/zinit "$HOME/.local/share/zinit/zinit.git"; then
+    append_failed_shell_integration "zinit"
+  fi
+fi
+```
+
+- [ ] **Step 5: Convert SCM Breeze install to accumulated failure**
+
+Replace the current SCM Breeze block with:
+
+```sh
+if [ ! -d "$HOME/.scm_breeze" ]; then
+  echo "Installing SCM Breeze..."
+  if git clone https://github.com/scmbreeze/scm_breeze.git "$HOME/.scm_breeze"; then
+    if ! "$HOME/.scm_breeze/install.sh"; then
+      append_failed_shell_integration "SCM Breeze"
+    fi
+  else
+    append_failed_shell_integration "SCM Breeze"
+  fi
+fi
+```
+
+- [ ] **Step 6: Finish by writing or clearing the marker**
+
+Replace the final line:
+
+```sh
+clear_install_warning shell-integrations
+```
+
+with:
+
+```sh
+finish_shell_integrations
+```
+
+- [ ] **Step 7: Run the targeted test**
+
+Run:
+
+```bash
+sh tests/shell_integrations_test.sh
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit the implementation**
+
+```bash
+git add .chezmoiscripts/run_onchange_before_30-install-shell-integrations.sh.tmpl tests/shell_integrations_test.sh
+git commit -m "fix: make shell integration warnings non-blocking"
+```
+
+---
+
+### Task 5: Integration Verification And PR Readiness
+
+**Files:**
+- Verify all modified files.
+
+- [ ] **Step 1: Run syntax checks**
+
+Run:
+
+```bash
+sh -n .chezmoiscripts/run_onchange_after_20-install-mise-tools.sh.tmpl
+sh -n .chezmoiscripts/run_onchange_before_30-install-shell-integrations.sh.tmpl
+sh -n tests/chezmoiignore_test.sh
+sh -n tests/shell_integrations_test.sh
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run targeted tests**
+
+Run:
+
+```bash
+sh tests/chezmoiignore_test.sh
+sh tests/shell_integrations_test.sh
+sh tests/terrapod_command_test.sh
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run full test suite**
+
+Run:
+
+```bash
+for test_script in tests/*.sh; do sh "$test_script" || exit $?; done
+for test_script in tests/*.zsh; do zsh "$test_script" || exit $?; done
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Review final diff**
+
+Run:
+
+```bash
+git diff --stat
+git diff -- .chezmoiscripts/run_onchange_after_20-install-mise-tools.sh.tmpl .chezmoiscripts/run_onchange_before_30-install-shell-integrations.sh.tmpl tests/chezmoiignore_test.sh tests/shell_integrations_test.sh docs/superpowers/plans/2026-06-07-mise-shell-warning-categories.md
+```
+
+Expected: Diff only contains Issue #102 plan, tests, and the two installer-template changes.
+
+- [ ] **Step 5: Commit any remaining changes**
+
+If previous task commits were combined by the executor, make one final commit:
+
+```bash
+git add .chezmoiscripts/run_onchange_after_20-install-mise-tools.sh.tmpl .chezmoiscripts/run_onchange_before_30-install-shell-integrations.sh.tmpl tests/chezmoiignore_test.sh tests/shell_integrations_test.sh docs/superpowers/plans/2026-06-07-mise-shell-warning-categories.md
+git commit -m "fix: recover mise and shell warning categories"
+```
+
+Expected: Branch has committed changes ready to push.
+
+---
+
+## Self-Review
+
+- Spec coverage: The plan covers marker writes for `mise-tools` and `shell-integrations`, non-blocking successful exits after marker writes, marker clearing on success, marker replacement on failed reruns, remaining item attempts for shell integrations, reliable failed-step detail, GitHub rate-limit guidance for mise, and tests for the requested cases.
+- Placeholder scan: No `TBD`, `TODO`, or unspecified "add tests" placeholders remain.
+- Type and name consistency: Category names are `mise-tools` and `shell-integrations`; helper names are local to each script and do not require shared library changes.

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -789,10 +789,30 @@ assert_managed_paths_include_prefix \
   ".chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl" \
   "Ubuntu VPS includes Optional AI Tool Stack warning cleanup by default"
 
+assert_managed_paths_include_prefix \
+  "$ubuntu_managed" \
+  ".chezmoiscripts/run_after_21-retry-mise-tools.sh.tmpl" \
+  "Ubuntu VPS includes marker-gated mise tool retry hook"
+
+assert_managed_paths_include_prefix \
+  "$ubuntu_managed" \
+  ".chezmoiscripts/run_before_31-retry-shell-integrations.sh.tmpl" \
+  "Ubuntu VPS includes marker-gated shell integration retry hook"
+
 assert_managed_paths_exclude_prefix \
   "$macos_managed" \
   "dot_config/nvim" \
   "macOS ignores Optional Editor Stack entries by default"
+
+assert_managed_paths_include_prefix \
+  "$macos_managed" \
+  ".chezmoiscripts/run_after_21-retry-mise-tools.sh.tmpl" \
+  "macOS includes marker-gated mise tool retry hook"
+
+assert_managed_paths_include_prefix \
+  "$macos_managed" \
+  ".chezmoiscripts/run_before_31-retry-shell-integrations.sh.tmpl" \
+  "macOS includes marker-gated shell integration retry hook"
 
 if [ -e "$repo_root/dot_config/zsh/path.d/antigravity.zsh.tmpl" ]; then
   fail "legacy Antigravity app-bundle PATH snippet is no longer managed"
@@ -855,6 +875,7 @@ fi
 pass "Ubuntu VPS installs GitHub CLI gh in the Core Shell Stack"
 
 mise_tools_installer="$(render_template "$ubuntu_data" ".chezmoiscripts/run_onchange_after_20-install-mise-tools.sh.tmpl")"
+mise_tools_retry="$(render_template "$ubuntu_data" ".chezmoiscripts/run_after_21-retry-mise-tools.sh.tmpl")"
 
 if ! printf '%s\n' "$mise_tools_installer" |
   grep -E '^# mise-config-sha256=[0-9a-f]{64}$' >/dev/null; then
@@ -867,6 +888,11 @@ mise_tools_installer_script="$tmp_dir/mise-tools-installer.sh"
 printf '%s\n' "$mise_tools_installer" >"$mise_tools_installer_script"
 sh -n "$mise_tools_installer_script" || fail "mise tool installer script should be valid sh"
 pass "mise tool installer script should be valid sh"
+
+mise_tools_retry_script="$tmp_dir/mise-tools-retry.sh"
+printf '%s\n' "$mise_tools_retry" >"$mise_tools_retry_script"
+sh -n "$mise_tools_retry_script" || fail "mise tool retry script should be valid sh"
+pass "mise tool retry script should be valid sh"
 
 mise_tools_bin="$tmp_dir/mise-tools-bin"
 mise_tools_state="$tmp_dir/mise-tools-state"
@@ -954,6 +980,59 @@ assert_contains_text "$mise_tools_marker_text" "summary='mise tool install needs
 assert_contains_text "$mise_tools_marker_text" "Failed step(s): corepack enable" "mise tool installer replaces stale marker with corepack enable failure"
 assert_not_contains_text "$mise_tools_marker_text" "stale guidance" "mise tool installer replaces stale marker guidance"
 assert_contains_text "$mise_tools_marker_text" "updated_at='" "mise tool installer replacement marker includes update timestamp"
+
+: >"$mise_tools_log"
+HOME="$mise_tools_home" \
+  XDG_STATE_HOME="$mise_tools_state" \
+  MISE_TOOLS_LOG="$mise_tools_log" \
+  PATH="$mise_tools_bin:/usr/bin:/bin" \
+  sh "$mise_tools_retry_script"
+if [ -e "$mise_tools_marker" ]; then
+  fail "mise tool retry should clear stale mise-tools marker after a successful retry"
+fi
+pass "mise tool retry clears stale mise-tools marker after a successful retry"
+mise_tools_retry_log_text="$(cat "$mise_tools_log")"
+assert_contains_text "$mise_tools_retry_log_text" "mise args:install --yes -C $mise_tools_home" "mise tool retry attempts mise install when marker exists"
+
+: >"$mise_tools_log"
+HOME="$mise_tools_home" \
+  XDG_STATE_HOME="$mise_tools_state" \
+  MISE_TOOLS_LOG="$mise_tools_log" \
+  MISE_TOOLS_INSTALL_STATUS=17 \
+  PATH="$mise_tools_bin:/usr/bin:/bin" \
+  sh "$mise_tools_retry_script"
+if [ -s "$mise_tools_log" ]; then
+  fail "mise tool retry should be a no-op when no marker exists"
+fi
+pass "mise tool retry is a no-op when no marker exists"
+
+HOME="$mise_tools_home" XDG_STATE_HOME="$mise_tools_state" sh -c \
+  '. "$1"; terrapod_install_warning_write mise-tools "mise tool install needs attention" "Previous mise warning."' \
+  sh "$repo_root/dot_local/lib/terrapod/install-warnings.sh"
+: >"$mise_tools_log"
+HOME="$mise_tools_home" \
+  XDG_STATE_HOME="$mise_tools_state" \
+  MISE_TOOLS_LOG="$mise_tools_log" \
+  MISE_TOOLS_INSTALL_STATUS=17 \
+  PATH="$mise_tools_bin:/usr/bin:/bin" \
+  sh "$mise_tools_retry_script"
+if [ ! -f "$mise_tools_marker" ]; then
+  fail "mise tool retry should keep a warning marker when retry still fails"
+fi
+pass "mise tool retry keeps a warning marker when retry still fails"
+mise_tools_marker_text="$(cat "$mise_tools_marker")"
+assert_contains_text "$mise_tools_marker_text" "Failed step(s): mise install" "mise tool retry replacement marker records failed mise install step"
+
+: >"$mise_tools_log"
+HOME="$mise_tools_home" \
+  XDG_STATE_HOME="$mise_tools_state" \
+  MISE_TOOLS_LOG="$mise_tools_log" \
+  PATH="$mise_tools_bin:/usr/bin:/bin" \
+  sh "$mise_tools_retry_script"
+if [ -e "$mise_tools_marker" ]; then
+  fail "mise tool retry should clear warning marker after recovery"
+fi
+pass "mise tool retry clears warning marker after recovery"
 
 ai_cli_tools_installer="$(render_template "$ai_cli_tools_data" ".chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl")"
 development_workspace_ai_installer="$(render_template "$development_workspace_data" ".chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl")"

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -863,6 +863,98 @@ fi
 
 pass "mise tool installer tracks rendered mise config changes"
 
+mise_tools_installer_script="$tmp_dir/mise-tools-installer.sh"
+printf '%s\n' "$mise_tools_installer" >"$mise_tools_installer_script"
+sh -n "$mise_tools_installer_script" || fail "mise tool installer script should be valid sh"
+pass "mise tool installer script should be valid sh"
+
+mise_tools_bin="$tmp_dir/mise-tools-bin"
+mise_tools_state="$tmp_dir/mise-tools-state"
+mise_tools_home="$tmp_dir/mise-tools-home"
+mise_tools_log="$tmp_dir/mise-tools.log"
+mkdir -p "$mise_tools_bin" "$mise_tools_home"
+write_stub "$mise_tools_bin/mise" \
+  'printf "%s\n" "mise args:$*" >>"$MISE_TOOLS_LOG"' \
+  'case "$1" in' \
+  '  install)' \
+  '    exit "${MISE_TOOLS_INSTALL_STATUS:-0}"' \
+  '    ;;' \
+  '  exec)' \
+  '    shift' \
+  '    while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do' \
+  '      shift' \
+  '    done' \
+  '    if [ "$#" -gt 0 ]; then' \
+  '      shift' \
+  '    fi' \
+  '    case "$*" in' \
+  '      "sh -c command -v corepack")' \
+  '        if [ "${MISE_TOOLS_COREPACK_PRESENT:-1}" = "1" ]; then' \
+  '          exit 0' \
+  '        fi' \
+  '        exit 1' \
+  '        ;;' \
+  '      "corepack enable")' \
+  '        exit "${MISE_TOOLS_COREPACK_STATUS:-0}"' \
+  '        ;;' \
+  '    esac' \
+  '    ;;' \
+  'esac' \
+  'exit 0'
+
+mise_tools_install_failure_status=0
+HOME="$mise_tools_home" \
+  XDG_STATE_HOME="$mise_tools_state" \
+  MISE_TOOLS_LOG="$mise_tools_log" \
+  MISE_TOOLS_INSTALL_STATUS=17 \
+  PATH="$mise_tools_bin:/usr/bin:/bin" \
+  sh "$mise_tools_installer_script" || mise_tools_install_failure_status=$?
+if [ "$mise_tools_install_failure_status" -ne 0 ]; then
+  fail "mise tool installer should continue after recording a mise install warning"
+fi
+mise_tools_marker="$mise_tools_state/terrapod/install-warnings/mise-tools"
+if [ ! -f "$mise_tools_marker" ]; then
+  fail "mise tool installer should write a mise-tools warning marker after mise install failure"
+fi
+mise_tools_marker_text="$(cat "$mise_tools_marker")"
+assert_contains_text "$mise_tools_marker_text" "summary='mise tool install needs attention'" "mise install failure marker keeps the expected summary"
+assert_contains_text "$mise_tools_marker_text" "Failed step(s): mise install" "mise install failure marker records failed mise install step"
+assert_contains_text "$mise_tools_marker_text" "GITHUB_TOKEN" "mise install failure marker suggests GitHub token recovery"
+assert_contains_text "$mise_tools_marker_text" "gh auth login" "mise install failure marker suggests GitHub auth recovery"
+mise_tools_log_text="$(cat "$mise_tools_log")"
+assert_contains_text "$mise_tools_log_text" "mise args:install --yes -C $mise_tools_home" "mise install failure still attempts mise install"
+assert_contains_text "$mise_tools_log_text" "mise args:exec --yes -C $mise_tools_home -- sh -c command -v corepack" "mise install failure still checks corepack availability"
+assert_contains_text "$mise_tools_log_text" "mise args:exec --yes -C $mise_tools_home -- corepack enable" "mise install failure still attempts corepack enable"
+
+HOME="$mise_tools_home" \
+  XDG_STATE_HOME="$mise_tools_state" \
+  MISE_TOOLS_LOG="$mise_tools_log" \
+  PATH="$mise_tools_bin:/usr/bin:/bin" \
+  sh "$mise_tools_installer_script"
+if [ -e "$mise_tools_marker" ]; then
+  fail "mise tool installer should clear stale mise-tools marker after a successful rerun"
+fi
+pass "mise tool installer clears stale mise-tools marker after successful rerun"
+
+mkdir -p "$mise_tools_state/terrapod/install-warnings"
+printf '%s\n' \
+  "category='mise-tools'" \
+  "summary='mise tool install needs attention'" \
+  "guidance='stale guidance'" \
+  "updated_at='2026-01-01T00:00:00Z'" \
+  >"$mise_tools_marker"
+HOME="$mise_tools_home" \
+  XDG_STATE_HOME="$mise_tools_state" \
+  MISE_TOOLS_LOG="$mise_tools_log" \
+  MISE_TOOLS_COREPACK_STATUS=23 \
+  PATH="$mise_tools_bin:/usr/bin:/bin" \
+  sh "$mise_tools_installer_script"
+mise_tools_marker_text="$(cat "$mise_tools_marker")"
+assert_contains_text "$mise_tools_marker_text" "summary='mise tool install needs attention'" "mise tool installer replacement marker keeps the expected summary"
+assert_contains_text "$mise_tools_marker_text" "Failed step(s): corepack enable" "mise tool installer replaces stale marker with corepack enable failure"
+assert_not_contains_text "$mise_tools_marker_text" "stale guidance" "mise tool installer replaces stale marker guidance"
+assert_contains_text "$mise_tools_marker_text" "updated_at='" "mise tool installer replacement marker includes update timestamp"
+
 ai_cli_tools_installer="$(render_template "$ai_cli_tools_data" ".chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl")"
 development_workspace_ai_installer="$(render_template "$development_workspace_data" ".chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl")"
 disabled_ai_cli_tools_cleanup="$(render_template "$ubuntu_data" ".chezmoiscripts/run_onchange_before_60-install-ai-cli-tools.sh.tmpl")"

--- a/tests/shell_integrations_test.sh
+++ b/tests/shell_integrations_test.sh
@@ -61,8 +61,18 @@ chezmoi execute-template \
   --file "$repo_root/.chezmoiscripts/run_onchange_before_30-install-shell-integrations.sh.tmpl" \
   >"$rendered"
 
+retry_rendered="$tmp_dir/shell-integrations-retry.sh"
+chezmoi execute-template \
+  --source "$repo_root" \
+  --override-data '{"chezmoi":{"os":"linux"}}' \
+  --file "$repo_root/.chezmoiscripts/run_before_31-retry-shell-integrations.sh.tmpl" \
+  >"$retry_rendered"
+
 sh -n "$rendered" || fail "rendered shell integrations script should be valid sh"
 pass "rendered shell integrations script is valid sh"
+
+sh -n "$retry_rendered" || fail "rendered shell integrations retry script should be valid sh"
+pass "rendered shell integrations retry script is valid sh"
 
 write_stub "$tmp_dir/bin/curl" \
   'printf "%s\n" "curl args:$*" >>"$SHELL_INTEGRATIONS_TEST_LOG"' \
@@ -90,6 +100,61 @@ export PATH="$tmp_dir/bin:/usr/bin:/bin"
 export HOME="$tmp_dir/home"
 export XDG_STATE_HOME="$tmp_dir/state"
 export SHELL_INTEGRATIONS_TEST_LOG="$tmp_dir/shell-integrations.log"
+
+retry_no_marker_home="$tmp_dir/retry-no-marker-home"
+retry_no_marker_state="$tmp_dir/retry-no-marker-state"
+retry_no_marker_log="$tmp_dir/retry-no-marker-shell-integrations.log"
+mkdir -p "$retry_no_marker_home"
+: >"$retry_no_marker_log"
+HOME="$retry_no_marker_home" \
+  XDG_STATE_HOME="$retry_no_marker_state" \
+  SHELL_INTEGRATIONS_TEST_LOG="$retry_no_marker_log" \
+  SHELL_INTEGRATIONS_CURL_STATUS=23 \
+  PATH="$tmp_dir/bin:/usr/bin:/bin" \
+  sh "$retry_rendered" >"$tmp_dir/shell-integrations-retry-no-marker.out" 2>"$tmp_dir/shell-integrations-retry-no-marker.err"
+if [ -s "$retry_no_marker_log" ]; then
+  fail "shell integrations retry should be a no-op when no marker exists"
+fi
+pass "shell integrations retry is a no-op when no marker exists"
+
+retry_home="$tmp_dir/retry-home"
+retry_state="$tmp_dir/retry-state"
+retry_log="$tmp_dir/retry-shell-integrations.log"
+mkdir -p "$retry_home"
+: >"$retry_log"
+HOME="$retry_home" XDG_STATE_HOME="$retry_state" sh -c \
+  '. "$1"; terrapod_install_warning_write shell-integrations "Shell integration setup needs attention" "Previous shell integration warning."' \
+  sh "$repo_root/dot_local/lib/terrapod/install-warnings.sh"
+
+SHELL_INTEGRATIONS_CURL_STATUS=23 \
+  HOME="$retry_home" \
+  XDG_STATE_HOME="$retry_state" \
+  SHELL_INTEGRATIONS_TEST_LOG="$retry_log" \
+  PATH="$tmp_dir/bin:/usr/bin:/bin" \
+  sh "$retry_rendered" >"$tmp_dir/shell-integrations-retry-curl-failure.out" 2>"$tmp_dir/shell-integrations-retry-curl-failure.err"
+
+retry_marker="$retry_state/terrapod/install-warnings/shell-integrations"
+if [ ! -f "$retry_marker" ]; then
+  fail "shell integrations retry should keep a warning marker when retry still fails"
+fi
+pass "shell integrations retry keeps a warning marker when retry still fails"
+
+retry_marker_text="$(cat "$retry_marker")"
+assert_contains "$retry_marker_text" "Oh My Zsh" "shell integrations retry marker mentions the failed Oh My Zsh step"
+retry_log_text="$(cat "$retry_log")"
+assert_contains "$retry_log_text" "curl args:-fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh" "shell integrations retry attempts Oh My Zsh when marker exists"
+assert_contains "$retry_log_text" "git args:clone https://github.com/zdharma-continuum/zinit" "shell integrations retry continues to zinit when Oh My Zsh fails"
+
+: >"$retry_log"
+HOME="$retry_home" \
+  XDG_STATE_HOME="$retry_state" \
+  SHELL_INTEGRATIONS_TEST_LOG="$retry_log" \
+  PATH="$tmp_dir/bin:/usr/bin:/bin" \
+  sh "$retry_rendered" >"$tmp_dir/shell-integrations-retry-recovery.out" 2>"$tmp_dir/shell-integrations-retry-recovery.err"
+if [ -e "$retry_marker" ]; then
+  fail "shell integrations retry should clear warning marker after recovery"
+fi
+pass "shell integrations retry clears warning marker after recovery"
 
 HOME="$HOME" XDG_STATE_HOME="$XDG_STATE_HOME" sh -c \
   '. "$1"; terrapod_install_warning_write shell-integrations "Shell integration setup needs attention" "Previous shell integration warning."' \

--- a/tests/shell_integrations_test.sh
+++ b/tests/shell_integrations_test.sh
@@ -86,6 +86,7 @@ write_stub "$tmp_dir/bin/git" \
   '    exit "$zinit_status"' \
   '  fi' \
   '  mkdir -p "$3"' \
+  '  : >"$3/zinit.zsh"' \
   '  exit 0' \
   'fi' \
   'if [ "$1" = clone ] && [ "$2" = https://github.com/scmbreeze/scm_breeze.git ]; then' \
@@ -155,6 +156,68 @@ if [ -e "$retry_marker" ]; then
   fail "shell integrations retry should clear warning marker after recovery"
 fi
 pass "shell integrations retry clears warning marker after recovery"
+
+partial_retry_home="$tmp_dir/partial-retry-home"
+partial_retry_state="$tmp_dir/partial-retry-state"
+partial_retry_log="$tmp_dir/partial-retry-shell-integrations.log"
+mkdir -p \
+  "$partial_retry_home/.oh-my-zsh" \
+  "$partial_retry_home/.local/share/zinit/zinit.git" \
+  "$partial_retry_home/.scm_breeze"
+write_stub "$partial_retry_home/.scm_breeze/install.sh" \
+  'printf "%s\n" "scm-breeze install" >>"$SHELL_INTEGRATIONS_TEST_LOG"' \
+  'exit 0'
+: >"$partial_retry_log"
+HOME="$partial_retry_home" XDG_STATE_HOME="$partial_retry_state" sh -c \
+  '. "$1"; terrapod_install_warning_write shell-integrations "Shell integration setup needs attention" "Previous shell integration warning."' \
+  sh "$repo_root/dot_local/lib/terrapod/install-warnings.sh"
+
+HOME="$partial_retry_home" \
+  XDG_STATE_HOME="$partial_retry_state" \
+  SHELL_INTEGRATIONS_TEST_LOG="$partial_retry_log" \
+  PATH="$tmp_dir/bin:/usr/bin:/bin" \
+  sh "$retry_rendered" >"$tmp_dir/shell-integrations-retry-partial-dirs.out" 2>"$tmp_dir/shell-integrations-retry-partial-dirs.err"
+
+partial_retry_marker="$partial_retry_state/terrapod/install-warnings/shell-integrations"
+if [ ! -f "$partial_retry_marker" ]; then
+  fail "shell integrations retry should keep marker when previous failures left partial directories"
+fi
+pass "shell integrations retry keeps marker when previous failures left partial directories"
+
+partial_retry_marker_text="$(cat "$partial_retry_marker")"
+assert_contains "$partial_retry_marker_text" "Oh My Zsh" "shell integrations retry marker keeps partial Oh My Zsh warning"
+assert_contains "$partial_retry_marker_text" "zinit" "shell integrations retry marker keeps partial zinit warning"
+
+partial_onchange_home="$tmp_dir/partial-onchange-home"
+partial_onchange_state="$tmp_dir/partial-onchange-state"
+partial_onchange_log="$tmp_dir/partial-onchange-shell-integrations.log"
+mkdir -p \
+  "$partial_onchange_home/.oh-my-zsh" \
+  "$partial_onchange_home/.local/share/zinit/zinit.git" \
+  "$partial_onchange_home/.scm_breeze"
+write_stub "$partial_onchange_home/.scm_breeze/install.sh" \
+  'printf "%s\n" "scm-breeze install" >>"$SHELL_INTEGRATIONS_TEST_LOG"' \
+  'exit 0'
+: >"$partial_onchange_log"
+HOME="$partial_onchange_home" XDG_STATE_HOME="$partial_onchange_state" sh -c \
+  '. "$1"; terrapod_install_warning_write shell-integrations "Shell integration setup needs attention" "Previous shell integration warning."' \
+  sh "$repo_root/dot_local/lib/terrapod/install-warnings.sh"
+
+HOME="$partial_onchange_home" \
+  XDG_STATE_HOME="$partial_onchange_state" \
+  SHELL_INTEGRATIONS_TEST_LOG="$partial_onchange_log" \
+  PATH="$tmp_dir/bin:/usr/bin:/bin" \
+  sh "$rendered" >"$tmp_dir/shell-integrations-onchange-partial-dirs.out" 2>"$tmp_dir/shell-integrations-onchange-partial-dirs.err"
+
+partial_onchange_marker="$partial_onchange_state/terrapod/install-warnings/shell-integrations"
+if [ ! -f "$partial_onchange_marker" ]; then
+  fail "shell integrations onchange should keep marker when previous failures left partial directories"
+fi
+pass "shell integrations onchange keeps marker when previous failures left partial directories"
+
+partial_onchange_marker_text="$(cat "$partial_onchange_marker")"
+assert_contains "$partial_onchange_marker_text" "Oh My Zsh" "shell integrations onchange marker keeps partial Oh My Zsh warning"
+assert_contains "$partial_onchange_marker_text" "zinit" "shell integrations onchange marker keeps partial zinit warning"
 
 HOME="$HOME" XDG_STATE_HOME="$XDG_STATE_HOME" sh -c \
   '. "$1"; terrapod_install_warning_write shell-integrations "Shell integration setup needs attention" "Previous shell integration warning."' \

--- a/tests/shell_integrations_test.sh
+++ b/tests/shell_integrations_test.sh
@@ -71,12 +71,16 @@ write_stub "$tmp_dir/bin/curl" \
 write_stub "$tmp_dir/bin/git" \
   'printf "%s\n" "git args:$*" >>"$SHELL_INTEGRATIONS_TEST_LOG"' \
   'if [ "$1" = clone ] && [ "$2" = https://github.com/zdharma-continuum/zinit ]; then' \
+  '  zinit_status="${SHELL_INTEGRATIONS_ZINIT_STATUS:-0}"' \
+  '  if [ "$zinit_status" -ne 0 ]; then' \
+  '    exit "$zinit_status"' \
+  '  fi' \
   '  mkdir -p "$3"' \
   '  exit 0' \
   'fi' \
   'if [ "$1" = clone ] && [ "$2" = https://github.com/scmbreeze/scm_breeze.git ]; then' \
   '  mkdir -p "$3"' \
-  '  printf "%s\n" "#!/bin/sh" "exit 0" >"$3/install.sh"' \
+  '  printf "%s\n" "#!/bin/sh" "printf \"%s\\n\" \"scm-breeze install\" >>\"\$SHELL_INTEGRATIONS_TEST_LOG\"" "exit \"\${SHELL_INTEGRATIONS_SCM_INSTALL_STATUS:-0}\"" >"$3/install.sh"' \
   '  chmod +x "$3/install.sh"' \
   '  exit 0' \
   'fi' \
@@ -93,9 +97,9 @@ HOME="$HOME" XDG_STATE_HOME="$XDG_STATE_HOME" sh -c \
 
 SHELL_INTEGRATIONS_CURL_STATUS=23
 export SHELL_INTEGRATIONS_CURL_STATUS
-if sh "$rendered" >"$tmp_dir/shell-integrations-curl-failure.out" 2>"$tmp_dir/shell-integrations-curl-failure.err"; then
+if ! sh "$rendered" >"$tmp_dir/shell-integrations-curl-failure.out" 2>"$tmp_dir/shell-integrations-curl-failure.err"; then
   unset SHELL_INTEGRATIONS_CURL_STATUS
-  fail "shell integrations should fail when the Oh My Zsh installer download fails"
+  fail "shell integrations should continue after recording an Oh My Zsh installer download warning"
 fi
 unset SHELL_INTEGRATIONS_CURL_STATUS
 
@@ -111,7 +115,48 @@ assert_contains "$marker_text" "Oh My Zsh" "shell integrations marker mentions t
 
 test_log="$(cat "$SHELL_INTEGRATIONS_TEST_LOG")"
 assert_contains "$test_log" "curl args:-fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh" "shell integrations attempts to download the Oh My Zsh installer"
-assert_not_contains "$test_log" "git args:clone https://github.com/zdharma-continuum/zinit" "shell integrations stops before zinit when Oh My Zsh download fails"
+assert_contains "$test_log" "git args:clone https://github.com/zdharma-continuum/zinit" "shell integrations continues to zinit when Oh My Zsh download fails"
+assert_contains "$test_log" "git args:clone https://github.com/scmbreeze/scm_breeze.git" "shell integrations continues to SCM Breeze when Oh My Zsh download fails"
+
+first_marker_text="$marker_text"
+
+: >"$SHELL_INTEGRATIONS_TEST_LOG"
+rm -rf "$HOME/.local/share/zinit/zinit.git"
+SHELL_INTEGRATIONS_ZINIT_STATUS=31
+export SHELL_INTEGRATIONS_ZINIT_STATUS
+if ! sh "$rendered" >"$tmp_dir/shell-integrations-zinit-failure.out" 2>"$tmp_dir/shell-integrations-zinit-failure.err"; then
+  unset SHELL_INTEGRATIONS_ZINIT_STATUS
+  fail "shell integrations should continue after replacing a warning marker for zinit failure"
+fi
+unset SHELL_INTEGRATIONS_ZINIT_STATUS
+
+if [ ! -f "$shell_integrations_marker" ]; then
+  fail "shell integrations should keep a warning marker when zinit fails on rerun"
+fi
+pass "shell integrations keeps a warning marker when zinit fails on rerun"
+
+replacement_marker_text="$(cat "$shell_integrations_marker")"
+assert_contains "$replacement_marker_text" "summary='Shell integration setup needs attention'" "shell integrations replacement marker keeps the expected summary"
+assert_contains "$replacement_marker_text" "zinit" "shell integrations replacement marker mentions the failed zinit step"
+assert_not_contains "$replacement_marker_text" "Oh My Zsh" "shell integrations replacement marker drops the previous Oh My Zsh failure"
+assert_contains "$replacement_marker_text" "updated_at='" "shell integrations replacement marker records update time"
+if [ "$replacement_marker_text" = "$first_marker_text" ]; then
+  fail "shell integrations replacement marker should change from the first marker"
+fi
+pass "shell integrations replacement marker changes from the first marker"
+
+: >"$SHELL_INTEGRATIONS_TEST_LOG"
+if ! sh "$rendered" >"$tmp_dir/shell-integrations-successful-rerun.out" 2>"$tmp_dir/shell-integrations-successful-rerun.err"; then
+  fail "shell integrations should succeed when all installers succeed on rerun"
+fi
+
+successful_rerun_log="$(cat "$SHELL_INTEGRATIONS_TEST_LOG")"
+assert_contains "$successful_rerun_log" "git args:clone https://github.com/zdharma-continuum/zinit" "shell integrations retries zinit during successful rerun"
+
+if [ -f "$shell_integrations_marker" ]; then
+  fail "shell integrations should clear warning marker after successful rerun"
+fi
+pass "shell integrations clears warning marker after successful rerun"
 
 rm -f "$shell_integrations_marker"
 : >"$SHELL_INTEGRATIONS_TEST_LOG"
@@ -127,3 +172,66 @@ if [ ! -f "$shell_integrations_marker" ]; then
   fail "first-run shell integrations should record a warning marker when the Oh My Zsh installer download fails"
 fi
 pass "first-run shell integrations records a warning marker when the Oh My Zsh installer download fails"
+
+export HOME="$tmp_dir/scm-home"
+export XDG_STATE_HOME="$tmp_dir/scm-state"
+export SHELL_INTEGRATIONS_TEST_LOG="$tmp_dir/scm-shell-integrations.log"
+mkdir -p "$HOME"
+: >"$SHELL_INTEGRATIONS_TEST_LOG"
+scm_shell_integrations_marker="$XDG_STATE_HOME/terrapod/install-warnings/shell-integrations"
+
+SHELL_INTEGRATIONS_SCM_INSTALL_STATUS=42
+export SHELL_INTEGRATIONS_SCM_INSTALL_STATUS
+if ! sh "$rendered" >"$tmp_dir/shell-integrations-scm-install-failure.out" 2>"$tmp_dir/shell-integrations-scm-install-failure.err"; then
+  unset SHELL_INTEGRATIONS_SCM_INSTALL_STATUS
+  fail "shell integrations should continue after recording an SCM Breeze installer warning"
+fi
+
+if [ ! -f "$scm_shell_integrations_marker" ]; then
+  unset SHELL_INTEGRATIONS_SCM_INSTALL_STATUS
+  fail "shell integrations should keep a warning marker when SCM Breeze installer fails"
+fi
+pass "shell integrations keeps a warning marker when SCM Breeze installer fails"
+
+scm_marker_text="$(cat "$scm_shell_integrations_marker")"
+assert_contains "$scm_marker_text" "SCM Breeze" "shell integrations marker mentions the failed SCM Breeze installer"
+
+: >"$SHELL_INTEGRATIONS_TEST_LOG"
+if ! sh "$rendered" >"$tmp_dir/shell-integrations-scm-install-failure-rerun.out" 2>"$tmp_dir/shell-integrations-scm-install-failure-rerun.err"; then
+  unset SHELL_INTEGRATIONS_SCM_INSTALL_STATUS
+  fail "shell integrations should continue after retrying a failed SCM Breeze installer"
+fi
+
+if [ ! -f "$scm_shell_integrations_marker" ]; then
+  unset SHELL_INTEGRATIONS_SCM_INSTALL_STATUS
+  fail "shell integrations should keep a warning marker when SCM Breeze installer fails on rerun"
+fi
+pass "shell integrations keeps a warning marker when SCM Breeze installer fails on rerun"
+
+scm_replacement_marker_text="$(cat "$scm_shell_integrations_marker")"
+assert_contains "$scm_replacement_marker_text" "SCM Breeze" "shell integrations replacement marker keeps the SCM Breeze failure"
+if [ "$scm_replacement_marker_text" = "$scm_marker_text" ]; then
+  unset SHELL_INTEGRATIONS_SCM_INSTALL_STATUS
+  fail "shell integrations should replace the SCM Breeze marker on failed rerun"
+fi
+pass "shell integrations replaces the SCM Breeze marker on failed rerun"
+
+scm_failure_rerun_log="$(cat "$SHELL_INTEGRATIONS_TEST_LOG")"
+assert_contains "$scm_failure_rerun_log" "scm-breeze install" "shell integrations retries SCM Breeze installer when warning marker exists"
+
+SHELL_INTEGRATIONS_SCM_INSTALL_STATUS=0
+export SHELL_INTEGRATIONS_SCM_INSTALL_STATUS
+: >"$SHELL_INTEGRATIONS_TEST_LOG"
+if ! sh "$rendered" >"$tmp_dir/shell-integrations-scm-install-success-rerun.out" 2>"$tmp_dir/shell-integrations-scm-install-success-rerun.err"; then
+  unset SHELL_INTEGRATIONS_SCM_INSTALL_STATUS
+  fail "shell integrations should succeed after SCM Breeze installer recovers"
+fi
+unset SHELL_INTEGRATIONS_SCM_INSTALL_STATUS
+
+scm_success_rerun_log="$(cat "$SHELL_INTEGRATIONS_TEST_LOG")"
+assert_contains "$scm_success_rerun_log" "scm-breeze install" "shell integrations reruns SCM Breeze installer during successful recovery"
+
+if [ -f "$scm_shell_integrations_marker" ]; then
+  fail "shell integrations should clear warning marker after SCM Breeze installer recovers"
+fi
+pass "shell integrations clears warning marker after SCM Breeze installer recovers"

--- a/tests/shell_integrations_test.sh
+++ b/tests/shell_integrations_test.sh
@@ -76,6 +76,23 @@ pass "rendered shell integrations retry script is valid sh"
 
 write_stub "$tmp_dir/bin/curl" \
   'printf "%s\n" "curl args:$*" >>"$SHELL_INTEGRATIONS_TEST_LOG"' \
+  'output_file=' \
+  'while [ "$#" -gt 0 ]; do' \
+  '  case "$1" in' \
+  '    -o)' \
+  '      shift' \
+  '      output_file="$1"' \
+  '      ;;' \
+  '  esac' \
+  '  shift' \
+  'done' \
+  'curl_status="${SHELL_INTEGRATIONS_CURL_STATUS:-0}"' \
+  'if [ "$curl_status" -ne 0 ]; then' \
+  '  exit "$curl_status"' \
+  'fi' \
+  'if [ -n "$output_file" ]; then' \
+  '  printf "%s\n" "#!/bin/sh" "mkdir -p \"\$HOME/.oh-my-zsh\"" ": >\"\$HOME/.oh-my-zsh/oh-my-zsh.sh\"" "exit \"\${SHELL_INTEGRATIONS_OMZ_INSTALL_STATUS:-0}\"" >"$output_file"' \
+  'fi' \
   'exit "${SHELL_INTEGRATIONS_CURL_STATUS:-0}"'
 
 write_stub "$tmp_dir/bin/git" \
@@ -179,14 +196,24 @@ HOME="$partial_retry_home" \
   sh "$retry_rendered" >"$tmp_dir/shell-integrations-retry-partial-dirs.out" 2>"$tmp_dir/shell-integrations-retry-partial-dirs.err"
 
 partial_retry_marker="$partial_retry_state/terrapod/install-warnings/shell-integrations"
-if [ ! -f "$partial_retry_marker" ]; then
-  fail "shell integrations retry should keep marker when previous failures left partial directories"
+if [ -f "$partial_retry_marker" ]; then
+  fail "shell integrations retry should clear marker after reinstalling partial directories"
 fi
-pass "shell integrations retry keeps marker when previous failures left partial directories"
+pass "shell integrations retry clears marker after reinstalling partial directories"
 
-partial_retry_marker_text="$(cat "$partial_retry_marker")"
-assert_contains "$partial_retry_marker_text" "Oh My Zsh" "shell integrations retry marker keeps partial Oh My Zsh warning"
-assert_contains "$partial_retry_marker_text" "zinit" "shell integrations retry marker keeps partial zinit warning"
+if [ ! -f "$partial_retry_home/.oh-my-zsh/oh-my-zsh.sh" ]; then
+  fail "shell integrations retry reinstalls partial Oh My Zsh directory"
+fi
+pass "shell integrations retry reinstalls partial Oh My Zsh directory"
+
+if [ ! -f "$partial_retry_home/.local/share/zinit/zinit.git/zinit.zsh" ]; then
+  fail "shell integrations retry reclones partial zinit directory"
+fi
+pass "shell integrations retry reclones partial zinit directory"
+
+partial_retry_log_text="$(cat "$partial_retry_log")"
+assert_contains "$partial_retry_log_text" "curl args:-fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh" "shell integrations retry reruns Oh My Zsh installer for partial directory"
+assert_contains "$partial_retry_log_text" "git args:clone https://github.com/zdharma-continuum/zinit" "shell integrations retry reclones zinit for partial directory"
 
 partial_onchange_home="$tmp_dir/partial-onchange-home"
 partial_onchange_state="$tmp_dir/partial-onchange-state"
@@ -210,14 +237,24 @@ HOME="$partial_onchange_home" \
   sh "$rendered" >"$tmp_dir/shell-integrations-onchange-partial-dirs.out" 2>"$tmp_dir/shell-integrations-onchange-partial-dirs.err"
 
 partial_onchange_marker="$partial_onchange_state/terrapod/install-warnings/shell-integrations"
-if [ ! -f "$partial_onchange_marker" ]; then
-  fail "shell integrations onchange should keep marker when previous failures left partial directories"
+if [ -f "$partial_onchange_marker" ]; then
+  fail "shell integrations onchange should clear marker after reinstalling partial directories"
 fi
-pass "shell integrations onchange keeps marker when previous failures left partial directories"
+pass "shell integrations onchange clears marker after reinstalling partial directories"
 
-partial_onchange_marker_text="$(cat "$partial_onchange_marker")"
-assert_contains "$partial_onchange_marker_text" "Oh My Zsh" "shell integrations onchange marker keeps partial Oh My Zsh warning"
-assert_contains "$partial_onchange_marker_text" "zinit" "shell integrations onchange marker keeps partial zinit warning"
+if [ ! -f "$partial_onchange_home/.oh-my-zsh/oh-my-zsh.sh" ]; then
+  fail "shell integrations onchange reinstalls partial Oh My Zsh directory"
+fi
+pass "shell integrations onchange reinstalls partial Oh My Zsh directory"
+
+if [ ! -f "$partial_onchange_home/.local/share/zinit/zinit.git/zinit.zsh" ]; then
+  fail "shell integrations onchange reclones partial zinit directory"
+fi
+pass "shell integrations onchange reclones partial zinit directory"
+
+partial_onchange_log_text="$(cat "$partial_onchange_log")"
+assert_contains "$partial_onchange_log_text" "curl args:-fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh" "shell integrations onchange reruns Oh My Zsh installer for partial directory"
+assert_contains "$partial_onchange_log_text" "git args:clone https://github.com/zdharma-continuum/zinit" "shell integrations onchange reclones zinit for partial directory"
 
 HOME="$HOME" XDG_STATE_HOME="$XDG_STATE_HOME" sh -c \
   '. "$1"; terrapod_install_warning_write shell-integrations "Shell integration setup needs attention" "Previous shell integration warning."' \
@@ -287,6 +324,7 @@ fi
 pass "shell integrations clears warning marker after successful rerun"
 
 rm -f "$shell_integrations_marker"
+rm -rf "$HOME/.oh-my-zsh"
 : >"$SHELL_INTEGRATIONS_TEST_LOG"
 SHELL_INTEGRATIONS_CURL_STATUS=23
 export SHELL_INTEGRATIONS_CURL_STATUS


### PR DESCRIPTION
## Summary
- Make `mise-tools` and `shell-integrations` installer failures marker-backed non-blocking recovery categories.
- Accumulate reliable failed steps/items, replace markers on failed reruns, and clear markers only after successful reruns.
- Add coverage for mise failure/rerun behavior, shell integration continuation, and SCM Breeze partial-install recovery.

Closes #102

## Test Plan
- `sh tests/chezmoiignore_test.sh`
- `sh tests/shell_integrations_test.sh`
- `sh tests/terrapod_command_test.sh`
- `for test_script in tests/*.sh; do sh "$test_script" || exit $?; done`
- `for test_script in tests/*.zsh; do zsh "$test_script" || exit $?; done`