### PR TITLE
fix: install verified chezmoi package in release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          go install github.com/twpayne/chezmoi/v2/cmd/chezmoi@v2.71.1
-          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
-          "$(go env GOPATH)/bin/chezmoi" --version
+          chezmoi_url="https://github.com/twpayne/chezmoi/releases/download/v2.71.1/chezmoi_2.71.1_linux_amd64.deb"
+          chezmoi_deb="$RUNNER_TEMP/chezmoi_2.71.1_linux_amd64.deb"
+          curl --fail --location --proto '=https' --proto-redir '=https' --output "$chezmoi_deb" "$chezmoi_url"
+          printf '%s  %s\n' '49b68f441f60fbf84a79928e35076ccd4d0d7d5c050924c27d03bda25a7024eb' "$chezmoi_deb" | sha256sum -c -
           sudo apt-get update
-          sudo apt-get install -y zsh
+          sudo apt-get install -y "$chezmoi_deb" zsh
+          chezmoi --version
       - name: Validate stable tag and repository state
         shell: bash
         run: |

--- a/.superpowers/sdd/ci-chezmoi-package-report.md
+++ b/.superpowers/sdd/ci-chezmoi-package-report.md
@@ -1,0 +1,113 @@
+# Ubuntu Release CI chezmoi package fix
+
+## Status
+
+완료. Release test job은 존재하지 않는 Go package를 설치하지 않고,
+official chezmoi v2.71.1 `linux_amd64.deb`를 pinned HTTPS URL에서 내려받아
+hard-coded SHA-256을 검증한 뒤 `zsh`와 함께 설치한다.
+
+Release build/publish job, exact eight assets, stable tag validation, signing
+제거 contract, no-mise fallback은 변경하지 않았다.
+
+## Root cause
+
+기존 prerequisite는 다음 package를 설치했다.
+
+```text
+github.com/twpayne/chezmoi/v2/cmd/chezmoi@v2.71.1
+```
+
+chezmoi v2.71.1 module에는 이 package가 존재하지 않는다. Module root
+`go install github.com/twpayne/chezmoi/v2@v2.71.1`도 upstream `go.mod`의
+`exclude` directives 때문에 사용할 수 없다.
+
+## Changes
+
+- `$RUNNER_TEMP/chezmoi_2.71.1_linux_amd64.deb`로만 download한다.
+- exact URL을 pin했다.
+  - `https://github.com/twpayne/chezmoi/releases/download/v2.71.1/chezmoi_2.71.1_linux_amd64.deb`
+- `curl --proto '=https' --proto-redir '=https'`로 initial request와 redirect를
+  모두 HTTPS로 제한했다.
+- 다음 exact SHA-256을 `sha256sum -c`로 검증한다.
+  - `49b68f441f60fbf84a79928e35076ccd4d0d7d5c050924c27d03bda25a7024eb`
+- 검증된 local `.deb`와 `zsh`를 한 번의 `apt-get install`로 설치한다.
+- 설치 후 `chezmoi --version`을 실행한다.
+- chezmoi `go install`과 `$GITHUB_PATH` mutation을 제거했다.
+- contract test에 wrong package path와 missing checksum negative fixtures를
+  추가했다.
+
+## TDD evidence
+
+`tests/release_artifacts_test.sh` contract를 먼저 변경한 뒤 production
+workflow를 변경하지 않은 상태에서 다음 RED를 확인했다.
+
+```text
+not ok - release test job installs the verified pinned chezmoi package and zsh
+```
+
+Prerequisite step만 최소 변경한 뒤 같은 test가 exit 0으로 GREEN이 됐다.
+
+## Docker validation
+
+Host에는 package를 설치하지 않았다. Docker Desktop이 중지된 상태여서
+daemon만 기동한 뒤 disposable container에서 검증했다.
+
+Apple Silicon의 기본 `arm64` container에서는 checksum이 `OK`인 뒤
+의도대로 amd64 package architecture mismatch가 발생했다. GitHub runner와
+동일하게 `--platform linux/amd64`를 명시해 다시 실행한 결과 exit 0이었다.
+
+```text
+/tmp/chezmoi_2.71.1_linux_amd64.deb: OK
+chezmoi version v2.71.1, commit 94f58519ad17b954a5e7621a3c4e24385fd5417a, built at 2026-07-20T20:06:37Z, built by goreleaser
+zsh 5.9 (x86_64-ubuntu-linux-gnu)
+```
+
+Base image에 없는 `curl`과 CA certificates만 같은 disposable container
+안에서 bootstrap했다.
+
+## Verification
+
+다음 검증은 모두 exit 0으로 통과했다.
+
+```sh
+sh tests/release_artifacts_test.sh
+
+mise exec go@1.26.0 -- go test ./...
+
+mise exec go@1.26.0 -- sh -c '
+  set -eu
+  for test_script in tests/*_test.sh; do
+    sh "$test_script"
+  done
+'
+
+git diff --check
+```
+
+첫 full suite 시도는 local `mise` shim에 default Go version이 없어 test
+실행 전에 중단됐다. Repo가 pin한 `mise exec go@1.26.0` environment로
+재실행한 full Go/shell suite는 모두 통과했다.
+
+## Self-review
+
+- Workflow diff는 `Install test prerequisites` step에만 한정된다.
+- exact pinned URL, HTTPS-only protocols, checksum, local package install,
+  version verification이 contract로 고정돼 있다.
+- wrong package path와 checksum 제거 fixture가 validator를 통과하지 못한다.
+- executable `go install` line은 workflow에 남아 있지 않다.
+- `$GITHUB_PATH` mutation은 test job에 남아 있지 않다.
+- release job과 exact eight published assets는 diff가 없으며 기존 contract가
+  계속 검증한다.
+- signing 관련 configuration이나 artifact를 추가하지 않았다.
+
+## Safety
+
+real home migration/install/`chezmoi apply`는 실행하지 않았다. Host OS에는
+chezmoi나 zsh를 설치하지 않았고, package installation은 `--rm` Docker
+container 내부에서만 수행했다.
+
+## Concerns
+
+Known code concern 없음. Local Docker image pull은 Docker Desktop credential
+helper가 응답하지 않아 empty temporary `DOCKER_CONFIG`로 anonymous pull을
+수행했으며, 검증 결과에는 영향이 없다.

