### PR TITLE
Trust Orca Homebrew cask explicitly

### DIFF
--- a/Brewfile.macos-desktop-apps.tmpl
+++ b/Brewfile.macos-desktop-apps.tmpl
@@ -25,5 +25,5 @@ cask "claude"
 cask "codex-app"
 cask "antigravity"
 cask "antigravity-ide"
-cask "stablyai/orca/orca"
+cask "stablyai/orca/orca", trusted: true
 {{ end -}}

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -287,6 +287,8 @@ _Avoid_: separate Korean introduction, independent README, self-labeled translat
 - The monitoring **macOS App Group** contains iStat Menus.
 - The ai-apps **macOS App Group** contains Claude Desktop, Codex Desktop, Antigravity 2.0, Antigravity IDE, and Orca.
 - The ai-apps **macOS App Group** installs these desktop apps through Homebrew casks `claude`, `codex-app`, `antigravity`, `antigravity-ide`, and the fully-qualified vendor cask `stablyai/orca/orca`.
+- The ai-apps **macOS App Group** declares `stablyai/orca/orca` with `trusted: true` so Homebrew trusts only the Orca cask, not the entire `stablyai/orca` tap.
+- Disabling the ai-apps **macOS App Group** does not revoke an existing Orca cask trust entry; Terrapod leaves Homebrew trust removal to an explicit user action.
 - The Hammerspoon app launcher maps Codex Desktop to `1`, Claude Desktop to `2`, Antigravity 2.0 to `3`, Orca to `4`, and Antigravity IDE to `i`.
 - Orca's bundled `orca` CLI remains an artifact of the ai-apps **macOS App Group** and is not a member of the cross-profile **Optional AI Tool Stack**.
 - Removing ChatGPT Atlas from the Hammerspoon app launcher is part of the planned launcher change.

--- a/README.ko.md
+++ b/README.ko.md
@@ -146,6 +146,8 @@ macOS desktop application은 machine-local data key로 제어되는 opt-in App G
 - `monitoring`: iStat Menus.
 - `ai-apps`: Claude Desktop, Codex 데스크톱 앱(통합 ChatGPT 데스크톱 앱으로 업데이트, `codex-app`), Antigravity 2.0, Antigravity IDE, Orca ADE(`stablyai/orca/orca`).
 
+Terrapod은 Orca를 설치할 때 fully-qualified `stablyai/orca/orca` cask만 trust하며, `stablyai/orca` tap 전체를 trust하지 않습니다.
+
 Machine-specific Homebrew package는 tracked `Brewfile` 밖에 둬야 합니다.
 
 ### Ubuntu 24.04 VPS

--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ installs that rendered bundle:
 - `monitoring`: iStat Menus.
 - `ai-apps`: Claude Desktop, Codex desktop app (updates to the unified ChatGPT desktop app; `codex-app`), Antigravity 2.0, Antigravity IDE, and Orca ADE (`stablyai/orca/orca`).
 
+When installing Orca, Terrapod trusts only the fully-qualified `stablyai/orca/orca` cask, not the entire `stablyai/orca` tap.
+
 Machine-specific Homebrew packages should live outside the tracked `Brewfile`.
 
 ### Ubuntu 24.04 VPS

--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -532,6 +532,7 @@ show_setup_option_block() {
       ;;
     "ai-apps macOS App Group")
       printf '%s\n' "  Installs Claude Desktop, Codex desktop app (updates to the unified ChatGPT desktop app), Antigravity 2.0, Antigravity IDE, and Orca."
+      printf '%s\n' "  Trusts only the fully-qualified stablyai/orca/orca cask, not the entire stablyai/orca tap."
       ;;
   esac
   printf '%s\n' ""

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -638,7 +638,7 @@ assert_not_contains_text "$ai_apps_brewfile" 'cask "chatgpt"' "ai-apps group doe
 assert_not_contains_text "$ai_apps_brewfile" 'cask "codex"' "ai-apps group does not render Codex CLI cask"
 assert_contains_text "$ai_apps_brewfile" 'cask "antigravity"' "ai-apps group renders Antigravity 2.0"
 assert_contains_text "$ai_apps_brewfile" 'cask "antigravity-ide"' "ai-apps group renders Antigravity IDE"
-assert_contains_text "$ai_apps_brewfile" 'cask "stablyai/orca/orca"' "ai-apps group renders Orca from its official Homebrew tap"
+assert_contains_text "$ai_apps_brewfile" 'cask "stablyai/orca/orca", trusted: true' "ai-apps group trusts only Orca's fully-qualified vendor cask"
 ai_apps_casks="$(
   printf '%s\n' "$ai_apps_brewfile" |
     awk '/^[[:space:]]*cask[[:space:]]+"/ { print }'
@@ -647,7 +647,7 @@ expected_ai_apps_casks='cask "claude"
 cask "codex-app"
 cask "antigravity"
 cask "antigravity-ide"
