### PR TITLE
fix: package extractable source releases

### DIFF
--- a/scripts/package-source.sh
+++ b/scripts/package-source.sh
@@ -32,7 +32,7 @@ mkdir -p "$(dirname "$output")"
 # Git trees contain tracked files in bytewise path order. git archive emits
 # their recorded modes with numeric owner/group 0; --mtime binds every entry
 # to the tagged commit time. gzip -n removes its own timestamp and filename.
-LC_ALL=C git -C "$root" archive --format=tar --mtime="@$timestamp" "$tag_commit" |
+LC_ALL=C git -C "$root" archive --format=tar --mtime="@$timestamp" "${tag_commit}^{tree}" |
   gzip -n >"$temporary"
 mv "$temporary" "$output"
 trap - EXIT HUP INT TERM

--- a/tests/release_artifacts_test.sh
+++ b/tests/release_artifacts_test.sh
@@ -198,6 +198,9 @@ digest_two="$(shasum -a 256 "$tmp_dir/source-2.tar.gz" | awk '{print $1}')"
 [ "$digest_one" = "$digest_two" ] || fail "source archives are reproducible"
 [ "$(od -An -t u1 -j 4 -N 4 "$tmp_dir/source-1.tar.gz" | tr -d ' ')" = "0000" ] ||
   fail "gzip timestamp is zero"
+first_archive_entry="$(gzip -dc "$tmp_dir/source-1.tar.gz" | dd bs=100 count=1 2>/dev/null | tr -d '\000')"
+[ "$first_archive_entry" != pax_global_header ] ||
+  fail "source archive starts with an unsupported global PAX header"
 archive_names="$(tar -tzf "$tmp_dir/source-1.tar.gz")"
 [ "$archive_names" = "$(printf '%s\n' "$archive_names" | LC_ALL=C sort)" ] ||
   fail "source archive paths are bytewise sorted"


### PR DESCRIPTION
## 변경 사항

- stable source archive를 commit object 대신 동일한 tree object에서 생성합니다.
- release artifact의 첫 entry가 unsupported global PAX header인지 검사하는 regression test를 추가합니다.

## 원인

`git archive`에 commit을 전달하면 commit ID를 담은 `pax_global_header`가 생성됩니다. Management Core extractor는 regular file과 directory만 허용하므로 v1.0.0 source archive staging이 실패했습니다.

## 영향

새 release의 source archive는 기존 ordering, mode, timestamp 재현성을 유지하면서 Management Core에서 정상적으로 staging할 수 있습니다.

## 검증

- RED: 기존 구현에서 `source archive starts with an unsupported global PAX header` 실패 확인
- GREEN: `sh tests/release_artifacts_test.sh`
- `go test ./...`
- 모든 `tests/*_test.sh`