### PR TITLE
test: make release CI vendor fixtures portable

### DIFF
--- a/.superpowers/sdd/ci-fixture-fix-report.md
+++ b/.superpowers/sdd/ci-fixture-fix-report.md
@@ -1,0 +1,80 @@
+# Ubuntu release CI portable fixture fix
+
+## Status
+
+Complete. The two integration tests now create vendor-home fixtures below the
+package workspace instead of the OS temporary root. The directories are unique,
+absolute, symlink-resolved, and removed automatically by `t.Cleanup`.
+
+Production vendor-home safety validation was not changed.
+
+## Root cause
+
+Both affected tests passed `t.TempDir()` directly to `legacy.WithVendor`.
+On macOS the temporary directory is normally below `/var/folders`, while on
+Ubuntu it is below `/tmp`. Production intentionally rejects `/tmp/**` and
+`/private/tmp/**` vendor homes, so the Ubuntu fixtures failed before exercising
+the intended integration behavior.
+
+## Changes
+
+- Added `testutil.WorkspaceTempDir`.
+  - Creates a unique directory below the Go package working directory.
+  - Converts it to an absolute path.
+  - Resolves symlinks so the returned directory is a real path.
+  - Registers automatic recursive cleanup with `t.Cleanup`.
+- Updated `TestProductionPlannerComposesRealStateBoundAdapters` to use the
+  workspace-backed fixture home.
+- Updated `TestEngineRunsRealTransferPreflightWithoutPrivilege` to use the same
+  helper.
+
+No migration, install, or `chezmoi apply` command was run. No fixture data was
+written to `/Users/minu` or the real `HOME`.
+
+## TDD evidence
+
+The supplied RED reproductions failed before this change with the expected
+`legacy: unsafe vendor home "/tmp/..."` error.
+
+After the fixture change, both exact reproductions passed:
+
+```text
+TMPDIR=/tmp mise exec go@1.26.0 -- go test ./cmd/tpod -run TestProductionPlannerComposesRealStateBoundAdapters -count=1 -v
+PASS
+ok github.com/juty9026/terrapod/cmd/tpod
+
+TMPDIR=/tmp mise exec go@1.26.0 -- go test ./internal/reconcile -run TestEngineRunsRealTransferPreflightWithoutPrivilege -count=1 -v
+PASS
+ok github.com/juty9026/terrapod/internal/reconcile
+```
+
+## Verification
+
+All requested verification completed successfully:
+
+```text
+TMPDIR=/tmp mise exec go@1.26.0 -- go test ./cmd/tpod ./internal/reconcile -count=1
+ok github.com/juty9026/terrapod/cmd/tpod
+ok github.com/juty9026/terrapod/internal/reconcile
+
+TMPDIR=/tmp mise exec go@1.26.0 -- go test ./... -count=1
+all packages passed
+
+git diff --check
+exit 0
+```
+
+## Self-review
+
+- Scope is limited to test infrastructure and the two affected fixture call
+  sites.
+- Production `internal/provider/legacy` code is unchanged.
+- The helper does not consult `TMPDIR` or `HOME`.
+- Unique directory creation avoids collisions between concurrent tests.
+- Cleanup is registered on the test lifecycle and reports removal failures.
+- No unrelated formatting or refactoring is included.
+
+## Concerns
+
+None. The helper assumes the checked-out source workspace is writable, which is
+already required by this repository's independent Orca Workspace test setup.

--- a/.superpowers/sdd/ci-fixture-fix-report.md
+++ b/.superpowers/sdd/ci-fixture-fix-report.md
@@ -78,3 +78,23 @@ exit 0
 
 None. The helper assumes the checked-out source workspace is writable, which is
 already required by this repository's independent Orca Workspace test setup.
+
+## Reviewer follow-up
+
+Moved cleanup registration to immediately after `os.MkdirTemp` succeeds and
+captured the original created path for removal. The fixture is now cleaned even
+if `filepath.Abs` or `filepath.EvalSymlinks` fails. Cleanup errors continue to be
+reported through the test.
+
+The requested follow-up verification passed:
+
+```text
+TMPDIR=/tmp mise exec go@1.26.0 -- go test ./cmd/tpod -run TestProductionPlannerComposesRealStateBoundAdapters -count=1
+ok github.com/juty9026/terrapod/cmd/tpod
+
+TMPDIR=/tmp mise exec go@1.26.0 -- go test ./internal/reconcile -run TestEngineRunsRealTransferPreflightWithoutPrivilege -count=1
+ok github.com/juty9026/terrapod/internal/reconcile
+
+git diff --check
+exit 0
+```