-cask "stablyai/orca/orca"'
+cask "stablyai/orca/orca", trusted: true'
 assert_text_equals \
   "$ai_apps_casks" \
   "$expected_ai_apps_casks" \

--- a/tests/readme_korean_test.sh
+++ b/tests/readme_korean_test.sh
@@ -145,6 +145,8 @@ assert_contains "$korean_readme" '`ai-apps`: Claude Desktop, Codex 데스크톱 
   "README.ko.md documents Orca ADE and its cask source in the ai-apps inventory"
 assert_contains "$korean_readme" '| `enableMacosAppGroupAiApps` | `false` | ai-apps macOS App Group인 Claude Desktop, Codex 데스크톱 앱(통합 ChatGPT 데스크톱 앱으로 업데이트, `codex-app`), Antigravity 2.0, Antigravity IDE, Orca ADE(`stablyai/orca/orca`)를 설치합니다. |' \
   "README.ko.md documents Orca ADE and its cask source on the ai-apps option row"
+assert_contains "$korean_readme" 'Terrapod은 Orca를 설치할 때 fully-qualified `stablyai/orca/orca` cask만 trust하며, `stablyai/orca` tap 전체를 trust하지 않습니다.' \
+  "README.ko.md documents Orca's cask-specific trust boundary"
 
 extract_headings "$readme" >"$tmp_dir/readme.headings"
 extract_headings "$korean_readme" >"$tmp_dir/readme-ko.headings"

--- a/tests/readme_optional_stack_profiles_test.sh
+++ b/tests/readme_optional_stack_profiles_test.sh
@@ -148,6 +148,8 @@ assert_key_row_contains '`enableMacosAppGroupAiApps`' 'Orca ADE' \
   "README documents Orca ADE on the ai-apps option row"
 assert_key_row_contains '`enableMacosAppGroupAiApps`' 'stablyai/orca/orca' \
   "README documents Orca's fully-qualified cask source"
+assert_contains 'When installing Orca, Terrapod trusts only the fully-qualified `stablyai/orca/orca` cask, not the entire `stablyai/orca` tap.' \
+  "README documents Orca's cask-specific trust boundary"
 
 assert_contains 'Optional stack profiles and macOS App Group settings are disabled by default.' \
   "README states optional stack profiles and App Groups are disabled by default"

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -1268,6 +1268,7 @@ assert_contains "$setup_output_text" "automation" "gum setup leads automation Ap
 assert_contains "$setup_output_text" "  Installs Hammerspoon, Karabiner-Elements, and Scroll Reverser." "gum setup describes automation under its group name"
 assert_contains "$setup_output_text" "ai-apps" "gum setup leads ai-apps App Group prompt with the group name"
 assert_contains "$setup_output_text" "  Installs Claude Desktop, Codex desktop app (updates to the unified ChatGPT desktop app), Antigravity 2.0, Antigravity IDE, and Orca." "gum setup lists Orca in the ai-apps App Group"
+assert_contains "$setup_output_text" "  Trusts only the fully-qualified stablyai/orca/orca cask, not the entire stablyai/orca tap." "gum setup discloses Orca's cask-specific trust boundary"
 assert_contains "$setup_output_text" "enableEditorStack = true" "gum setup summary includes concrete Editor Stack setting"
 assert_contains "$setup_output_text" "enableMacosAppGroupMonitoring = true" "gum setup summary includes concrete macOS App Group setting"
 assert_contains "$setup_output_text" "enableMacosAppGroupAiApps = true" "gum setup summary includes concrete ai-apps App Group setting"


### PR DESCRIPTION
## What changed

- declare `stablyai/orca/orca` with cask-scoped `trusted: true`
- disclose the trust boundary in Terrapod Setup and both READMEs
- document that disabling `ai-apps` does not automatically revoke Homebrew trust
- update rendering and documentation regression coverage

## Why

Homebrew now refuses to load the Orca cask from the non-official `stablyai/orca` tap unless trust is explicit. The previous fully-qualified cask declaration tapped the repository but did not grant the item-specific trust required by current Homebrew.

This keeps the trust scope limited to the Orca cask instead of trusting every current and future item in the tap. Existing users can recover through `tpod update` followed by `tpod apply`.

## Validation

- repository shell suites passed, excluding the independently checked `chezmoiignore_test.sh`
- `tests/zshrc_zoxide_test.zsh` passed
- enabled and disabled ai-apps rendering checks passed
- existing failure-attribution parser preserved `stablyai/orca/orca`
- Homebrew Bundle parsed the trusted cask declaration
- `git diff --check` and shell syntax checks passed

`tests/chezmoiignore_test.sh` still stops at an unrelated existing mise exit-status assertion before reaching its later Orca assertions; the Orca rendering and parser behavior were verified independently.