--- a/.superpowers/sdd/ci-chezmoi-package-report.md
+++ b/.superpowers/sdd/ci-chezmoi-package-report.md
@@ -111,3 +111,54 @@ container 내부에서만 수행했다.
 Known code concern 없음. Local Docker image pull은 Docker Desktop credential
 helper가 응답하지 않아 empty temporary `DOCKER_CONFIG`로 anonymous pull을
 수행했으며, 검증 결과에는 영향이 없다.
+
+## Reviewer follow-up: executable order contract
+
+Reviewer의 Minor finding에 따라 workflow implementation은 변경하지 않고
+`tests/release_artifacts_test.sh`의 prerequisite contract만 강화했다.
+
+### TDD evidence
+
+먼저 exact checksum command를 comment 처리한 contaminated fixture와 checksum
+command를 `apt-get install` 뒤로 이동한 contaminated fixture를 추가했다.
+기존 substring validator에서 focused test가 다음 RED로 종료되는 것을
+확인했다.
+
+```text
+not ok - release prerequisite contract rejects a commented checksum verification
+```
+
+Validator를 exact executable whole-line과 line order 검사로 변경한 뒤 같은
+focused test가 exit 0으로 GREEN이 됐다. 두 negative fixture는 각각 comment
+처리된 checksum과 잘못된 checksum order를 계속 거부한다.
+
+### Contract changes
+
+- Leading whitespace만 제거한 뒤 exact whole-line이 정확히 한 번 존재하는지
+  검사한다. 따라서 comment나 command 뒤 documentation text는 executable
+  command로 인정되지 않는다.
+- 다음 네 command의 line number를 얻어 strict order를 검증한다.
+  - pinned HTTPS-only `curl`
+  - exact `sha256sum -c`
+  - verified local `.deb`와 `zsh`의 `apt-get install`
+  - `chezmoi --version`
+- Required order는 `curl < checksum < apt install < version`이다.
+- Pinned URL assignment, `$RUNNER_TEMP` package path, `apt-get update`도
+  executable exact whole-line으로 검증한다.
+
+### Follow-up verification
+
+다음 검증은 모두 exit 0으로 통과했다.
+
+```sh
+sh tests/release_artifacts_test.sh
+sh -n tests/release_artifacts_test.sh
+git diff --check
+```
+
+Follow-up diff는 `tests/release_artifacts_test.sh`와 이 report에만 한정되며,
+`.github/workflows/release.yml`은 변경하지 않았다.
+
+### Follow-up concerns
+
+Known concern 없음.