--- a/cmd/tpod/main_test.go
+++ b/cmd/tpod/main_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/juty9026/terrapod/internal/resource"
 	"github.com/juty9026/terrapod/internal/resource/managementcore"
 	"github.com/juty9026/terrapod/internal/state"
+	"github.com/juty9026/terrapod/internal/testutil"
 )
 
 func TestProductionActiveCatalogRequiresPublishedReleaseVersion(t *testing.T) {
@@ -410,7 +411,7 @@ func TestBuiltBinaryDispatchesThroughRealConstrainedChezmoiClient(t *testing.T) 
 }
 
 func TestProductionPlannerComposesRealStateBoundAdapters(t *testing.T) {
-	home := t.TempDir()
+	home := testutil.WorkspaceTempDir(t)
 	layout := paths.Resolve(home, map[string]string{})
 	store, err := state.Open(layout.StateDir)
 	if err != nil {

--- a/internal/reconcile/transfer_adapter_test.go
+++ b/internal/reconcile/transfer_adapter_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juty9026/terrapod/internal/provider/legacy"
 	"github.com/juty9026/terrapod/internal/resource"
 	"github.com/juty9026/terrapod/internal/state"
+	"github.com/juty9026/terrapod/internal/testutil"
 )
 
 type transferProvider struct {
@@ -69,7 +70,7 @@ func (p *transferProvider) Inspect(context.Context, model.Resource) (model.Obser
 }
 
 func TestEngineRunsRealTransferPreflightWithoutPrivilege(t *testing.T) {
-	home := t.TempDir()
+	home := testutil.WorkspaceTempDir(t)
 	backend := &transferProvider{name: "homebrew-cask", pkg: "claude-code"}
 	desired, _ := resource.NewProviderAdapter(backend, func(context.Context, model.Resource, model.Observation, model.Ownership) ([]model.Operation, error) {
 		return nil, nil

--- a/internal/testutil/fs.go
+++ b/internal/testutil/fs.go
@@ -6,6 +6,28 @@ import (
 	"testing"
 )
 
+func WorkspaceTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp(".", ".terrapod-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir, err = filepath.Abs(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir, err = filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Errorf("remove workspace temp dir: %v", err)
+		}
+	})
+	return dir
+}
+
 func WriteFile(t *testing.T, path string, contents []byte, mode os.FileMode) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {

--- a/internal/testutil/fs.go
+++ b/internal/testutil/fs.go
@@ -12,6 +12,12 @@ func WorkspaceTempDir(t *testing.T) string {
 	if err != nil {
 		t.Fatal(err)
 	}
+	createdDir := dir
+	t.Cleanup(func() {
+		if err := os.RemoveAll(createdDir); err != nil {
+			t.Errorf("remove workspace temp dir: %v", err)
+		}
+	})
 	dir, err = filepath.Abs(dir)
 	if err != nil {
 		t.Fatal(err)
@@ -20,11 +26,6 @@ func WorkspaceTempDir(t *testing.T) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() {
-		if err := os.RemoveAll(dir); err != nil {
-			t.Errorf("remove workspace temp dir: %v", err)
-		}
-	})
 	return dir
 }
 


### PR DESCRIPTION
## Summary

- keep vendor-home integration fixtures outside the OS temporary-root deny paths
- preserve the production `legacy.WithVendor` rejection of `/tmp/**` and `/private/tmp/**`
- make fixture paths absolute, symlink-resolved, unique, and automatically cleaned

## Root cause

The release workflow runs on Ubuntu, where `t.TempDir()` resolves below `/tmp`.
Two integration tests passed that directory to the real vendor-home safety
boundary, which correctly rejected it. The same tests passed on macOS because
its temporary directory normally lives below `/var/folders`.

## Verification

- reproduced both failures locally with `TMPDIR=/tmp`
- exact two regression tests pass with `TMPDIR=/tmp`
- `TMPDIR=/tmp go test ./... -count=1`
- all `tests/*_test.sh`: 23/23 passed
- independent review: approved, no findings
- `git diff --check`
- clean worktree

Production safety validation is unchanged. No migration, installer, or chezmoi
apply command was run against `/Users/minu` or another real home.
