### PR TITLE
Move personal Git settings out of Terrapod

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -285,7 +285,6 @@ Optional stack profile과 macOS App Group setting은 기본적으로 disabled입
 | `enableMacosAppGroupLauncher` | `false` | launcher macOS App Group인 Raycast와 1Password CLI를 설치합니다. |
 | `enableMacosAppGroupMonitoring` | `false` | monitoring macOS App Group인 iStat Menus를 설치합니다. |
 | `enableMacosAppGroupDevelopmentApps` | `false` | development-apps macOS App Group인 Zed와 Orca ADE(`stablyai/orca/orca`)를 설치합니다. |
-| `gitAllowedSigners` | `[]` | workstation-specific SSH signing identity를 `~/.ssh/allowed_signers`에 추가합니다. |
 
 `enableDevelopmentWorkspace`가 `true`이면 `enableEditorStack`이나 `enableAiCliTools`가 false로 기록되어 있어도 Optional Editor Stack과 Optional AI Tool Stack이 함께 활성화됩니다.
 
@@ -345,18 +344,24 @@ enableAiCliTools = false
 enableDevelopmentWorkspace = true
 ```
 
-Git signing identity는 어느 profile과도 함께 설정할 수 있습니다.
+## Git Configuration
 
-```toml
-gitAllowedSigners = [
-  "name@company.com ssh-ed25519 AAAA_COMPANY_PUBLIC_KEY company",
-]
-```
-
-그 다음 dotfiles를 apply합니다.
+Terrapod은 공용 Git 설정을 `~/.config/git/config`에서 관리합니다.
+`~/.gitconfig`이 없으면 생성하고, 이후 content는 사용자가 관리합니다. 설치 후
+identity를 설정합니다.
 
 ```sh
-terrapod apply
+git config set --global user.name "Your Name"
+git config set --global user.email "you@example.com"
+```
+
+SSH commit signing은 optional입니다. 자신의 public key로 활성화하려면 다음과
+같이 설정합니다.
+
+```sh
+git config set --global gpg.format ssh
+git config set --global user.signingKey "ssh-ed25519 YOUR_PUBLIC_KEY"
+git config set --global commit.gpgSign true
 ```
 
 ## Repository Conventions

--- a/README.md
+++ b/README.md
@@ -303,7 +303,6 @@ Optional stack profiles and macOS App Group settings are disabled by default.
 | `enableMacosAppGroupLauncher` | `false` | Installs the launcher macOS App Group: Raycast and 1Password CLI. |
 | `enableMacosAppGroupMonitoring` | `false` | Installs the monitoring macOS App Group: iStat Menus. |
 | `enableMacosAppGroupDevelopmentApps` | `false` | Installs the development-apps macOS App Group: Zed and Orca ADE (`stablyai/orca/orca`). |
-| `gitAllowedSigners` | `[]` | Adds workstation-specific SSH signing identities to `~/.ssh/allowed_signers`. |
 
 When `enableDevelopmentWorkspace` is `true`, it enables both the Optional Editor Stack and Optional AI Tool Stack
 even when `enableEditorStack` or `enableAiCliTools` are recorded as false.
@@ -366,18 +365,23 @@ enableAiCliTools = false
 enableDevelopmentWorkspace = true
 ```
 
-Git signing identities can be configured alongside any profile.
+## Git Configuration
 
-```toml
-gitAllowedSigners = [
-  "name@company.com ssh-ed25519 AAAA_COMPANY_PUBLIC_KEY company",
-]
-```
-
-Then apply the dotfiles.
+Terrapod manages shared Git settings in `~/.config/git/config`. It creates
+`~/.gitconfig` when missing, then leaves its contents user-managed. Configure
+your identity after installation.
 
 ```sh
-terrapod apply
+git config set --global user.name "Your Name"
+git config set --global user.email "you@example.com"
+```
+
+SSH commit signing is optional. To enable it with your own public key:
+
+```sh
+git config set --global gpg.format ssh
+git config set --global user.signingKey "ssh-ed25519 YOUR_PUBLIC_KEY"
+git config set --global commit.gpgSign true
 ```
 
 ## Repository Conventions