--- a/tests/release_artifacts_test.sh
+++ b/tests/release_artifacts_test.sh
@@ -74,16 +74,49 @@ validate_no_runner_tool_reinstall() {
   fi
 }
 
+executable_line_number() {
+  contract="$1"
+  expected_line="$2"
+  matches="$(
+    printf '%s\n' "$contract" |
+      sed 's/^[[:space:]]*//' |
+      grep -n -F -x -- "$expected_line"
+  )" || return 1
+
+  [ "$(printf '%s\n' "$matches" | wc -l | tr -d ' ')" -eq 1 ] || return 1
+  printf '%s\n' "${matches%%:*}"
+}
+
 validate_test_prerequisite_contract() {
   test_job_contract="$1"
 
-  [ "$(printf '%s\n' "$test_job_contract" | grep -c -F 'chezmoi_url="https://github.com/twpayne/chezmoi/releases/download/v2.71.1/chezmoi_2.71.1_linux_amd64.deb"')" -eq 1 ] &&
-    [ "$(printf '%s\n' "$test_job_contract" | grep -c -F 'chezmoi_deb="$RUNNER_TEMP/chezmoi_2.71.1_linux_amd64.deb"')" -eq 1 ] &&
-    [ "$(printf '%s\n' "$test_job_contract" | grep -c -F 'curl --fail --location --proto '\''=https'\'' --proto-redir '\''=https'\'' --output "$chezmoi_deb" "$chezmoi_url"')" -eq 1 ] &&
-    [ "$(printf '%s\n' "$test_job_contract" | grep -c -F 'printf '\''%s  %s\n'\'' '\''49b68f441f60fbf84a79928e35076ccd4d0d7d5c050924c27d03bda25a7024eb'\'' "$chezmoi_deb" | sha256sum -c -')" -eq 1 ] &&
-    [ "$(printf '%s\n' "$test_job_contract" | grep -c -F 'sudo apt-get update')" -eq 1 ] &&
-    [ "$(printf '%s\n' "$test_job_contract" | grep -c -F 'sudo apt-get install -y "$chezmoi_deb" zsh')" -eq 1 ] &&
-    [ "$(printf '%s\n' "$test_job_contract" | grep -c -F 'chezmoi --version')" -eq 1 ] ||
+  executable_line_number "$test_job_contract" \
+    'chezmoi_url="https://github.com/twpayne/chezmoi/releases/download/v2.71.1/chezmoi_2.71.1_linux_amd64.deb"' >/dev/null ||
+    return 1
+  executable_line_number "$test_job_contract" \
+    'chezmoi_deb="$RUNNER_TEMP/chezmoi_2.71.1_linux_amd64.deb"' >/dev/null ||
+    return 1
+  curl_line="$(
+    executable_line_number "$test_job_contract" \
+      'curl --fail --location --proto '\''=https'\'' --proto-redir '\''=https'\'' --output "$chezmoi_deb" "$chezmoi_url"'
+  )" || return 1
+  checksum_line="$(
+    executable_line_number "$test_job_contract" \
+      'printf '\''%s  %s\n'\'' '\''49b68f441f60fbf84a79928e35076ccd4d0d7d5c050924c27d03bda25a7024eb'\'' "$chezmoi_deb" | sha256sum -c -'
+  )" || return 1
+  executable_line_number "$test_job_contract" 'sudo apt-get update' >/dev/null ||
+    return 1
+  apt_install_line="$(
+    executable_line_number "$test_job_contract" \
+      'sudo apt-get install -y "$chezmoi_deb" zsh'
+  )" || return 1
+  version_line="$(
+    executable_line_number "$test_job_contract" 'chezmoi --version'
+  )" || return 1
+
+  [ "$curl_line" -lt "$checksum_line" ] &&
+    [ "$checksum_line" -lt "$apt_install_line" ] &&
+    [ "$apt_install_line" -lt "$version_line" ] ||
     return 1
 
   if printf '%s\n' "$test_job_contract" |
@@ -251,6 +284,24 @@ missing_checksum_fixture="$(
 )"
 if validate_test_prerequisite_contract "$missing_checksum_fixture"; then
   fail "release prerequisite contract rejects a missing checksum verification"
