### PR TITLE
Add Scroll Reverser to macOS automation app group

### DIFF
--- a/Brewfile.macos-desktop-apps.tmpl
+++ b/Brewfile.macos-desktop-apps.tmpl
@@ -7,6 +7,7 @@ cask "ghostty"
 # automation macOS App Group
 cask "hammerspoon"
 cask "karabiner-elements"
+cask "scroll-reverser"
 {{ end -}}
 {{ if default false (get . "enableMacosAppGroupLauncher") -}}
 # launcher macOS App Group

--- a/README.ko.md
+++ b/README.ko.md
@@ -141,7 +141,7 @@ macOS에서는 initial apply가 초기 terminal environment를 위해 `.chezmois
 macOS desktop application은 machine-local data key로 제어되는 opt-in App Group으로 나뉩니다. Homebrew bootstrap 중 chezmoi는 선택한 group을 `Brewfile.macos-desktop-apps.tmpl`에서 temporary Brewfile로 render하고, 그 rendered bundle을 설치합니다.
 
 - `terminal-apps`: Ghostty.
-- `automation`: Hammerspoon과 Karabiner-Elements.
+- `automation`: Hammerspoon, Karabiner-Elements, Scroll Reverser.
 - `launcher`: Raycast와 1Password CLI.
 - `monitoring`: iStat Menus.
 - `ai-apps`: Claude Desktop, Codex Desktop(`codex-app`), Antigravity 2.0, Antigravity IDE.
@@ -245,7 +245,7 @@ Optional stack profile과 macOS App Group setting은 기본적으로 disabled입
 | `enableAiCliTools` | `false` | official vendor installer를 통해 Antigravity CLI, Claude Code, Codex를 설치합니다. 기존 npm-installed AI CLI는 unmanaged 상태로 둡니다. |
 | `enableDevelopmentWorkspace` | `false` | Optional Editor Stack, Optional AI Tool Stack, development-specific Zellij workspace surface를 포함하는 Optional Development Workspace preset을 활성화합니다. |
 | `enableMacosAppGroupTerminalApps` | `false` | terminal-apps macOS App Group에 포함된 Ghostty를 설치합니다. |
-| `enableMacosAppGroupAutomation` | `false` | automation macOS App Group인 Hammerspoon과 Karabiner-Elements를 설치합니다. |
+| `enableMacosAppGroupAutomation` | `false` | automation macOS App Group인 Hammerspoon, Karabiner-Elements, Scroll Reverser를 설치합니다. |
 | `enableMacosAppGroupLauncher` | `false` | launcher macOS App Group인 Raycast와 1Password CLI를 설치합니다. |
 | `enableMacosAppGroupMonitoring` | `false` | monitoring macOS App Group인 iStat Menus를 설치합니다. |
 | `enableMacosAppGroupAiApps` | `false` | ai-apps macOS App Group인 Claude Desktop, Codex Desktop(`codex-app`), Antigravity 2.0, Antigravity IDE를 설치합니다. |

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ groups from `Brewfile.macos-desktop-apps.tmpl` into a temporary Brewfile and
 installs that rendered bundle:
 
 - `terminal-apps`: Ghostty.
-- `automation`: Hammerspoon and Karabiner-Elements.
+- `automation`: Hammerspoon, Karabiner-Elements, and Scroll Reverser.
 - `launcher`: Raycast and 1Password CLI.
 - `monitoring`: iStat Menus.
 - `ai-apps`: Claude Desktop, Codex Desktop (`codex-app`), Antigravity 2.0, and Antigravity IDE.
@@ -270,7 +270,7 @@ Optional stack profiles and macOS App Group settings are disabled by default.
 | `enableAiCliTools` | `false` | Installs Antigravity CLI, Claude Code, and Codex through official vendor installers. Existing npm-installed AI CLIs are left unmanaged. |
 | `enableDevelopmentWorkspace` | `false` | Enables the Optional Development Workspace preset, including the Optional Editor Stack, Optional AI Tool Stack, and development-specific Zellij workspace surfaces. |
 | `enableMacosAppGroupTerminalApps` | `false` | Installs the terminal-apps macOS App Group: Ghostty. |
-| `enableMacosAppGroupAutomation` | `false` | Installs the automation macOS App Group: Hammerspoon and Karabiner-Elements. |
+| `enableMacosAppGroupAutomation` | `false` | Installs the automation macOS App Group: Hammerspoon, Karabiner-Elements, and Scroll Reverser. |
 | `enableMacosAppGroupLauncher` | `false` | Installs the launcher macOS App Group: Raycast and 1Password CLI. |
 | `enableMacosAppGroupMonitoring` | `false` | Installs the monitoring macOS App Group: iStat Menus. |
 | `enableMacosAppGroupAiApps` | `false` | Installs the ai-apps macOS App Group: Claude Desktop, Codex Desktop (`codex-app`), Antigravity 2.0, and Antigravity IDE. |

--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -522,7 +522,7 @@ show_setup_option_block() {
       printf '%s\n' "  Installs Ghostty."
       ;;
     "automation macOS App Group")
-      printf '%s\n' "  Installs Hammerspoon and Karabiner-Elements."
+      printf '%s\n' "  Installs Hammerspoon, Karabiner-Elements, and Scroll Reverser."
       ;;
     "launcher macOS App Group")
       printf '%s\n' "  Installs Raycast and 1Password CLI."
@@ -971,7 +971,7 @@ print_macos_app_group_status() {
     print_indented_colon_state_line "terminal-apps" "disabled"
   fi
   if is_enabled "$(config_data_bool "$config_file" enableMacosAppGroupAutomation)"; then
-    print_indented_colon_state_line "automation" "enabled" "(Hammerspoon and Karabiner-Elements)"
+    print_indented_colon_state_line "automation" "enabled" "(Hammerspoon, Karabiner-Elements, and Scroll Reverser)"
   else
     print_indented_colon_state_line "automation" "disabled"
   fi

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -606,6 +606,7 @@ assert_not_contains_text "$macos_brewfile" 'cask "ghostty"' "macOS default does 
 assert_not_contains_text "$macos_brewfile" 'cask "cmux"' "macOS default does not render cmux"
 assert_not_contains_text "$macos_brewfile" 'cask "hammerspoon"' "macOS default does not render Hammerspoon"
 assert_not_contains_text "$macos_brewfile" 'cask "karabiner-elements"' "macOS default does not render Karabiner-Elements"
+assert_not_contains_text "$macos_brewfile" 'cask "scroll-reverser"' "macOS default does not render Scroll Reverser"
 assert_not_contains_text "$macos_brewfile" 'cask "raycast"' "macOS default does not render Raycast"
 assert_not_contains_text "$macos_brewfile" 'cask "1password-cli"' "macOS default does not render 1Password CLI"
 assert_not_contains_text "$macos_brewfile" 'cask "istat-menus"' "macOS default does not render iStat Menus"
@@ -621,6 +622,7 @@ assert_not_contains_text "$terminal_apps_brewfile" 'cask "hammerspoon"' "termina
 
 assert_contains_text "$automation_apps_brewfile" 'cask "hammerspoon"' "automation group renders Hammerspoon"
 assert_contains_text "$automation_apps_brewfile" 'cask "karabiner-elements"' "automation group renders Karabiner-Elements"
+assert_contains_text "$automation_apps_brewfile" 'cask "scroll-reverser"' "automation group renders Scroll Reverser"
 
 assert_contains_text "$launcher_apps_brewfile" 'cask "raycast"' "launcher group renders Raycast"
 assert_contains_text "$launcher_apps_brewfile" 'cask "1password-cli"' "launcher group renders 1Password CLI"

--- a/tests/readme_optional_stack_profiles_test.sh
+++ b/tests/readme_optional_stack_profiles_test.sh
@@ -118,6 +118,8 @@ assert_key_row_contains '`enableMacosAppGroupAutomation`' 'Hammerspoon' \
   "README documents Hammerspoon on the automation option row"
 assert_key_row_contains '`enableMacosAppGroupAutomation`' 'Karabiner-Elements' \
   "README documents Karabiner-Elements on the automation option row"
+assert_key_row_contains '`enableMacosAppGroupAutomation`' 'Scroll Reverser' \
+  "README documents Scroll Reverser on the automation option row"
 assert_key_row_contains '`enableMacosAppGroupLauncher`' 'launcher' \
   "README documents launcher group on its option row"
 assert_key_row_contains '`enableMacosAppGroupLauncher`' 'Raycast' \

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -1264,6 +1264,8 @@ assert_not_contains "$setup_output_text" "Optional Editor Stack: included by Opt
 assert_not_contains "$setup_output_text" "Optional AI Tool Stack: included by Optional Development Workspace" "gum setup no longer repeats workspace-included AI Tool Stack as a standalone message"
 assert_contains "$setup_output_text" "terminal-apps" "gum setup leads terminal-apps App Group prompt with the group name"
 assert_contains "$setup_output_text" "  Installs Ghostty." "gum setup describes terminal-apps under its group name"
+assert_contains "$setup_output_text" "automation" "gum setup leads automation App Group prompt with the group name"
+assert_contains "$setup_output_text" "  Installs Hammerspoon, Karabiner-Elements, and Scroll Reverser." "gum setup describes automation under its group name"
 assert_contains "$setup_output_text" "ai-apps" "gum setup leads ai-apps App Group prompt with the group name"
 assert_contains "$setup_output_text" "  Installs Claude Desktop, Codex Desktop, Antigravity 2.0, and Antigravity IDE." "gum setup describes ai-apps under its group name"
 assert_contains "$setup_output_text" "enableEditorStack = true" "gum setup summary includes concrete Editor Stack setting"
@@ -1556,7 +1558,7 @@ enableEditorStack = true
 enableAiCliTools = true
 enableDevelopmentWorkspace = true
 enableMacosAppGroupTerminalApps = true
-enableMacosAppGroupAutomation = false
+enableMacosAppGroupAutomation = true
 enableMacosAppGroupLauncher = true
 enableMacosAppGroupMonitoring = false
 enableMacosAppGroupAiApps = true
@@ -1576,7 +1578,7 @@ assert_contains "$macos_status_output" "Optional Editor Stack         : enabled 
 assert_contains "$macos_status_output" "Optional AI Tool Stack        : enabled (tools available: agy, claude, codex)" "Terrapod status reports enabled Optional AI Tool Stack tool state"
 assert_contains "$macos_status_output" "Optional Development Workspace: enabled (development Zellij layouts)" "Terrapod status reports enabled Optional Development Workspace state"
 assert_contains "$macos_status_output" "terminal-apps                 : enabled (Ghostty)" "Terrapod status reports enabled Ghostty-only terminal-apps macOS App Group"
-assert_contains "$macos_status_output" "automation                    : disabled" "Terrapod status reports disabled automation macOS App Group"
+assert_contains "$macos_status_output" "automation                    : enabled (Hammerspoon, Karabiner-Elements, and Scroll Reverser)" "Terrapod status reports enabled automation macOS App Group"
 assert_contains "$macos_status_output" "launcher                      : enabled (Raycast and 1Password CLI)" "Terrapod status reports enabled launcher macOS App Group"
 assert_contains "$macos_status_output" "monitoring                    : disabled" "Terrapod status reports disabled monitoring macOS App Group"
 assert_contains "$macos_status_output" "ai-apps                       : enabled (Claude Desktop, Codex Desktop, Antigravity 2.0, and Antigravity IDE)" "Terrapod status reports enabled ai-apps macOS App Group"


### PR DESCRIPTION
## What changed

- Added the Homebrew cask `scroll-reverser` to the macOS `automation` App Group.
- Updated Terrapod setup/status copy so the automation App Group lists Scroll Reverser alongside Hammerspoon and Karabiner-Elements.
- Updated English and Korean README documentation plus shell test expectations for the new App Group membership.

## Why

Scroll Reverser should be managed as part of the existing macOS automation/input tooling instead of requiring a separate machine-local Homebrew override.

## Impact

Users who enable `enableMacosAppGroupAutomation = true` will have Scroll Reverser included in the rendered macOS Desktop App Stack Brewfile. The default configuration still excludes it unless the automation App Group is enabled.

## Validation

Passed:

- `git diff --check --cached`
- `sh -n dot_local/bin/executable_terrapod`
- `sh tests/readme_optional_stack_profiles_test.sh`
- `sh tests/readme_korean_test.sh`
- `sh tests/terrapod_command_test.sh`
- `chezmoi execute-template` check confirming automation-enabled output includes `cask "scroll-reverser"` and default output excludes it

Known failing check:

- `sh tests/chezmoiignore_test.sh` currently fails at `macOS mise tool installer fails when mise is missing without a homebrew-core marker`, before reaching the new Scroll Reverser assertions. This appears unrelated to this change and reflects the existing mise warning-marker behavior.