--- a/create_dot_gitconfig
+++ b/create_dot_gitconfig
@@ -1,0 +1,1 @@
+# User-specific Git settings. Terrapod does not manage this file after creation.

--- a/dot_config/git/config
+++ b/dot_config/git/config
@@ -1,19 +1,3 @@
-[user]
-	name = Minu
-	email = juty9026@gmail.com
-	signingkey = ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINz8oDp6v7P4IXYUzIsNuH3TvCogpPexpMYNB4JTxysJ
-[gpg]
-	format = ssh
-{{ if eq .chezmoi.os "darwin" }}
-[gpg "ssh"]
-	program = /Applications/1Password.app/Contents/MacOS/op-ssh-sign
-	allowedSignersFile = ~/.ssh/allowed_signers
-[commit]
-	gpgsign = true
-{{ else }}
-[commit]
-	gpgsign = false
-{{ end }}
 [merge]
 	ff = false
 	conflictStyle = zdiff3

--- a/private_dot_ssh/allowed_signers.tmpl
+++ b/private_dot_ssh/allowed_signers.tmpl
@@ -1,5 +1,0 @@
-{{- $extraAllowedSigners := default (list) (get . "gitAllowedSigners") -}}
-juty9026@gmail.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINz8oDp6v7P4IXYUzIsNuH3TvCogpPexpMYNB4JTxysJ github
-{{- range $extraAllowedSigners }}
-{{ . }}
-{{- end }}