+fi
+commented_checksum_fixture="$(
+  printf '%s\n' "$prerequisite_fixture" |
+    sed '/sha256sum -c/s/^[[:space:]]*/          # /'
+)"
+if validate_test_prerequisite_contract "$commented_checksum_fixture"; then
+  fail "release prerequisite contract rejects a commented checksum verification"
+fi
+misordered_checksum_fixture="$(
+  printf '%s\n' "$prerequisite_fixture" |
+    awk '
+      /sha256sum -c/ { checksum = $0; next }
+      { print }
+      /apt-get install -y/ { print checksum }
+    '
+)"
+if validate_test_prerequisite_contract "$misordered_checksum_fixture"; then
+  fail "release prerequisite contract rejects checksum verification after apt install"
 fi
 validate_test_prerequisite_contract "$prerequisite_fixture" ||
   fail "release prerequisite fixture models the required verified package install"

--- a/tests/release_artifacts_test.sh
+++ b/tests/release_artifacts_test.sh
@@ -64,12 +64,30 @@ validate_no_runner_tool_reinstall() {
       sed -n -E 's/^[[:space:]]*(go[[:space:]]+install([[:space:]]|$).*)/\1/p'
   )"
 
-  [ "$apt_install_lines" = 'sudo apt-get install -y zsh' ] &&
-    [ "$go_install_lines" = 'go install github.com/twpayne/chezmoi/v2/cmd/chezmoi@v2.71.1' ] ||
+  [ "$apt_install_lines" = 'sudo apt-get install -y "$chezmoi_deb" zsh' ] &&
+    [ -z "$go_install_lines" ] ||
     return 1
 
   if printf '%s\n' "$workflow_contract" |
     grep -E '^[[:space:]]*(-[[:space:]]+uses:.*mise|mise[[:space:]]+install([[:space:]]|$))' >/dev/null; then
+    return 1
+  fi
+}
+
+validate_test_prerequisite_contract() {
+  test_job_contract="$1"
+
+  [ "$(printf '%s\n' "$test_job_contract" | grep -c -F 'chezmoi_url="https://github.com/twpayne/chezmoi/releases/download/v2.71.1/chezmoi_2.71.1_linux_amd64.deb"')" -eq 1 ] &&
+    [ "$(printf '%s\n' "$test_job_contract" | grep -c -F 'chezmoi_deb="$RUNNER_TEMP/chezmoi_2.71.1_linux_amd64.deb"')" -eq 1 ] &&
+    [ "$(printf '%s\n' "$test_job_contract" | grep -c -F 'curl --fail --location --proto '\''=https'\'' --proto-redir '\''=https'\'' --output "$chezmoi_deb" "$chezmoi_url"')" -eq 1 ] &&
+    [ "$(printf '%s\n' "$test_job_contract" | grep -c -F 'printf '\''%s  %s\n'\'' '\''49b68f441f60fbf84a79928e35076ccd4d0d7d5c050924c27d03bda25a7024eb'\'' "$chezmoi_deb" | sha256sum -c -')" -eq 1 ] &&
+    [ "$(printf '%s\n' "$test_job_contract" | grep -c -F 'sudo apt-get update')" -eq 1 ] &&
+    [ "$(printf '%s\n' "$test_job_contract" | grep -c -F 'sudo apt-get install -y "$chezmoi_deb" zsh')" -eq 1 ] &&
+    [ "$(printf '%s\n' "$test_job_contract" | grep -c -F 'chezmoi --version')" -eq 1 ] ||
+    return 1
+
+  if printf '%s\n' "$test_job_contract" |
+    grep -E 'go[[:space:]]+install[[:space:]]+github\.com/twpayne/chezmoi|GITHUB_PATH' >/dev/null; then
     return 1
   fi
 }
@@ -213,6 +231,31 @@ pass "manifest binds all release assets"
 
 workflow="$(cat "$repo_root/.github/workflows/release.yml")"
 test_job="$(printf '%s\n' "$workflow" | sed -n '/^  test:$/,/^  release:$/p')"
+prerequisite_fixture='          chezmoi_url="https://github.com/twpayne/chezmoi/releases/download/v2.71.1/chezmoi_2.71.1_linux_amd64.deb"
+          chezmoi_deb="$RUNNER_TEMP/chezmoi_2.71.1_linux_amd64.deb"
+          curl --fail --location --proto '\''=https'\'' --proto-redir '\''=https'\'' --output "$chezmoi_deb" "$chezmoi_url"
+          printf '\''%s  %s\n'\'' '\''49b68f441f60fbf84a79928e35076ccd4d0d7d5c050924c27d03bda25a7024eb'\'' "$chezmoi_deb" | sha256sum -c -
+          sudo apt-get update
+          sudo apt-get install -y "$chezmoi_deb" zsh
+          chezmoi --version'
+wrong_package_fixture="$(
+  printf '%s\n' "$prerequisite_fixture" |
+    sed 's|chezmoi_2.71.1_linux_amd64\.deb|cmd/chezmoi|'
+)"
+if validate_test_prerequisite_contract "$wrong_package_fixture"; then
+  fail "release prerequisite contract rejects the wrong chezmoi package path"
+fi
+missing_checksum_fixture="$(
+  printf '%s\n' "$prerequisite_fixture" |
+    sed '/sha256sum -c/d'
+)"
+if validate_test_prerequisite_contract "$missing_checksum_fixture"; then
+  fail "release prerequisite contract rejects a missing checksum verification"
+fi
+validate_test_prerequisite_contract "$prerequisite_fixture" ||
+  fail "release prerequisite fixture models the required verified package install"
+validate_test_prerequisite_contract "$test_job" ||
+  fail "release test job installs the verified pinned chezmoi package and zsh"
 for runner_tool in mise jq gh; do
   if validate_no_runner_tool_reinstall \
     "$(printf '%s\n' "$workflow"; printf '          sudo apt-get install -y %s\n' "$runner_tool")"; then
