### PR TITLE
fix: provide Homebrew migration home

### DIFF
--- a/cmd/tpod/composition.go
+++ b/cmd/tpod/composition.go
@@ -60,12 +60,12 @@ func productionPlanner(layout paths.Layout, store *state.Store, client chezmoi.C
 	if err != nil {
 		return nil, err
 	}
-	runner := execx.NewRunner([]string{"LC_ALL"}, noninteractivePrivilege, os.Geteuid)
-	formulaProvider, err := homebrew.New(homebrew.Formula, tools.brew, filepath.Join(layout.StateDir, "recovery", "homebrew"), runner, homebrew.AppPolicy{})
+	runner := execx.NewRunner([]string{"HOME", "LC_ALL"}, noninteractivePrivilege, os.Geteuid)
+	formulaProvider, err := homebrew.New(homebrew.Formula, tools.brew, filepath.Join(layout.StateDir, "recovery", "homebrew"), runner, homebrew.AppPolicy{Home: layout.HomeDir})
 	if err != nil {
 		return nil, err
 	}
-	caskProvider, err := homebrew.New(homebrew.Cask, tools.brew, filepath.Join(layout.StateDir, "recovery", "homebrew"), runner, homebrew.AppPolicy{HomeApplications: filepath.Join(layout.HomeDir, "Applications")})
+	caskProvider, err := homebrew.New(homebrew.Cask, tools.brew, filepath.Join(layout.StateDir, "recovery", "homebrew"), runner, homebrew.AppPolicy{Home: layout.HomeDir, HomeApplications: filepath.Join(layout.HomeDir, "Applications")})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/homebrew/homebrew.go
+++ b/internal/provider/homebrew/homebrew.go
@@ -64,6 +64,7 @@ type FileSystem interface {
 }
 
 type AppPolicy struct {
+	Home             string
 	HomeApplications string
 	Inspector        AppInspector
 	Running          RunningChecker
@@ -78,6 +79,7 @@ type Adapter struct {
 	recoveryDir      string
 	standard         bool
 	runner           Runner
+	home             string
 	homeApplications string
 	inspector        AppInspector
 	running          RunningChecker
@@ -116,6 +118,9 @@ func New(kind Kind, brewPath, recoveryDir string, runner Runner, policy AppPolic
 	if policy.HomeApplications != "" && (!filepath.IsAbs(policy.HomeApplications) || filepath.Clean(policy.HomeApplications) != policy.HomeApplications) {
 		return nil, fmt.Errorf("homebrew: home Applications path must be clean and absolute: %q", policy.HomeApplications)
 	}
+	if policy.Home != "" && (!filepath.IsAbs(policy.Home) || filepath.Clean(policy.Home) != policy.Home) {
+		return nil, fmt.Errorf("homebrew: home path must be clean and absolute: %q", policy.Home)
+	}
 	fs := policy.FS
 	if fs == nil {
 		fs = osFS{}
@@ -132,6 +137,7 @@ func New(kind Kind, brewPath, recoveryDir string, runner Runner, policy AppPolic
 		recoveryDir:      recoveryDir,
 		standard:         standard,
 		runner:           runner,
+		home:             policy.Home,
 		homeApplications: policy.HomeApplications,
 		inspector:        policy.Inspector,
 		running:          policy.Running,
@@ -387,7 +393,11 @@ func (a *Adapter) validateOperation(operation model.Operation) error {
 }
 
 func (a *Adapter) run(ctx context.Context, args ...string) (execx.Result, error) {
-	return a.runner.Run(ctx, execx.Request{Path: a.brewPath, Args: append([]string(nil), args...)})
+	request := execx.Request{Path: a.brewPath, Args: append([]string(nil), args...)}
+	if a.home != "" {
+		request.Env = map[string]string{"HOME": a.home}
+	}
+	return a.runner.Run(ctx, request)
 }
 
 type appDeclaration struct {

--- a/internal/provider/homebrew/homebrew_test.go
+++ b/internal/provider/homebrew/homebrew_test.go
@@ -84,6 +84,7 @@ func TestConstructorRejectsTypedNilDependencies(t *testing.T) {
 
 func TestFormulaInspectUsesFixedInventoryCommandsAndVerifiesProvidedCommands(t *testing.T) {
 	var calls []execx.Request
+	home := t.TempDir()
 	runner := runnerFunc(func(_ context.Context, request execx.Request) (execx.Result, error) {
 		calls = append(calls, request)
 		switch strings.Join(request.Args, " ") {
@@ -96,7 +97,7 @@ func TestFormulaInspectUsesFixedInventoryCommandsAndVerifiesProvidedCommands(t *
 		}
 	})
 	fs := fakeFS{files: map[string]os.FileInfo{"/opt/homebrew/bin/rg": fakeInfo{name: "rg", mode: 0o755}}}
-	adapter, err := New(Formula, "/opt/homebrew/bin/brew", t.TempDir(), runner, AppPolicy{FS: fs})
+	adapter, err := New(Formula, "/opt/homebrew/bin/brew", t.TempDir(), runner, AppPolicy{Home: home, FS: fs})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,8 +112,8 @@ func TestFormulaInspectUsesFixedInventoryCommandsAndVerifiesProvidedCommands(t *
 		t.Fatalf("observation = %#v", got)
 	}
 	want := []execx.Request{
-		{Path: "/opt/homebrew/bin/brew", Args: []string{"info", "--json=v2", "ripgrep"}},
-		{Path: "/opt/homebrew/bin/brew", Args: []string{"list", "--versions", "ripgrep"}},
+		{Path: "/opt/homebrew/bin/brew", Args: []string{"info", "--json=v2", "ripgrep"}, Env: map[string]string{"HOME": home}},
+		{Path: "/opt/homebrew/bin/brew", Args: []string{"list", "--versions", "ripgrep"}, Env: map[string]string{"HOME": home}},
 	}
 	if !reflect.DeepEqual(calls, want) {
 		t.Fatalf("calls = %#v, want %#v", calls, want)


### PR DESCRIPTION
## 변경 사항

- production Homebrew adapters에 검증된 `layout.HomeDir`을 전달합니다.
- Homebrew command request에 `HOME`을 명시적으로 포함합니다.
- sanitized runner가 `HOME`만 허용하도록 allowlist를 확장합니다.
- inventory inspection에서 `HOME` propagation을 검증하는 regression test를 추가합니다.

## 원인

Management Core의 `execx.Runner`는 command environment를 비운 상태로 실행합니다. Homebrew adapter가 `HOME`을 전달하지 않아 `brew info --json=v2 bat`가 `$HOME must be set to run brew`로 종료됐고, migration preflight가 중단됐습니다.

## 영향

migration과 일반 reconciliation에서 Homebrew formula/cask command가 검증된 사용자 home을 사용합니다. 다른 provider의 environment contract는 변경하지 않습니다.

## 검증

- RED: `AppPolicy`에 explicit Home dependency가 없어 regression test compile failure 확인
- GREEN: Homebrew request의 `HOME` propagation test 통과
- `env -i HOME="$HOME" /opt/homebrew/bin/brew info --json=v2 bat`
- `go test ./...`
- 모든 `tests/*_test.sh`