--- a/tests/git_config_test.sh
+++ b/tests/git_config_test.sh
@@ -1,0 +1,124 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+managed_config="$repo_root/dot_config/git/config"
+user_config_source="$repo_root/create_dot_gitconfig"
+readme="$repo_root/README.md"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT INT TERM
+
+fail() {
+  printf '%s\n' "not ok - $1" >&2
+  exit 1
+}
+
+pass() {
+  printf '%s\n' "ok - $1"
+}
+
+assert_contains() {
+  file="$1"
+  needle="$2"
+  message="$3"
+
+  if ! grep -F "$needle" "$file" >/dev/null; then
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
+assert_not_contains() {
+  file="$1"
+  needle="$2"
+  message="$3"
+
+  if grep -F "$needle" "$file" >/dev/null; then
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
+if [ ! -f "$managed_config" ]; then
+  fail "Terrapod manages shared Git settings through ~/.config/git/config"
+fi
+pass "Terrapod manages shared Git settings through ~/.config/git/config"
+
+if [ -e "$repo_root/private_dot_gitconfig.tmpl" ]; then
+  fail "Terrapod leaves ~/.gitconfig unmanaged"
+fi
+pass "Terrapod leaves ~/.gitconfig unmanaged"
+
+if [ ! -f "$user_config_source" ]; then
+  fail "Terrapod creates ~/.gitconfig only when it does not exist"
+fi
+pass "Terrapod creates ~/.gitconfig only when it does not exist"
+
+if [ -e "$repo_root/private_dot_ssh/allowed_signers.tmpl" ]; then
+  fail "Terrapod leaves SSH allowed signers unmanaged"
+fi
+pass "Terrapod leaves SSH allowed signers unmanaged"
+
+assert_contains "$managed_config" "[merge]" "shared Git config preserves merge settings"
+assert_contains "$managed_config" "[pull]" "shared Git config preserves pull settings"
+assert_contains "$managed_config" "[delta]" "shared Git config preserves delta settings"
+
+for personal_setting in \
+  "[user]" \
+  "signingkey" \
+  "[gpg]" \
+  "op-ssh-sign" \
+  "allowedSignersFile" \
+  "gpgsign"
+do
+  assert_not_contains "$managed_config" "$personal_setting" \
+    "shared Git config excludes personal setting: $personal_setting"
+done
+
+test_home="$tmp_dir/home"
+test_xdg="$tmp_dir/xdg"
+mkdir -p "$test_home" "$test_xdg/git"
+cp "$managed_config" "$test_xdg/git/config"
+cp "$managed_config" "$tmp_dir/shared-config-before"
+
+HOME="$test_home" XDG_CONFIG_HOME="$test_xdg" \
+  chezmoi --source "$repo_root" --destination "$test_home" apply "$test_home/.gitconfig"
+HOME="$test_home" XDG_CONFIG_HOME="$test_xdg" \
+  git config set --global user.name "Test User"
+HOME="$test_home" XDG_CONFIG_HOME="$test_xdg" \
+  git config set --global user.email "test@example.com"
+
+if ! cmp -s "$tmp_dir/shared-config-before" "$test_xdg/git/config"; then
+  fail "setting user-level Git identity leaves shared Terrapod config unchanged"
+fi
+pass "setting user-level Git identity leaves shared Terrapod config unchanged"
+
+if [ "$(HOME="$test_home" XDG_CONFIG_HOME="$test_xdg" git config get user.name)" != "Test User" ] ||
+   [ "$(HOME="$test_home" XDG_CONFIG_HOME="$test_xdg" git config get user.email)" != "test@example.com" ]; then
+  fail "user-level Git identity overrides shared Terrapod settings"
+fi
+pass "user-level Git identity overrides shared Terrapod settings"
+
+if [ "$(HOME="$test_home" XDG_CONFIG_HOME="$test_xdg" git config get merge.ff)" != "false" ]; then
+  fail "setting user-level Git identity preserves shared Terrapod settings"
+fi
+pass "setting user-level Git identity preserves shared Terrapod settings"
+
+cp "$test_home/.gitconfig" "$tmp_dir/user-config-before"
+HOME="$test_home" XDG_CONFIG_HOME="$test_xdg" \
+  chezmoi --source "$repo_root" --destination "$test_home" apply "$test_home/.gitconfig"
+if ! cmp -s "$tmp_dir/user-config-before" "$test_home/.gitconfig"; then
+  fail "Terrapod preserves user changes in ~/.gitconfig on later applies"
+fi
+pass "Terrapod preserves user changes in ~/.gitconfig on later applies"
+
+assert_contains "$readme" 'git config set --global user.name "Your Name"' \
+  "README documents user-level Git name setup"
+assert_contains "$readme" 'git config set --global user.email "you@example.com"' \
+  "README documents user-level Git email setup"
+assert_contains "$readme" 'git config set --global user.signingKey "ssh-ed25519 YOUR_PUBLIC_KEY"' \
+  "README documents optional SSH signing setup"
+assert_not_contains "$readme" "gitAllowedSigners" \
+  "README removes the managed Git signer option"

--- a/tests/terrapod_config_test.sh
+++ b/tests/terrapod_config_test.sh
@@ -1269,15 +1269,15 @@ pass "existing update preserves config file mode"
 
 assert_no_terrapod_temp_files "$array_config" "successful array-table update cleans Terrapod temp files"
 
-signers_home="$tmp_dir/signers-home"
-signers_xdg="$tmp_dir/signers-xdg"
-signers_config="$signers_xdg/chezmoi/chezmoi.toml"
-mkdir -p "$signers_home" "$(dirname "$signers_config")"
+custom_array_home="$tmp_dir/custom-array-home"
+custom_array_xdg="$tmp_dir/custom-array-xdg"
+custom_array_config="$custom_array_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$custom_array_home" "$(dirname "$custom_array_config")"
 
-cat >"$signers_config" <<'TOML'
+cat >"$custom_array_config" <<'TOML'
 [data]
-gitAllowedSigners = [
-  "name@company.com ssh-ed25519 AAAA_COMPANY_PUBLIC_KEY company",
+customValues = [
+  "preserve-me",
 ]
 enableEditorStack = false
 enableAiCliTools = false
@@ -1286,18 +1286,18 @@ enableAiCliTools = false
 branch = "main"
 TOML
 
-run_terrapod_configure development "y" "$signers_home" "$signers_xdg"
+run_terrapod_configure development "y" "$custom_array_home" "$custom_array_xdg"
 
-assert_contains "$signers_config" "gitAllowedSigners = [" "documented signer array update preserves array header"
-assert_contains "$signers_config" "name@company.com ssh-ed25519 AAAA_COMPANY_PUBLIC_KEY company" "documented signer array update preserves signer value"
-assert_data_key_once_with_value "$signers_config" "enableEditorStack" "true" "documented signer array update writes Editor Stack in data"
-assert_data_key_once_with_value "$signers_config" "enableAiCliTools" "true" "documented signer array update writes AI Tool Stack in data"
-assert_data_key_once_with_value "$signers_config" "enableDevelopmentWorkspace" "true" "documented signer array update writes Development Workspace in data"
-assert_data_key_once_with_value "$signers_config" "enableMacosAppGroupTerminalApps" "false" "documented signer array update writes terminal-apps App Group in data"
-assert_data_key_once_with_value "$signers_config" "enableMacosAppGroupAutomation" "false" "documented signer array update writes automation App Group in data"
-assert_data_key_once_with_value "$signers_config" "enableMacosAppGroupLauncher" "false" "documented signer array update writes launcher App Group in data"
-assert_data_key_once_with_value "$signers_config" "enableMacosAppGroupMonitoring" "false" "documented signer array update writes monitoring App Group in data"
-assert_contains "$signers_config" "branch = \"main\"" "documented signer array update preserves later sections"
+assert_contains "$custom_array_config" "customValues = [" "custom array update preserves array header"
+assert_contains "$custom_array_config" "preserve-me" "custom array update preserves array value"
+assert_data_key_once_with_value "$custom_array_config" "enableEditorStack" "true" "custom array update writes Editor Stack in data"
+assert_data_key_once_with_value "$custom_array_config" "enableAiCliTools" "true" "custom array update writes AI Tool Stack in data"
+assert_data_key_once_with_value "$custom_array_config" "enableDevelopmentWorkspace" "true" "custom array update writes Development Workspace in data"
+assert_data_key_once_with_value "$custom_array_config" "enableMacosAppGroupTerminalApps" "false" "custom array update writes terminal-apps App Group in data"
+assert_data_key_once_with_value "$custom_array_config" "enableMacosAppGroupAutomation" "false" "custom array update writes automation App Group in data"
+assert_data_key_once_with_value "$custom_array_config" "enableMacosAppGroupLauncher" "false" "custom array update writes launcher App Group in data"
+assert_data_key_once_with_value "$custom_array_config" "enableMacosAppGroupMonitoring" "false" "custom array update writes monitoring App Group in data"
+assert_contains "$custom_array_config" "branch = \"main\"" "custom array update preserves later sections"
 
 multiline_array_home="$tmp_dir/multiline-array-home"
 multiline_array_xdg="$tmp_dir/multiline-array-xdg"


### PR DESCRIPTION
## 변경 사항

- 공용 Git 설정을 `~/.config/git/config`으로 이동했습니다.
- `~/.gitconfig`은 없을 때만 생성하고 이후 content는 사용자가 관리하도록 분리했습니다.
- 개인 Git identity, SSH signing key, 1Password signer, `allowed_signers` 관리를 제거했습니다.
- user identity와 optional SSH signing 설정 방법을 README에 추가했습니다.
- create-once 및 user override 동작을 검증하는 regression test를 추가했습니다.

## 이유

public Terrapod repository가 특정 사용자의 Git identity와 signing 정책을 배포하지 않고 범용 공용 설정만 관리하도록 책임을 분리합니다.

## 영향

새 installation에서는 `git config set --global`이 user-managed `~/.gitconfig`에 기록됩니다. 기존 `~/.gitconfig`은 변경하지 않습니다.

## 검증

- 전체 automated test 18개 통과
- `git diff --check` 통과
- 기존 email 및 SSH public key가 현재 source에서 제거된 것을 확인했습니다.