@@ -224,20 +267,10 @@ if validate_no_runner_tool_reinstall \
   fail "release workflow contract rejects go install of mise"
 fi
 validate_no_runner_tool_reinstall \
-  "$(printf '%s\n' "$workflow"; printf '%s\n' '          # sudo apt-get install -y jq' '          echo "go install github.com/jdx/mise@v1.0.0"')" ||
+  "$(printf '%s\n' "$prerequisite_fixture"; printf '%s\n' '          # sudo apt-get install -y jq' '          echo "go install github.com/jdx/mise@v1.0.0"')" ||
   fail "release workflow install contract ignores documentation"
 validate_no_runner_tool_reinstall "$workflow" ||
   fail "release workflow only installs required test prerequisites"
-[ "$(printf '%s\n' "$workflow" | grep -c -F 'go install github.com/twpayne/chezmoi/v2/cmd/chezmoi@')" -eq 1 ] ||
-  fail "release workflow installs chezmoi exactly once"
-printf '%s\n' "$test_job" | grep -F 'go install github.com/twpayne/chezmoi/v2/cmd/chezmoi@v2.71.1' >/dev/null ||
-  fail "release test job installs pinned chezmoi v2.71.1"
-printf '%s\n' "$test_job" | grep -F 'echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"' >/dev/null ||
-  fail "release test job exposes GOPATH bin to later steps"
-printf '%s\n' "$test_job" | grep -F '"$(go env GOPATH)/bin/chezmoi" --version' >/dev/null ||
-  fail "release test job verifies the installed chezmoi binary"
-printf '%s\n' "$test_job" | grep -F 'apt-get install -y zsh' >/dev/null ||
-  fail "release test job installs zsh with Ubuntu package tooling"
 printf '%s' "$workflow" | grep -F 'release_base="https://github.com/${GITHUB_REPOSITORY}/releases/latest/download"' >/dev/null ||
   fail "versioned installer repairs from the latest stable release base"
 for required in \


### PR DESCRIPTION
## Summary

- install the official pinned chezmoi v2.71.1 `linux_amd64.deb` in the Ubuntu Release test job
- verify the package with its exact SHA-256 before local `.deb` installation
- keep initial requests and redirects HTTPS-only
- strengthen the Release workflow contract so commented commands or checksum verification after installation are rejected

## Root cause

The previous workflow attempted to install `github.com/twpayne/chezmoi/v2/cmd/chezmoi@v2.71.1`, but that Go package does not exist. Installing the module root is also unsupported because the upstream module contains `exclude` directives.

## Verification

- `mise exec go@1.26.0 -- go test ./...`
- all 23 `tests/*_test.sh`
- `sh -n tests/release_artifacts_test.sh`
- `git diff --check`
- disposable `ubuntu:24.04` `linux/amd64` container: checksum verified, chezmoi v2.71.1 and zsh 5.9 installed

## Safety

- no real-home migration, installer execution, or `chezmoi apply`
- no host package installation
- no signing configuration reintroduced
