### PR TITLE
Add the mobile-dev macOS App Group

### DIFF
--- a/.chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl
+++ b/.chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl
@@ -86,7 +86,7 @@ join_lines_with_commas() {
   ' "$1"
 }
 
-desktop_app_cask_records() {
+desktop_app_package_records() {
   brewfile="$1"
 
   awk '
@@ -97,12 +97,17 @@ desktop_app_cask_records() {
       next
     }
 
-    /^[[:space:]]*cask[[:space:]]+"/ {
-      cask = $0
-      sub(/^[[:space:]]*cask[[:space:]]+"/, "", cask)
-      sub(/".*$/, "", cask)
-      if (cask != "") {
-        printf "%s\t%s\n", group, cask
+    /^[[:space:]]*(cask|brew)[[:space:]]+"/ {
+      declaration = $0
+      sub(/^[[:space:]]+/, "", declaration)
+      sub(/[[:space:]]+$/, "", declaration)
+
+      token = declaration
+      sub(/^(cask|brew)[[:space:]]+"/, "", token)
+      sub(/".*$/, "", token)
+
+      if (token != "") {
+        printf "%s\t%s\t%s\n", group, token, declaration
       }
     }
   ' "$brewfile"
@@ -114,7 +119,7 @@ cleanup_desktop_app_bundle_temps() {
   [ -z "${records_file:-}" ] || rm -f "$records_file"
   [ -z "${failed_casks_file:-}" ] || rm -f "$failed_casks_file"
   [ -z "${failed_groups_file:-}" ] || rm -f "$failed_groups_file"
-  [ -z "${single_cask_brewfile:-}" ] || rm -f "$single_cask_brewfile"
+  [ -z "${single_package_brewfile:-}" ] || rm -f "$single_package_brewfile"
 }
 
 run_desktop_app_bundle() {
@@ -128,7 +133,7 @@ run_desktop_app_bundle() {
   records_file=
   failed_casks_file=
   failed_groups_file=
-  single_cask_brewfile=
+  single_package_brewfile=
 
   records_file="$(mktemp "${TMPDIR:-/tmp}/terrapod-macos-desktop-records.XXXXXX")" || return 1
   failed_casks_file="$(mktemp "${TMPDIR:-/tmp}/terrapod-macos-desktop-failed-casks.XXXXXX")" || {
@@ -140,7 +145,7 @@ run_desktop_app_bundle() {
     return 1
   }
 
-  if ! desktop_app_cask_records "$brewfile" >"$records_file"; then
+  if ! desktop_app_package_records "$brewfile" >"$records_file"; then
     cleanup_desktop_app_bundle_temps
     return 1
   fi
@@ -151,18 +156,18 @@ run_desktop_app_bundle() {
   fi
 
   tab="$(printf '\t')"
-  while IFS="$tab" read -r app_group cask; do
-    single_cask_brewfile="$(mktemp "${TMPDIR:-/tmp}/terrapod-macos-desktop-cask.XXXXXX")" || {
+  while IFS="$tab" read -r app_group token declaration; do
+    single_package_brewfile="$(mktemp "${TMPDIR:-/tmp}/terrapod-macos-desktop-package.XXXXXX")" || {
       cleanup_desktop_app_bundle_temps
       return 1
     }
-    if ! printf 'cask "%s"\n' "$cask" >"$single_cask_brewfile"; then
+    if ! printf '%s\n' "$declaration" >"$single_package_brewfile"; then
       cleanup_desktop_app_bundle_temps
       return 1
     fi
 
-    if ! HOMEBREW_NO_AUTO_UPDATE=1 brew bundle --no-upgrade --file="$single_cask_brewfile"; then
-      if ! printf '%s\n' "$cask" >>"$failed_casks_file"; then
+    if ! HOMEBREW_NO_AUTO_UPDATE=1 brew bundle --no-upgrade --file="$single_package_brewfile"; then
+      if ! printf '%s\n' "$token" >>"$failed_casks_file"; then
         cleanup_desktop_app_bundle_temps
         return 1
       fi
@@ -174,8 +179,8 @@ run_desktop_app_bundle() {
       fi
     fi
 
-    rm -f "$single_cask_brewfile"
-    single_cask_brewfile=
+    rm -f "$single_package_brewfile"
+    single_package_brewfile=
   done <"$records_file"
 
   if [ -s "$failed_casks_file" ]; then

--- a/.chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl
+++ b/.chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl
@@ -6,7 +6,8 @@
     (default false (get . "enableMacosAppGroupAutomation"))
     (default false (get . "enableMacosAppGroupLauncher"))
     (default false (get . "enableMacosAppGroupMonitoring"))
-    (default false (get . "enableMacosAppGroupDevelopmentApps")))
+    (default false (get . "enableMacosAppGroupDevelopmentApps"))
+    (default false (get . "enableMacosAppGroupMobileDev")))
 -}}
 #!/bin/sh
 set -eu

--- a/.chezmoiscripts/run_onchange_after_50-open-karabiner-if-needed.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_50-open-karabiner-if-needed.sh.tmpl
@@ -5,6 +5,7 @@
   (default false (get . "enableMacosAppGroupLauncher"))
   (default false (get . "enableMacosAppGroupMonitoring"))
   (default false (get . "enableMacosAppGroupDevelopmentApps"))
+  (default false (get . "enableMacosAppGroupMobileDev"))
 -}}
 #!/bin/sh
 set -eu

--- a/Brewfile.macos-desktop-apps.tmpl
+++ b/Brewfile.macos-desktop-apps.tmpl
@@ -24,3 +24,8 @@ cask "zed"
 cask "stablyai/orca/orca", trusted: true
 cask "orbstack"
 {{ end -}}
+{{ if default false (get . "enableMacosAppGroupMobileDev") -}}
+# mobile-dev macOS App Group
+cask "android-studio"
+brew "mobile-dev-inc/tap/maestro", trusted: true
+{{ end -}}

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -53,7 +53,7 @@ mise, which installs and selects Bun, Node.js, Python, and uv independently from
 _Avoid_: Modern CLI Provider, Homebrew runtime manager, aqua tool provider
 
 **macOS Desktop App Stack**:
-The opt-in macOS cask set for GUI apps, system-style desktop apps, and cask-delivered desktop support tools.
+The opt-in macOS package set for GUI apps, system-style desktop apps, cask-delivered desktop support tools, and tap-delivered companion CLIs that ship with those apps.
 _Avoid_: Homebrew bootstrap, shared CLI formula, Core Shell Stack
 
 **macOS App Group**:
@@ -292,7 +292,7 @@ _Avoid_: separate Korean introduction, independent README, self-labeled translat
 - Enabling the **Optional Development Workspace** does not enable the **macOS Desktop App Stack**.
 - **macOS App Groups** are configured during **Terrapod** setup and remain within the **macOS Desktop App Stack** boundary.
 - When **macOS App Group** settings change, `tpod apply` keeps Homebrew desktop app warning marker content aligned with currently enabled groups; failures for disabled groups are removed from readiness warnings while enabled group failures remain.
-- The implemented **macOS App Groups** are terminal-apps, automation, launcher, monitoring, and development-apps.
+- The implemented **macOS App Groups** are terminal-apps, automation, launcher, monitoring, development-apps, and mobile-dev.
 - The terminal-apps **macOS App Group** contains Ghostty.
 - cmux is outside the declared **macOS Desktop App Stack**; existing cmux installs or settings may remain on a machine unmanaged and are not removed by **Terrapod**.
 - The automation **macOS App Group** contains Hammerspoon and Karabiner-Elements.
@@ -303,6 +303,12 @@ _Avoid_: separate Korean introduction, independent README, self-labeled translat
 - The development-apps **macOS App Group** declares `stablyai/orca/orca` with `trusted: true` so Homebrew trusts only the Orca cask, not the entire `stablyai/orca` tap.
 - Disabling the development-apps **macOS App Group** does not revoke an existing Orca cask trust entry; Terrapod leaves Homebrew trust removal to an explicit user action.
 - The managed `.zprofile` sources the OrbStack shell integration only when the development-apps **macOS App Group** is enabled, and guards the source with a readability check so a missing OrbStack cask cannot break login shells.
+- The mobile-dev **macOS App Group** contains Android Studio and Maestro.
+- The mobile-dev **macOS App Group** declares `mobile-dev-inc/tap/maestro` with `trusted: true` so Homebrew trusts only the Maestro formula, not the entire `mobile-dev-inc/tap` tap.
+- The homebrew-cask `maestro` is a different product from the mobile-dev **macOS App Group**'s Maestro and is never declared.
+- The managed `.zshenv` exports `ANDROID_HOME`, `ANDROID_SDK_ROOT`, and `JAVA_HOME` only when the mobile-dev **macOS App Group** is enabled, and renders them before the machine-local override loop so explicit overrides still run last.
+- `JAVA_HOME` resolves to the runtime bundled with Android Studio, so **Terrapod** declares no separate JDK.
+- Android SDK components and Xcode remain outside **Terrapod** ownership; the Android SDK Manager owns the former and the App Store distributes the latter.
 - `enableMacosAppGroupAiApps` is deprecated and is not an alias for `enableMacosAppGroupDevelopmentApps`; users must run explicit setup or configure migration.
 - The Hammerspoon app launcher maps Orca to `1` and Zed to `2`.
 - Orca's bundled `orca` CLI remains an artifact of the development-apps **macOS App Group** and is not a member of the cross-profile **Optional AI Tool Stack**.

--- a/README.ko.md
+++ b/README.ko.md
@@ -295,7 +295,7 @@ Optional stack profile과 macOS App Group setting은 기본적으로 disabled입
 | `enableMacosAppGroupLauncher` | `false` | launcher macOS App Group인 Raycast와 1Password CLI를 설치합니다. |
 | `enableMacosAppGroupMonitoring` | `false` | monitoring macOS App Group인 iStat Menus를 설치합니다. |
 | `enableMacosAppGroupDevelopmentApps` | `false` | development-apps macOS App Group인 Zed, Orca ADE(`stablyai/orca/orca`), OrbStack을 설치합니다. |
-| `enableMacosAppGroupMobileDev` | `false` | mobile-dev macOS App Group인 Android Studio와 Maestro(`mobile-dev-inc/tap/maestro`)를 설치합니다. |
+| `enableMacosAppGroupMobileDev` | `false` | mobile-dev macOS App Group인 Android Studio와 Maestro(`mobile-dev-inc/tap/maestro`)를 설치합니다. `ANDROID_HOME`과 `JAVA_HOME`도 함께 설정합니다. |
 
 `enableDevelopmentWorkspace`가 `true`이면 `enableEditorStack`이나 `enableAiCliTools`가 false로 기록되어 있어도 Optional Editor Stack과 Optional AI Tool Stack이 함께 활성화됩니다.
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -157,8 +157,13 @@ macOS desktop application은 machine-local data key로 제어되는 opt-in App G
 - `launcher`: Raycast와 1Password CLI.
 - `monitoring`: iStat Menus.
 - `development-apps`: Zed, Orca ADE(`stablyai/orca/orca`), OrbStack.
+- `mobile-dev`: Android Studio와 Maestro(`mobile-dev-inc/tap/maestro`).
 
 Terrapod은 Orca를 설치할 때 fully-qualified `stablyai/orca/orca` cask만 trust하며, `stablyai/orca` tap 전체를 trust하지 않습니다.
+
+Terrapod은 fully-qualified `mobile-dev-inc/tap/maestro` formula만 trust하며, `mobile-dev-inc/tap` tap 전체를 trust하지 않습니다. homebrew-cask의 `maestro`는 다른 제품이므로 설치하지 않습니다.
+
+Terrapod은 Android SDK component와 Xcode를 설치하지 않습니다. SDK는 Android Studio의 SDK Manager가 소유하고, Xcode는 App Store로 배포됩니다. `JAVA_HOME`은 별도로 선언한 JDK가 아니라 Android Studio가 번들한 runtime을 가리키므로, command line과 IDE가 항상 같은 Java version을 사용합니다.
 
 development-apps group은 OrbStack이 설치되어 있으면 managed `.zprofile`에서 OrbStack shell integration을 source합니다. cask이 없어도 login shell은 정상 동작합니다.
 
@@ -290,6 +295,7 @@ Optional stack profile과 macOS App Group setting은 기본적으로 disabled입
 | `enableMacosAppGroupLauncher` | `false` | launcher macOS App Group인 Raycast와 1Password CLI를 설치합니다. |
 | `enableMacosAppGroupMonitoring` | `false` | monitoring macOS App Group인 iStat Menus를 설치합니다. |
 | `enableMacosAppGroupDevelopmentApps` | `false` | development-apps macOS App Group인 Zed, Orca ADE(`stablyai/orca/orca`), OrbStack을 설치합니다. |
+| `enableMacosAppGroupMobileDev` | `false` | mobile-dev macOS App Group인 Android Studio와 Maestro(`mobile-dev-inc/tap/maestro`)를 설치합니다. |
 
 `enableDevelopmentWorkspace`가 `true`이면 `enableEditorStack`이나 `enableAiCliTools`가 false로 기록되어 있어도 Optional Editor Stack과 Optional AI Tool Stack이 함께 활성화됩니다.
 

--- a/README.md
+++ b/README.md
@@ -165,8 +165,13 @@ installs that rendered bundle:
 - `launcher`: Raycast and 1Password CLI.
 - `monitoring`: iStat Menus.
 - `development-apps`: Zed, Orca ADE (`stablyai/orca/orca`), and OrbStack.
+- `mobile-dev`: Android Studio and Maestro (`mobile-dev-inc/tap/maestro`).
 
 When installing Orca, Terrapod trusts only the fully-qualified `stablyai/orca/orca` cask, not the entire `stablyai/orca` tap.
+
+Terrapod trusts only the fully-qualified `mobile-dev-inc/tap/maestro` formula, not the entire `mobile-dev-inc/tap` tap. The unrelated homebrew-cask `maestro` is a different product and is never installed.
+
+Terrapod does not install Android SDK components or Xcode. Android Studio's SDK Manager owns the SDK, and Xcode is distributed through the App Store. `JAVA_HOME` resolves to the runtime bundled with Android Studio rather than a separately declared JDK, so the command line and the IDE always agree on a Java version.
 
 The development-apps group also sources the OrbStack shell integration from the managed `.zprofile` when OrbStack is installed. Login shells stay usable when the cask is missing.
 
@@ -311,6 +316,7 @@ Optional stack profiles and macOS App Group settings are disabled by default.
 | `enableMacosAppGroupLauncher` | `false` | Installs the launcher macOS App Group: Raycast and 1Password CLI. |
 | `enableMacosAppGroupMonitoring` | `false` | Installs the monitoring macOS App Group: iStat Menus. |
 | `enableMacosAppGroupDevelopmentApps` | `false` | Installs the development-apps macOS App Group: Zed, Orca ADE (`stablyai/orca/orca`), and OrbStack. |
+| `enableMacosAppGroupMobileDev` | `false` | Installs the mobile-dev macOS App Group: Android Studio and Maestro (`mobile-dev-inc/tap/maestro`). It also sets `ANDROID_HOME` and `JAVA_HOME`. |
 
 When `enableDevelopmentWorkspace` is `true`, it enables both the Optional Editor Stack and Optional AI Tool Stack
 even when `enableEditorStack` or `enableAiCliTools` are recorded as false.

--- a/docs/adr/0013-scope-the-mobile-dev-app-group.md
+++ b/docs/adr/0013-scope-the-mobile-dev-app-group.md
@@ -1,0 +1,37 @@
+# Scope the mobile-dev App Group to entry points
+
+The `mobile-dev` **macOS App Group** installs Android Studio and Maestro and
+renders the Android and Java shell environment. It does not install Android SDK
+components, Xcode, or a separate JDK.
+
+`JAVA_HOME` resolves to the runtime Android Studio bundles at
+`/Applications/Android Studio.app/Contents/jbr/Contents/Home`.
+
+## Considered Options
+
+- Declare Android SDK components through `sdkmanager`: rejected because
+  `platforms`, `build-tools`, `ndk`, and `system-images` are license-gated
+  multi-gigabyte downloads, and accepting licences inside a non-interactive
+  `tpod apply` is not something Terrapod should do on a user's behalf.
+- Install Xcode through a third-party CLI: rejected because App Store
+  distribution requires Apple account authentication, which a non-interactive
+  apply cannot supply.
+- Declare a JDK through the `temurin` cask or mise: rejected because a second
+  Java runtime can disagree with the version Android Studio uses for Gradle
+  builds, and the bundled runtime is already installed by the cask this group
+  declares.
+- Model the group as a cross-profile optional stack: rejected because it
+  depends on the `android-studio` cask and an `/Applications` path, so it would
+  introduce a macOS-only optional stack and duplicate the App Group machinery.
+
+## Consequences
+
+- A fresh macOS workstation gets the IDE, the SDK Manager, and Maestro from
+  `tpod apply`, then populates the SDK through Android Studio on first launch.
+- `ANDROID_HOME` points at `$HOME/Library/Android/sdk`, a directory the SDK
+  Manager creates rather than the cask.
+- Existing vendor-installed Maestro binaries under `~/.maestro/bin` are not
+  removed. The existing shadowing warning reports them when they resolve ahead
+  of the Homebrew copy.
+- Adding `enableMacosAppGroupMobileDev` changes managed setup config
+  completeness, so already-configured machines are asked to rerun setup.

--- a/docs/adr/0013-scope-the-mobile-dev-app-group.md
+++ b/docs/adr/0013-scope-the-mobile-dev-app-group.md
@@ -30,8 +30,10 @@ components, Xcode, or a separate JDK.
   `tpod apply`, then populates the SDK through Android Studio on first launch.
 - `ANDROID_HOME` points at `$HOME/Library/Android/sdk`, a directory the SDK
   Manager creates rather than the cask.
-- Existing vendor-installed Maestro binaries under `~/.maestro/bin` are not
-  removed. The existing shadowing warning reports them when they resolve ahead
-  of the Homebrew copy.
+- The existing vendor-installed Maestro binary under `~/.maestro/bin` is left
+  in place, consistent with Terrapod's non-destructive apply contract. The
+  managed shell environment no longer adds that directory to PATH, so the
+  Homebrew copy is the one that resolves. Terrapod does not detect or report a
+  vendor copy that a user's own PATH additions place ahead of it.
 - Adding `enableMacosAppGroupMobileDev` changes managed setup config
   completeness, so already-configured machines are asked to rerun setup.

--- a/docs/superpowers/plans/2026-08-22-mobile-dev-app-group.md
+++ b/docs/superpowers/plans/2026-08-22-mobile-dev-app-group.md
@@ -1,0 +1,834 @@
+# Mobile Dev App Group Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `mobile-dev` macOS App Group that installs Android Studio and Maestro and renders the Android and Java shell environment they need.
+
+**Architecture:** One new machine-local setting key, `enableMacosAppGroupMobileDev`, gates a new group in the rendered macOS Desktop App Stack Brewfile and a new block in `dot_zshenv.tmpl`. The reconcile script's per-package retry path is first generalized so it can attribute failures for tap formulae as well as casks.
+
+**Tech Stack:** POSIX `sh`, chezmoi Go templates, zsh, Homebrew Bundle, awk. Tests are hand-rolled `sh` scripts under `tests/` using `chezmoi execute-template` and `chezmoi cat` against fixture data.
+
+**Spec:** `docs/superpowers/specs/2026-08-22-mobile-dev-app-group-design.md`
+
+## Global Constraints
+
+- Managed scripts are POSIX `sh`, not bash. `dot_zshenv.tmpl` is zsh.
+- Homebrew declarations for non-official taps use a fully-qualified token plus `trusted: true`, never a bare `tap` statement. Exact Maestro token: `mobile-dev-inc/tap/maestro`.
+- Never declare the homebrew-cask `maestro`; it is a different product (runmaestro.ai AI agent command center).
+- `ANDROID_HOME` is exactly `$HOME/Library/Android/sdk`.
+- `JAVA_HOME` is exactly `/Applications/Android Studio.app/Contents/jbr/Contents/Home`.
+- Do not declare `android-platform-tools`, a JDK cask, Xcode, or any Android SDK component.
+- Every apply path stays non-destructive: never uninstall, never `brew upgrade`, always `HOMEBREW_NO_AUTO_UPDATE=1 brew bundle --no-upgrade`.
+- Run tests with `sh tests/<name>.sh` from the repository root.
+- Three test files fail in this environment for reasons unrelated to this work and also fail on `main`: `tests/jetendard_font_test.sh`, `tests/jetendard_settings_test.sh`, `tests/terrapod_command_test.sh`. `tests/homebrew_ubuntu_smoke.sh` needs Docker and Ubuntu. Do not treat these as regressions, and do not attempt to fix them.
+
+## Decisions Made While Planning
+
+Two points where this plan resolves detail the spec left open. Both are inside the spec's intent; flagged here so a reviewer can reject them independently.
+
+1. **Record format carries the verbatim declaration line, not parsed kind plus options.** The spec asks each record to carry group, kind, token, and options. Storing the trimmed source line achieves all four with one field and no re-serialization, so `cask "stablyai/orca/orca", trusted: true` round-trips exactly. The parsed token is still emitted separately for failure reporting.
+
+2. **The warning marker keeps the wording `failed casks:`.** With a formula in the group this wording is imprecise. Renaming it touches five assertions across two test files plus the guidance string, which is scope the spec did not ask for. Left as-is; raise separately if the imprecision matters.
+
+---
+
+### Task 1: Generalize the reconcile record format
+
+The per-package retry path in the reconcile script only understands `cask "` lines and rebuilds each record as a bare `cask "<name>"`. That drops declaration options and ignores formulae. This task makes records carry the full declaration so tap formulae are retried and attributed, and so Orca's `trusted: true` survives retry.
+
+**Files:**
+- Modify: `.chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl:93-109` (`desktop_app_cask_records`) and `:154-179` (retry loop)
+- Test: `tests/chezmoiignore_test.sh`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `desktop_app_package_records <brewfile>` writing tab-separated `group<TAB>token<TAB>declaration` lines to stdout. Task 2 relies on this recognizing `brew "` lines.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/chezmoiignore_test.sh`, immediately after the block that ends with `pass "development-apps bootstrap script is valid sh"`:
+
+```sh
+package_records_probe="$tmp_dir/package-records-probe.sh"
+package_records_brewfile="$tmp_dir/package-records-brewfile"
+cat >"$package_records_brewfile" <<'PROBE_BREWFILE'
+# development-apps macOS App Group
+cask "zed"
+cask "stablyai/orca/orca", trusted: true
+# mobile-dev macOS App Group
+cask "android-studio"
+brew "mobile-dev-inc/tap/maestro", trusted: true
+PROBE_BREWFILE
+
+sed -n '/^desktop_app_package_records()/,/^}/p' \
+  "$repo_root/.chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl" \
+  >"$package_records_probe"
+printf '%s\n' 'desktop_app_package_records "$1"' >>"$package_records_probe"
+
+package_records_output="$(sh "$package_records_probe" "$package_records_brewfile")"
+
+expected_package_records="$(printf '%s\n' \
+  'development-apps	zed	cask "zed"' \
+  'development-apps	stablyai/orca/orca	cask "stablyai/orca/orca", trusted: true' \
+  'mobile-dev	android-studio	cask "android-studio"' \
+  'mobile-dev	mobile-dev-inc/tap/maestro	brew "mobile-dev-inc/tap/maestro", trusted: true')"
+
+assert_text_equals \
+  "$package_records_output" \
+  "$expected_package_records" \
+  "desktop app package records carry group, token, and the verbatim declaration for casks and tap formulae"
+
+assert_contains_text \
+  "$macos_development_apps_bootstrap" \
+  'read -r app_group token declaration' \
+  "per-package retry reads the declaration field alongside the group and token"
+assert_contains_text \
+  "$macos_development_apps_bootstrap" \
+  '>"$single_package_brewfile"' \
+  "per-package retry writes the recorded declaration so options such as trusted: true survive"
+```
+
+The three separators inside each `expected_package_records` line must be real tab characters. The `PROBE_BREWFILE` heredoc contains no tabs.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `sh tests/chezmoiignore_test.sh`
+Expected: FAIL with `not ok - desktop app package records carry group, token, and the verbatim declaration for casks and tap formulae`. The `sed` range extracts nothing because `desktop_app_package_records` does not exist yet, so the probe prints nothing.
+
+- [ ] **Step 3: Rewrite the record parser**
+
+In `.chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl`, replace the whole `desktop_app_cask_records` function with:
+
+```sh
+desktop_app_package_records() {
+  brewfile="$1"
+
+  awk '
+    /^[[:space:]]*#[[:space:]]+.*[[:space:]]macOS App Group[[:space:]]*$/ {
+      group = $0
+      sub(/^[[:space:]]*#[[:space:]]+/, "", group)
+      sub(/[[:space:]]+macOS App Group[[:space:]]*$/, "", group)
+      next
+    }
+
+    /^[[:space:]]*(cask|brew)[[:space:]]+"/ {
+      declaration = $0
+      sub(/^[[:space:]]+/, "", declaration)
+      sub(/[[:space:]]+$/, "", declaration)
+
+      token = declaration
+      sub(/^(cask|brew)[[:space:]]+"/, "", token)
+      sub(/".*$/, "", token)
+
+      if (token != "") {
+        printf "%s\t%s\t%s\n", group, token, declaration
+      }
+    }
+  ' "$brewfile"
+}
+```
+
+- [ ] **Step 4: Rewrite the retry loop**
+
+In the same file, replace the retry loop body. The old loop reads two fields and rebuilds `cask "%s"`; the new one reads three and writes the declaration verbatim. Replace from `tab="$(printf '\t')"` through the `done <"$records_file"` line with:
+
+```sh
+  tab="$(printf '\t')"
+  while IFS="$tab" read -r app_group token declaration; do
+    single_package_brewfile="$(mktemp "${TMPDIR:-/tmp}/terrapod-macos-desktop-package.XXXXXX")" || {
+      cleanup_desktop_app_bundle_temps
+      return 1
+    }
+    if ! printf '%s\n' "$declaration" >"$single_package_brewfile"; then
+      cleanup_desktop_app_bundle_temps
+      return 1
+    fi
+
+    if ! HOMEBREW_NO_AUTO_UPDATE=1 brew bundle --no-upgrade --file="$single_package_brewfile"; then
+      if ! printf '%s\n' "$token" >>"$failed_casks_file"; then
+        cleanup_desktop_app_bundle_temps
+        return 1
+      fi
+      if [ -n "$app_group" ] && ! grep -Fx "$app_group" "$failed_groups_file" >/dev/null 2>&1; then
+        if ! printf '%s\n' "$app_group" >>"$failed_groups_file"; then
+          cleanup_desktop_app_bundle_temps
+          return 1
+        fi
+      fi
+    fi
+
+    rm -f "$single_package_brewfile"
+    single_package_brewfile=
+  done <"$records_file"
+```
+
+- [ ] **Step 5: Update the remaining references to the renamed identifiers**
+
+Search the file for the old names and update each hit:
+
+```bash
+grep -n "desktop_app_cask_records\|single_cask_brewfile" .chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl
+```
+
+Rename `desktop_app_cask_records` to `desktop_app_package_records` at its call site, and rename every `single_cask_brewfile` to `single_package_brewfile`, including the declaration near the top of the temp-cleanup section and inside `cleanup_desktop_app_bundle_temps`. Leave `failed_casks_file`, `failed_casks`, and the `failed casks:` guidance wording unchanged; those feed user-facing text asserted elsewhere.
+
+- [ ] **Step 6: Loosen the test stub's whole-line package matching**
+
+This step is required, not optional. `write_brew_bundle_stub` in `tests/chezmoiignore_test.sh` injects failures by matching a package declaration with `grep -Fx`, a whole-line match. Now that the retry Brewfile carries options, the line reads `cask "stablyai/orca/orca", trusted: true` and no longer equals `cask "stablyai/orca/orca"`. Left unchanged, the existing Orca bulk-failure assertions stop firing.
+
+In the stub body, replace the formula matcher:
+
+```sh
+    '      if [ -n "$bundle_file" ] && grep -Eq "^brew \"$formula\"(,[[:space:]]|$)" "$bundle_file" 2>/dev/null; then' \
+```
+
+and the cask matcher:
+
+```sh
+    '      if [ -n "$bundle_file" ] && grep -Eq "^cask \"$cask\"(,[[:space:]]|$)" "$bundle_file" 2>/dev/null; then' \
+```
+
+Both now match a declaration whether it ends at the token or continues into options. Leave the `MACOS_BREW_FAIL_CORE_BULK`, `MACOS_BREW_FAIL_DESKTOP_BULK`, and `MACOS_BREW_FAIL_BULK` matchers on `grep -Fx`; those match fixed marker lines that never carry options.
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `sh tests/chezmoiignore_test.sh`
+Expected: PASS, including the two new assertions and every pre-existing Orca and Ghostty failure-marker assertion.
+
+If an Orca marker assertion fails here, the stub change in Step 6 is wrong or incomplete; fix it rather than weakening the assertion.
+
+- [ ] **Step 8: Verify nothing else regressed**
+
+Run: `sh tests/homebrew_manifests_test.sh && sh tests/terrapod_config_test.sh`
+Expected: both PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add .chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl tests/chezmoiignore_test.sh
+git commit -m "Retry desktop app packages with their full declaration"
+```
+
+---
+
+### Task 2: Declare the mobile-dev group packages
+
+**Files:**
+- Modify: `Brewfile.macos-desktop-apps.tmpl` (append after the `development-apps` block)
+- Test: `tests/chezmoiignore_test.sh`
+
+**Interfaces:**
+- Consumes: `desktop_app_package_records` from Task 1 recognizing `brew "` lines.
+- Produces: the template data key `enableMacosAppGroupMobileDev`, consumed by Task 3 and Task 4.
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/chezmoiignore_test.sh`, add the fixture data and rendering next to the other group data definitions. Put this immediately after the line defining `macos_development_apps_data`:
+
+```sh
+macos_mobile_dev_data='{"chezmoi":{"os":"darwin"},"enableMacosAppGroupTerminalApps":false,"enableMacosAppGroupAutomation":false,"enableMacosAppGroupLauncher":false,"enableMacosAppGroupMonitoring":false,"enableMacosAppGroupDevelopmentApps":false,"enableMacosAppGroupMobileDev":true}'
+```
+
+Immediately after the line defining `development_apps_brewfile`, add:
+
+```sh
+mobile_dev_brewfile="$(render_template "$macos_mobile_dev_data" "Brewfile.macos-desktop-apps.tmpl")"
+```
+
+Then add the assertions immediately after the existing `"development-apps group renders exactly the expected casks"` assertion:
+
+```sh
+assert_contains_text "$mobile_dev_brewfile" 'cask "android-studio"' "mobile-dev group renders Android Studio"
+assert_contains_text "$mobile_dev_brewfile" 'brew "mobile-dev-inc/tap/maestro", trusted: true' "mobile-dev group trusts only the fully-qualified Maestro formula, not the entire mobile-dev-inc/tap tap"
+assert_not_contains_text "$mobile_dev_brewfile" 'cask "maestro"' "mobile-dev group does not render the unrelated homebrew-cask maestro"
+assert_not_contains_text "$mobile_dev_brewfile" 'tap "mobile-dev-inc/tap"' "mobile-dev group taps on demand through the fully-qualified token instead of trusting the whole tap"
+assert_not_contains_text "$mobile_dev_brewfile" 'android-platform-tools' "mobile-dev group leaves platform tools to the Android SDK"
+assert_not_contains_text "$mobile_dev_brewfile" 'cask "temurin"' "mobile-dev group resolves Java through the Android Studio bundled runtime instead of a declared JDK"
+assert_not_contains_text "$mobile_dev_brewfile" 'cask "zed"' "mobile-dev group does not render development-apps casks"
+
+mobile_dev_packages="$(
+  printf '%s\n' "$mobile_dev_brewfile" |
+    awk '/^[[:space:]]*(cask|brew)[[:space:]]+"/ { print }'
+)"
+expected_mobile_dev_packages='cask "android-studio"
+brew "mobile-dev-inc/tap/maestro", trusted: true'
+assert_text_equals \
+  "$mobile_dev_packages" \
+  "$expected_mobile_dev_packages" \
+  "mobile-dev group renders exactly the expected packages"
+
+assert_not_contains_text "$macos_brewfile" 'cask "android-studio"' "macOS default does not render Android Studio"
+assert_not_contains_text "$macos_brewfile" 'mobile-dev-inc/tap/maestro' "macOS default does not render Maestro"
+assert_not_contains_text "$development_apps_brewfile" 'cask "android-studio"' "development-apps group does not render Android Studio"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `sh tests/chezmoiignore_test.sh`
+Expected: FAIL with `not ok - mobile-dev group renders Android Studio`.
+
+- [ ] **Step 3: Add the group to the Brewfile template**
+
+Append to the end of `Brewfile.macos-desktop-apps.tmpl`, after the `development-apps` block's `{{ end -}}`:
+
+```
+{{ if default false (get . "enableMacosAppGroupMobileDev") -}}
+# mobile-dev macOS App Group
+cask "android-studio"
+brew "mobile-dev-inc/tap/maestro", trusted: true
+{{ end -}}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `sh tests/chezmoiignore_test.sh`
+Expected: PASS.
+
+- [ ] **Step 5: Verify the rendering by hand**
+
+```bash
+d=$(mktemp -d); : > "$d/chezmoi.toml"
+chezmoi --config "$d/chezmoi.toml" --source . \
+  --override-data '{"chezmoi":{"os":"darwin"},"enableMacosAppGroupMobileDev":true}' \
+  execute-template --file Brewfile.macos-desktop-apps.tmpl
+rm -rf "$d"
+```
+
+Expected output is exactly the header comment, the `# mobile-dev macOS App Group` comment, the Android Studio cask, and the Maestro formula. Passing `--config` with an empty file is required; without it chezmoi merges this machine's real settings and renders every group.
+
+- [ ] **Step 6: Write the failure attribution test**
+
+This proves the Task 1 record change actually reaches the warning marker for a tap formula, which the record-level assertions alone do not show.
+
+Add near the top of the test, immediately after the line defining `macos_development_apps_bootstrap`:
+
+```sh
+macos_mobile_dev_bootstrap="$(render_template "$macos_mobile_dev_data" ".chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl")"
+```
+
+Then add this after the existing development-apps failure assertions, immediately before the section that follows them:
+
+```sh
+mobile_dev_bootstrap_script="$tmp_dir/macos-mobile-dev-bootstrap.sh"
+printf '%s\n' "$macos_mobile_dev_bootstrap" | sed \
+  -e "s#/opt/homebrew/bin/brew#$tmp_dir/mobile-dev-failure-bin/brew#g" \
+  -e "s#/usr/local/bin/brew#$tmp_dir/mobile-dev-failure-bin/brew#g" \
+  >"$mobile_dev_bootstrap_script"
+sh -n "$mobile_dev_bootstrap_script" || fail "mobile-dev bootstrap script should be valid sh"
+pass "mobile-dev bootstrap script is valid sh"
+
+mobile_dev_failure_bin="$tmp_dir/mobile-dev-failure-bin"
+mobile_dev_failure_state="$tmp_dir/mobile-dev-failure-state"
+mobile_dev_failure_home="$tmp_dir/mobile-dev-failure-home"
+mobile_dev_failure_log="$tmp_dir/mobile-dev-failure-brew.log"
+mkdir -p "$mobile_dev_failure_bin" "$mobile_dev_failure_home"
+write_brew_bundle_stub "$mobile_dev_failure_bin/brew"
+
+if ! HOME="$mobile_dev_failure_home" XDG_STATE_HOME="$mobile_dev_failure_state" MACOS_BREW_LOG="$mobile_dev_failure_log" MACOS_BREW_FAIL_DESKTOP_BULK=1 MACOS_BREW_FAIL_FORMULAE="mobile-dev-inc/tap/maestro" PATH="$mobile_dev_failure_bin:/usr/bin:/bin" \
+  sh "$mobile_dev_bootstrap_script" >"$tmp_dir/mobile-dev-failure.out" 2>"$tmp_dir/mobile-dev-failure.err"; then
+  fail "Maestro desktop app bundle failure does not block bootstrap script"
+fi
+
+mobile_dev_failure_marker="$mobile_dev_failure_state/terrapod/install-warnings/homebrew-desktop-apps"
+if [ ! -f "$mobile_dev_failure_marker" ]; then
+  fail "Maestro formula failure records a homebrew-desktop-apps marker"
+fi
+pass "Maestro formula failure records a homebrew-desktop-apps marker"
+
+mobile_dev_failure_marker_text="$(cat "$mobile_dev_failure_marker")"
+assert_contains_text "$mobile_dev_failure_marker_text" "mobile-dev-inc/tap/maestro" \
+  "a failed tap formula is named in the desktop app warning marker"
+assert_contains_text "$mobile_dev_failure_marker_text" "App Groups: mobile-dev" \
+  "a failed tap formula is attributed to its macOS App Group"
+```
+
+The failing package is injected through `MACOS_BREW_FAIL_FORMULAE` rather than `MACOS_BREW_FAIL_CASKS` because Maestro is declared with `brew`, and the stub matches formulae and casks with separate loops.
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `sh tests/chezmoiignore_test.sh`
+Expected: PASS. If the marker exists but omits `App Groups: mobile-dev`, the awk group tracking in Task 1 is not carrying the group across `brew` lines; fix Task 1's parser rather than relaxing the assertion.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Brewfile.macos-desktop-apps.tmpl tests/chezmoiignore_test.sh
+git commit -m "Declare the mobile-dev macOS App Group packages"
+```
+
+---
+
+### Task 3: Render the Android shell environment
+
+**Files:**
+- Modify: `dot_zshenv.tmpl:23` (insert before the machine-local override loop)
+- Test: `tests/chezmoiignore_test.sh`, `tests/zshenv_local_bin_test.sh`
+
+**Interfaces:**
+- Consumes: `enableMacosAppGroupMobileDev` from Task 2.
+- Produces: exported `ANDROID_HOME`, `ANDROID_SDK_ROOT`, and `JAVA_HOME` in the rendered `.zshenv`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/chezmoiignore_test.sh`, add after the mobile-dev Brewfile assertions from Task 2:
+
+```sh
+mobile_dev_zshenv="$(render_managed_file "$macos_mobile_dev_data" ".zshenv")"
+macos_default_zshenv="$(render_managed_file "$macos_data" ".zshenv")"
+
+assert_contains_text "$mobile_dev_zshenv" 'export ANDROID_HOME="$HOME/Library/Android/sdk"' "mobile-dev group exports ANDROID_HOME"
+assert_contains_text "$mobile_dev_zshenv" 'export ANDROID_SDK_ROOT="$ANDROID_HOME"' "mobile-dev group exports ANDROID_SDK_ROOT"
+assert_contains_text "$mobile_dev_zshenv" 'export JAVA_HOME="$android_studio_jbr"' "mobile-dev group resolves JAVA_HOME to the Android Studio bundled runtime"
+assert_contains_text "$mobile_dev_zshenv" 'if [[ -d "$android_studio_jbr" ]]; then' "JAVA_HOME is guarded so a failed Android Studio install cannot break java"
+assert_contains_text "$mobile_dev_zshenv" 'if [[ -d "$ANDROID_HOME/platform-tools" ]]; then' "platform-tools joins PATH only when the SDK provides it"
+assert_not_contains_text "$mobile_dev_zshenv" '.maestro/bin' "Maestro resolves through the Homebrew prefix instead of its vendor install directory"
+assert_not_contains_text "$mobile_dev_zshenv" 'mise activate' "the Android environment does not repeat the mise activation the managed zshrc already runs"
+assert_not_contains_text "$macos_default_zshenv" 'ANDROID_HOME' "macOS default does not render the Android environment"
+
+mobile_dev_android_line="$(printf '%s\n' "$mobile_dev_zshenv" | grep -n 'export ANDROID_HOME' | head -1 | cut -d: -f1)"
+mobile_dev_override_line="$(printf '%s\n' "$mobile_dev_zshenv" | grep -n 'zsh/path.d' | head -1 | cut -d: -f1)"
+if [ -z "$mobile_dev_android_line" ] || [ -z "$mobile_dev_override_line" ]; then
+  fail "rendered .zshenv should contain both the Android environment and the machine-local override loop"
+fi
+if [ "$mobile_dev_android_line" -ge "$mobile_dev_override_line" ]; then
+  fail "the Android environment must render before the machine-local override loop so explicit overrides still run last"
+fi
+pass "the Android environment renders before the machine-local override loop"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `sh tests/chezmoiignore_test.sh`
+Expected: FAIL with `not ok - mobile-dev group exports ANDROID_HOME`.
+
+- [ ] **Step 3: Add the block to the zshenv template**
+
+In `dot_zshenv.tmpl`, insert this immediately before the line `# Explicit machine-local overrides run last.`:
+
+```
+{{ if default false (get . "enableMacosAppGroupMobileDev") }}
+# Android tooling from the mobile-dev macOS App Group.
+# The Android SDK Manager owns this directory; the cask does not create it.
+export ANDROID_HOME="$HOME/Library/Android/sdk"
+export ANDROID_SDK_ROOT="$ANDROID_HOME"
+
+# emulator is prepended first so platform-tools ends up ahead of it.
+if [[ -d "$ANDROID_HOME/emulator" ]]; then
+  path=("$ANDROID_HOME/emulator" $path)
+fi
+if [[ -d "$ANDROID_HOME/platform-tools" ]]; then
+  path=("$ANDROID_HOME/platform-tools" $path)
+fi
+
+# Java resolves to the runtime Android Studio bundles, so the command line and
+# the IDE always agree on a version.
+android_studio_jbr="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+if [[ -d "$android_studio_jbr" ]]; then
+  export JAVA_HOME="$android_studio_jbr"
+fi
+unset android_studio_jbr
+{{ end }}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `sh tests/chezmoiignore_test.sh`
+Expected: PASS.
+
+- [ ] **Step 5: Verify PATH precedence did not regress**
+
+Run: `sh tests/zshenv_local_bin_test.sh`
+Expected: PASS. This suite asserts `$HOME/.local/bin` ordering and the Homebrew shellenv block; the Android block must not displace either.
+
+- [ ] **Step 6: Verify the rendered file is valid zsh**
+
+```bash
+d=$(mktemp -d); : > "$d/chezmoi.toml"
+chezmoi --config "$d/chezmoi.toml" --source . --destination "$d/home" \
+  --override-data '{"chezmoi":{"os":"darwin"},"enableMacosAppGroupMobileDev":true}' \
+  cat "$d/home/.zshenv" > "$d/zshenv"
+zsh -n "$d/zshenv" && echo "rendered .zshenv parses"
+rm -rf "$d"
+```
+
+Expected: `rendered .zshenv parses`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add dot_zshenv.tmpl tests/chezmoiignore_test.sh
+git commit -m "Render the Android environment for the mobile-dev App Group"
+```
+
+---
+
+### Task 4: Wire the setting key through the command surfaces
+
+This task adds the key everywhere Terrapod reads or writes managed settings, and populates both App Group inventory surfaces. Setup disclosure and status reporting ship together deliberately: a key that installs software without naming it in the confirmation prompt is the defect this repository already corrected once for OrbStack.
+
+**Files:**
+- Modify: `dot_local/bin/executable_terrapod` at `managed_setup_keys` (:638), `setup_option_title` (:484), `show_setup_option_block` (:520), `prompt_for_setup_settings` (:625), `print_macos_app_group_status` (:1065), the settings section list (:1327-1338), `render_settings_data` (:1789), `render_preset_data` (:1802), `load_setup_defaults` (:1821), and the setup settings writer (:1866)
+- Modify: `install.sh:769-778` (`managed_setup_keys`)
+- Test: `tests/terrapod_command_test.sh`, `tests/terrapod_config_test.sh`, `tests/terrapod_installer_test.sh`
+
+**Interfaces:**
+- Consumes: `enableMacosAppGroupMobileDev` from Task 2.
+- Produces: `render_settings_data <profile> <editor> <ai> <workspace> <terminalApps> <automation> <launcher> <monitoring> <developmentApps> <mobileDev>` — ten positional arguments. The tenth must be referenced as `${10}`, since `$10` parses as `$1` followed by a literal `0` in POSIX `sh`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/terrapod_command_test.sh`, update the development-apps setup assertion by adding a mobile-dev assertion directly after it:
+
+```sh
+assert_contains "$setup_output_text" "  Installs Android Studio and Maestro." "gum setup lists Android Studio and Maestro in the mobile-dev App Group"
+assert_contains "$setup_output_text" "  Sets ANDROID_HOME and JAVA_HOME for Android builds." "gum setup discloses that the mobile-dev App Group changes the shell environment"
+```
+
+Then, directly after each of the two existing assertions matching `development-apps              : enabled (Zed, Orca ADE, and OrbStack)`, add the matching mobile-dev line. For the one using `$macos_status_output`:
+
+```sh
+assert_contains "$macos_status_output" "mobile-dev                   : enabled (Android Studio and Maestro)" "Terrapod status lists Android Studio and Maestro in the enabled mobile-dev App Group"
+```
+
+For the one using `$dotted_status_output`:
+
+```sh
+assert_contains "$dotted_status_output" "mobile-dev                   : enabled (Android Studio and Maestro)" "Terrapod status reads root dotted data keys for the mobile-dev App Group"
+```
+
+The column padding above must place the colon in the same column as the neighbouring lines. Confirm the exact width in Step 6 rather than trusting the count here.
+
+In `tests/terrapod_config_test.sh` and `tests/terrapod_installer_test.sh`, every fixture that lists the managed setting keys needs the new key. Find them with:
+
+```bash
+grep -rn "enableMacosAppGroupDevelopmentApps" tests/terrapod_config_test.sh tests/terrapod_installer_test.sh
+```
+
+For each hit that is an expected config body, add `enableMacosAppGroupMobileDev = false` after the development-apps line, except in a `workstation` Preset expectation, where it is `true`. For the single-line TOML fixture in `tests/terrapod_installer_test.sh` that spells the keys inside `data = { ... }`, append `, enableMacosAppGroupMobileDev = false` before the closing brace.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `sh tests/terrapod_config_test.sh`
+Expected: FAIL, reporting a configured Preset whose written config lacks `enableMacosAppGroupMobileDev`.
+
+`sh tests/terrapod_command_test.sh` also fails, but it fails on `main` too and aborts before reaching the new assertions. Use `terrapod_config_test.sh` as this task's red signal.
+
+- [ ] **Step 3: Add the key to both managed key lists**
+
+In `dot_local/bin/executable_terrapod`, in `managed_setup_keys`, add a line after `enableMacosAppGroupDevelopmentApps`:
+
+```sh
+    enableMacosAppGroupDevelopmentApps \
+    enableMacosAppGroupMobileDev
+}
+```
+
+Make the identical change in `install.sh`. Both lists must stay in sync; a key present in one and missing from the other makes setup completeness disagree between the installer and the command.
+
+- [ ] **Step 4: Extend the settings and Preset writers**
+
+In `render_settings_data`, add a line to the heredoc after the development-apps line:
+
+```sh
+enableMacosAppGroupDevelopmentApps = $9
+enableMacosAppGroupMobileDev = ${10}
+EOF
+```
+
+In `render_preset_data`, each branch grows from eight booleans to nine:
+
+```sh
+    minimal)
+      render_settings_data "$profile" false false false false false false false false false
+      ;;
+    development)
+      render_settings_data "$profile" true true true false false false false false false
+      ;;
+    workstation)
+      render_settings_data "$profile" true true true true true true true true true
+      ;;
+```
+
+In `load_setup_defaults`, add one line to each of the three Preset branches, after the development-apps line. It is `false` for `minimal` and `development`, and `true` for `workstation`:
+
+```sh
+      setup_enableMacosAppGroupMobileDev=false
+```
+
+In the setup settings writer that passes `"$setup_enableMacosAppGroupDevelopmentApps"` as its last argument, append a tenth argument on a new line:
+
+```sh
+    "$setup_enableMacosAppGroupDevelopmentApps" \
+    "$setup_enableMacosAppGroupMobileDev"
+```
+
+- [ ] **Step 5: Add the setup prompt and its disclosure**
+
+In `setup_option_title`, add a case before the `*)` fallback:
+
+```sh
+    "mobile-dev macOS App Group")
+      printf '%s\n' "mobile-dev"
+      ;;
+```
+
+In `show_setup_option_block`, add a case after the development-apps case:
+
+```sh
+    "mobile-dev macOS App Group")
+      printf '%s\n' "  Installs Android Studio and Maestro."
+      printf '%s\n' "  Sets ANDROID_HOME and JAVA_HOME for Android builds."
+      printf '%s\n' "  Trusts only the fully-qualified mobile-dev-inc/tap/maestro formula, not the entire mobile-dev-inc/tap tap."
+      printf '%s\n' "  Android SDK components and Xcode stay outside Terrapod."
+      ;;
+```
+
+In `prompt_for_setup_settings`, add a prompt after the development-apps prompt:
+
+```sh
+    setup_enableMacosAppGroupMobileDev="$(prompt_setup_bool "mobile-dev macOS App Group" "$setup_enableMacosAppGroupMobileDev")"
+```
+
+In the same function's non-macOS branch, which sets every App Group variable to `false`, add:
+
+```sh
+    setup_enableMacosAppGroupMobileDev=false
+```
+
+Apply that same addition to every other place that zeroes the App Group variables. Find them with:
+
+```bash
+grep -n "setup_enableMacosAppGroupDevelopmentApps=false" dot_local/bin/executable_terrapod
+```
+
+- [ ] **Step 6: Add the status reporting**
+
+In `print_macos_app_group_status`, add after the development-apps block:
+
+```sh
+  if is_enabled "$(config_data_bool "$config_file" enableMacosAppGroupMobileDev)"; then
+    print_indented_colon_state_line "mobile-dev" "enabled" "(Android Studio and Maestro)"
+  else
+    print_indented_colon_state_line "mobile-dev" "disabled"
+  fi
+```
+
+In the settings section that builds `*_state` variables, add the lookup and the printed line:
+
+```sh
+  mobile_dev_state="$(config_bool_state_label "$config_file" enableMacosAppGroupMobileDev)"
+```
+
+and, after `print_named_state_line "development-apps" "$development_apps_state"`:
+
+```sh
+  print_named_state_line "mobile-dev" "$mobile_dev_state"
+```
+
+Now confirm the padding used in the Step 1 assertions:
+
+```bash
+sh dot_local/bin/executable_terrapod status | grep -E "development-apps|mobile-dev"
+```
+
+Copy the `mobile-dev` line's exact spacing into the two assertions in `tests/terrapod_command_test.sh` if it differs from what Step 1 wrote.
+
+Do not add a `tpod doctor` check for this group. Optional group installation failures are reported through the `homebrew-desktop-apps` warning marker that Task 2 exercises, and no other App Group has a dedicated doctor check.
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `sh tests/terrapod_config_test.sh && sh tests/terrapod_installer_test.sh`
+Expected: both PASS.
+
+- [ ] **Step 8: Verify the shell syntax and the status output**
+
+```bash
+sh -n dot_local/bin/executable_terrapod && sh -n install.sh && echo "both parse"
+sh dot_local/bin/executable_terrapod status | sed -n '/macOS App Groups:/,/^$/p'
+```
+
+Expected: `both parse`, and a status block whose last line is the `mobile-dev` line. On this machine the workstation Preset predates the new key, so `mobile-dev` reports `disabled` until setup is rerun. That is the intended completeness behavior, not a bug.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add dot_local/bin/executable_terrapod install.sh tests/terrapod_command_test.sh tests/terrapod_config_test.sh tests/terrapod_installer_test.sh
+git commit -m "Add the mobile-dev App Group setting to the command surfaces"
+```
+
+---
+
+### Task 5: Document the group and its scope boundary
+
+**Files:**
+- Modify: `README.md` (App Group inventory list, machine-local settings table, scope paragraph)
+- Modify: `README.ko.md` (the same three places)
+- Modify: `CONTEXT.md` (macOS Desktop App Stack definition, App Group facts)
+- Create: `docs/adr/0013-scope-the-mobile-dev-app-group.md`
+- Test: `tests/readme_optional_stack_profiles_test.sh`, `tests/readme_korean_test.sh`
+
+**Interfaces:**
+- Consumes: the group membership and setting key from Tasks 2 and 4.
+- Produces: nothing later tasks depend on.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/readme_optional_stack_profiles_test.sh`, add after the development-apps option row assertions:
+
+```sh
+assert_key_row_contains '`enableMacosAppGroupMobileDev`' 'mobile-dev' \
+  "README documents mobile-dev group on its option row"
+assert_key_row_contains '`enableMacosAppGroupMobileDev`' 'Android Studio' \
+  "README documents Android Studio on the mobile-dev option row"
+assert_key_row_contains '`enableMacosAppGroupMobileDev`' 'mobile-dev-inc/tap/maestro' \
+  "README documents Maestro's fully-qualified formula source"
+assert_contains 'Terrapod does not install Android SDK components or Xcode. Android Studio'"'"'s SDK Manager owns the SDK, and Xcode is distributed through the App Store.' \
+  "README documents the mobile development scope boundary"
+```
+
+In `tests/readme_korean_test.sh`, add after the development-apps assertions:
+
+```sh
+assert_contains "$korean_readme" '`mobile-dev`: Android Studio와 Maestro(`mobile-dev-inc/tap/maestro`).' \
+  "README.ko.md documents Android Studio and Maestro in the mobile-dev inventory"
+assert_contains "$korean_readme" '| `enableMacosAppGroupMobileDev` | `false` | mobile-dev macOS App Group인 Android Studio와 Maestro(`mobile-dev-inc/tap/maestro`)를 설치합니다. |' \
+  "README.ko.md documents the mobile-dev option row"
+assert_contains "$korean_readme" 'Terrapod은 Android SDK component와 Xcode를 설치하지 않습니다. SDK는 Android Studio의 SDK Manager가 소유하고, Xcode는 App Store로 배포됩니다.' \
+  "README.ko.md documents the mobile development scope boundary"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `sh tests/readme_optional_stack_profiles_test.sh`
+Expected: FAIL with `not ok - README documents mobile-dev group on its option row`.
+
+- [ ] **Step 3: Update README.md**
+
+Add to the App Group inventory list, after the `development-apps` bullet:
+
+```markdown
+- `mobile-dev`: Android Studio and Maestro (`mobile-dev-inc/tap/maestro`).
+```
+
+Add to the machine-local settings table, after the development-apps row:
+
+```markdown
+| `enableMacosAppGroupMobileDev` | `false` | Installs the mobile-dev macOS App Group: Android Studio and Maestro (`mobile-dev-inc/tap/maestro`). It also sets `ANDROID_HOME` and `JAVA_HOME`. |
+```
+
+Add a paragraph after the sentence describing Orca's trust boundary:
+
+```markdown
+Terrapod trusts only the fully-qualified `mobile-dev-inc/tap/maestro` formula, not the entire `mobile-dev-inc/tap` tap. The unrelated homebrew-cask `maestro` is a different product and is never installed.
+
+Terrapod does not install Android SDK components or Xcode. Android Studio's SDK Manager owns the SDK, and Xcode is distributed through the App Store. `JAVA_HOME` resolves to the runtime bundled with Android Studio rather than a separately declared JDK, so the command line and the IDE always agree on a Java version.
+```
+
+- [ ] **Step 4: Update README.ko.md**
+
+Add the matching bullet after the `development-apps` bullet:
+
+```markdown
+- `mobile-dev`: Android Studio와 Maestro(`mobile-dev-inc/tap/maestro`).
+```
+
+Add the matching settings row after the development-apps row:
+
+```markdown
+| `enableMacosAppGroupMobileDev` | `false` | mobile-dev macOS App Group인 Android Studio와 Maestro(`mobile-dev-inc/tap/maestro`)를 설치합니다. `ANDROID_HOME`과 `JAVA_HOME`도 함께 설정합니다. |
+```
+
+Add the matching paragraphs after the Orca trust sentence:
+
+```markdown
+Terrapod은 fully-qualified `mobile-dev-inc/tap/maestro` formula만 trust하며, `mobile-dev-inc/tap` tap 전체를 trust하지 않습니다. homebrew-cask의 `maestro`는 다른 제품이므로 설치하지 않습니다.
+
+Terrapod은 Android SDK component와 Xcode를 설치하지 않습니다. SDK는 Android Studio의 SDK Manager가 소유하고, Xcode는 App Store로 배포됩니다. `JAVA_HOME`은 별도로 선언한 JDK가 아니라 Android Studio가 번들한 runtime을 가리키므로, command line과 IDE가 항상 같은 Java version을 사용합니다.
+```
+
+- [ ] **Step 5: Update CONTEXT.md**
+
+Widen the macOS Desktop App Stack definition so it admits tap-delivered companion CLIs. Replace its description line with:
+
+```markdown
+The opt-in macOS package set for GUI apps, system-style desktop apps, cask-delivered desktop support tools, and tap-delivered companion CLIs that ship with those apps.
+```
+
+Add these facts next to the existing App Group facts:
+
+```markdown
+- The mobile-dev **macOS App Group** contains Android Studio and Maestro.
+- The mobile-dev **macOS App Group** declares `mobile-dev-inc/tap/maestro` with `trusted: true` so Homebrew trusts only the Maestro formula, not the entire `mobile-dev-inc/tap` tap.
+- The homebrew-cask `maestro` is a different product from the mobile-dev **macOS App Group**'s Maestro and is never declared.
+- The managed `.zshenv` exports `ANDROID_HOME`, `ANDROID_SDK_ROOT`, and `JAVA_HOME` only when the mobile-dev **macOS App Group** is enabled, and renders them before the machine-local override loop so explicit overrides still run last.
+- `JAVA_HOME` resolves to the runtime bundled with Android Studio, so **Terrapod** declares no separate JDK.
+- Android SDK components and Xcode remain outside **Terrapod** ownership; the Android SDK Manager owns the former and the App Store distributes the latter.
+```
+
+- [ ] **Step 6: Write the ADR**
+
+Create `docs/adr/0013-scope-the-mobile-dev-app-group.md`:
+
+```markdown
+# Scope the mobile-dev App Group to entry points
+
+The `mobile-dev` **macOS App Group** installs Android Studio and Maestro and
+renders the Android and Java shell environment. It does not install Android SDK
+components, Xcode, or a separate JDK.
+
+`JAVA_HOME` resolves to the runtime Android Studio bundles at
+`/Applications/Android Studio.app/Contents/jbr/Contents/Home`.
+
+## Considered Options
+
+- Declare Android SDK components through `sdkmanager`: rejected because
+  `platforms`, `build-tools`, `ndk`, and `system-images` are license-gated
+  multi-gigabyte downloads, and accepting licences inside a non-interactive
+  `tpod apply` is not something Terrapod should do on a user's behalf.
+- Install Xcode through a third-party CLI: rejected because App Store
+  distribution requires Apple account authentication, which a non-interactive
+  apply cannot supply.
+- Declare a JDK through the `temurin` cask or mise: rejected because a second
+  Java runtime can disagree with the version Android Studio uses for Gradle
+  builds, and the bundled runtime is already installed by the cask this group
+  declares.
+- Model the group as a cross-profile optional stack: rejected because it
+  depends on the `android-studio` cask and an `/Applications` path, so it would
+  introduce a macOS-only optional stack and duplicate the App Group machinery.
+
+## Consequences
+
+- A fresh macOS workstation gets the IDE, the SDK Manager, and Maestro from
+  `tpod apply`, then populates the SDK through Android Studio on first launch.
+- `ANDROID_HOME` points at `$HOME/Library/Android/sdk`, a directory the SDK
+  Manager creates rather than the cask.
+- Existing vendor-installed Maestro binaries under `~/.maestro/bin` are not
+  removed. The existing shadowing warning reports them when they resolve ahead
+  of the Homebrew copy.
+- Adding `enableMacosAppGroupMobileDev` changes managed setup config
+  completeness, so already-configured machines are asked to rerun setup.
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `sh tests/readme_optional_stack_profiles_test.sh && sh tests/readme_korean_test.sh`
+Expected: both PASS.
+
+- [ ] **Step 8: Run the full suite**
+
+```bash
+for f in tests/*.sh tests/*.zsh; do
+  case "$f" in *homebrew_ubuntu_smoke.sh) continue;; esac
+  case "$f" in *.zsh) r=zsh;; *) r=sh;; esac
+  if out=$("$r" "$f" 2>&1); then echo "PASS $f"; else echo "FAIL $f"; printf '%s\n' "$out" | grep -v '^ok - ' | tail -3; fi
+done
+```
+
+Expected: every file PASSes except `tests/jetendard_font_test.sh`, `tests/jetendard_settings_test.sh`, and `tests/terrapod_command_test.sh`, which fail identically on `main`. If any other file fails, or if those three fail at a different assertion than they do on `main`, stop and investigate rather than proceeding.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add README.md README.ko.md CONTEXT.md docs/adr/0013-scope-the-mobile-dev-app-group.md tests/readme_optional_stack_profiles_test.sh tests/readme_korean_test.sh
+git commit -m "Document the mobile-dev App Group and its scope boundary"
+```

--- a/docs/superpowers/plans/2026-08-22-mobile-dev-app-group.md
+++ b/docs/superpowers/plans/2026-08-22-mobile-dev-app-group.md
@@ -802,9 +802,11 @@ components, Xcode, or a separate JDK.
   `tpod apply`, then populates the SDK through Android Studio on first launch.
 - `ANDROID_HOME` points at `$HOME/Library/Android/sdk`, a directory the SDK
   Manager creates rather than the cask.
-- Existing vendor-installed Maestro binaries under `~/.maestro/bin` are not
-  removed. The existing shadowing warning reports them when they resolve ahead
-  of the Homebrew copy.
+- The existing vendor-installed Maestro binary under `~/.maestro/bin` is left
+  in place, consistent with Terrapod's non-destructive apply contract. The
+  managed shell environment no longer adds that directory to PATH, so the
+  Homebrew copy is the one that resolves. Terrapod does not detect or report a
+  vendor copy that a user's own PATH additions place ahead of it.
 - Adding `enableMacosAppGroupMobileDev` changes managed setup config
   completeness, so already-configured machines are asked to rerun setup.
 ```

--- a/docs/superpowers/specs/2026-08-22-mobile-dev-app-group-design.md
+++ b/docs/superpowers/specs/2026-08-22-mobile-dev-app-group-design.md
@@ -162,8 +162,9 @@ ways:
   already activates mise, so the tail repeated it.
 - `$HOME/.maestro/bin` is dropped from PATH. Maestro now comes from Homebrew,
   whose prefix `.zshenv` already exports. Terrapod does not delete the existing
-  vendor-installed binary; the existing status and doctor warning for a command
-  resolving outside the active Homebrew prefix reports the shadowing instead.
+  vendor-installed binary; it is simply left off PATH so the Homebrew copy is
+  the one that resolves. Terrapod does not detect or report a vendor copy that
+  a user's own PATH additions place ahead of it.
 - Existence guards wrap the exports, matching the guard the OrbStack shell
   integration uses. A failed Android Studio install would otherwise leave
   `JAVA_HOME` pointing at a missing directory and break `java` entirely, and

--- a/docs/superpowers/specs/2026-08-22-mobile-dev-app-group-design.md
+++ b/docs/superpowers/specs/2026-08-22-mobile-dev-app-group-design.md
@@ -1,0 +1,252 @@
+# Mobile Dev App Group Design
+
+## Goal
+
+Reproduce this machine's Android development entry points on a fresh macOS
+Terminal Profile through a new `mobile-dev` macOS App Group. The group installs
+Android Studio and Maestro, and renders the Android and Java shell environment
+that those tools need.
+
+The group covers entry points only. Android SDK components and Xcode stay
+outside Terrapod's ownership.
+
+This change is non-destructive. Enabling the group does not remove an existing
+Android Studio, Maestro, or SDK installation, and disabling it does not
+uninstall anything.
+
+## Current State
+
+The configured workstation runs Android development entirely outside Terrapod:
+
+- Android Studio is installed manually in `/Applications`, not through Homebrew.
+- Maestro is installed by its own vendor script into `~/.maestro/bin`.
+- No JDK is installed through Homebrew. `JAVA_HOME` points at Android Studio's
+  bundled JBR, and `java` resolves to that OpenJDK 25 runtime.
+- The Android SDK at `~/Library/Android/sdk` is populated by Android Studio's
+  SDK Manager and holds `build-tools`, `cmake`, `ndk`, `platforms`, and
+  `system-images`.
+- Xcode is installed from the App Store at `/Applications/Xcode.app`.
+- `~/.zshrc` carries a hand-added tail that exports `ANDROID_HOME`,
+  `ANDROID_SDK_ROOT`, `JAVA_HOME`, and PATH entries for `platform-tools`,
+  `emulator`, and `~/.maestro/bin`. It also repeats
+  `eval "$(mise activate zsh)"`, which the managed `dot_zshrc.tmpl` already
+  runs.
+
+Because Terrapod owns `.zshrc`, applying the declared state deletes that tail.
+No declared state replaces it, so a fresh machine has no Android environment at
+all.
+
+Neither CocoaPods, Watchman, nor Flutter is installed, so this machine is not
+running a React Native or Flutter workflow. The group is scoped to native
+Android tooling plus the Maestro end-to-end runner.
+
+## Considered Approaches
+
+### New `mobile-dev` macOS App Group
+
+Add one setting key and one group to the rendered macOS Desktop App Stack
+Brewfile, and render the shell environment from the same key.
+
+This is the selected approach. It reuses the entire App Group mechanism:
+the setup confirmation prompt, the `tpod status` line, the desktop app warning
+marker, the reconcile script's group attribution, the documentation tables, and
+the existing test fixtures. The `workstation` Preset already enables every App
+Group, so the group joins that Preset without new Preset logic. macOS-only
+scope is already inherent to the App Group concept.
+
+Its cost is two cask-only assumptions that must be loosened, both local and
+both reusable by any future group that ships a tap formula. See
+"Reconcile Record Format".
+
+### New `enableMobileDevStack` optional stack
+
+Shape the group like the Optional AI Tool Stack, with its own rendered
+Brewfile. This fits a mixed app-and-CLI payload without amending any
+definition.
+
+Rejected because every existing optional stack is cross-profile while this one
+depends on the `android-studio` cask and an `/Applications` path. It would
+introduce "macOS-only optional stack" as a new concept and duplicate the
+installation, warning, status, and setup machinery that App Groups already
+provide.
+
+### Extend the existing `development-apps` App Group
+
+Add both packages to the group that already carries Zed, Orca ADE, and
+OrbStack, with no new setting key.
+
+Rejected because it removes the user's choice. A machine that wants Zed and
+Orca would be forced to install Android Studio and its multi-gigabyte payload,
+and mobile development is a separate concern from general desktop development
+tooling.
+
+## Package Ownership
+
+The `mobile-dev` macOS App Group owns:
+
+- `android-studio`, a Homebrew cask, providing the IDE, the SDK Manager, and
+  the bundled JBR that `JAVA_HOME` resolves to
+- `mobile-dev-inc/tap/maestro`, a Homebrew formula, providing the `maestro`
+  end-to-end test runner
+
+Maestro is declared exactly the way Orca already is, as a fully-qualified token
+carrying `trusted: true`:
+
+```
+brew "mobile-dev-inc/tap/maestro", trusted: true
+```
+
+Homebrew refuses to load formulae and casks from non-official taps unless they
+are trusted, and `trusted: true` trusts this one entry rather than the whole
+`mobile-dev-inc/tap` tap. No separate `tap` statement is needed; the
+fully-qualified token taps on demand.
+
+The cask named `maestro` in homebrew-cask is a different product, an AI agent
+command center published at runmaestro.ai. The fully-qualified token also keeps
+that name collision from resolving to the wrong package.
+
+`android-platform-tools` is deliberately excluded. The Android SDK already
+provides `adb` and `emulator`, and the rendered PATH points into the SDK.
+
+## Scope Boundary
+
+These stay outside Terrapod's ownership and are documented as such:
+
+- **Android SDK components.** `platforms`, `build-tools`, `ndk`, `cmake`, and
+  `system-images` are license-gated multi-gigabyte downloads owned by Android
+  Studio's SDK Manager. Declaring them would put license acceptance and
+  multi-gigabyte transfers inside a non-interactive `tpod apply`.
+- **Xcode.** It is distributed through the App Store and needs Apple account
+  authentication, which conflicts with non-interactive apply.
+- **The JDK.** `JAVA_HOME` resolves to Android Studio's bundled JBR rather than
+  a separately declared JDK, so the command-line toolchain and the IDE always
+  agree on a Java version and no second multi-hundred-megabyte runtime is
+  downloaded.
+
+## Setting Surface
+
+The group adds one machine-local setting key,
+`enableMacosAppGroupMobileDev`, defaulting to `false`.
+
+Preset behavior follows the existing rule without new logic. Only the
+`workstation` Preset enables every macOS App Group, so `minimal` and
+`development` record the key as `false`.
+
+`render_settings_data` in `dot_local/bin/executable_terrapod` currently consumes
+positional parameters `$1` through `$9`. The tenth key must be written as
+`${10}`, and each `render_preset_data` branch grows from eight boolean
+arguments to nine.
+
+Adding a key changes managed setup config completeness. Terrapod treats a
+managed setup config as complete only when the profile and every current
+optional stack and App Group key are present, so every already-configured
+machine is asked to rerun setup after this change. This matches what previous
+App Group additions did.
+
+## Shell Environment
+
+The Android and Java environment renders from `dot_zshenv.tmpl`, not
+`dot_zshrc.tmpl`. `.zshrc` loads only for interactive shells, while
+`ANDROID_HOME` and `JAVA_HOME` must also reach non-interactive callers such as
+Gradle wrapper scripts and IDE-spawned shells. PATH initialization is already
+`.zshenv`'s stated responsibility.
+
+The block renders only when `enableMacosAppGroupMobileDev` is true, and sits
+immediately before the `~/.config/zsh/path.d` loop so explicit machine-local
+overrides still run last.
+
+The rendered block differs from the current hand-added `.zshrc` tail in three
+ways:
+
+- `eval "$(mise activate zsh)"` is dropped. The managed `dot_zshrc.tmpl`
+  already activates mise, so the tail repeated it.
+- `$HOME/.maestro/bin` is dropped from PATH. Maestro now comes from Homebrew,
+  whose prefix `.zshenv` already exports. Terrapod does not delete the existing
+  vendor-installed binary; the existing status and doctor warning for a command
+  resolving outside the active Homebrew prefix reports the shadowing instead.
+- Existence guards wrap the exports, matching the guard the OrbStack shell
+  integration uses. A failed Android Studio install would otherwise leave
+  `JAVA_HOME` pointing at a missing directory and break `java` entirely, and
+  absent SDK directories would otherwise be appended to PATH as noise.
+
+`ANDROID_HOME` remains `$HOME/Library/Android/sdk`. That path is created by the
+SDK Manager rather than by the cask, which is exactly the ownership boundary
+this design documents.
+
+## Reconcile Record Format
+
+`10-reconcile-homebrew.sh` installs the rendered desktop Brewfile in one bulk
+`brew bundle` pass and drops to per-package retry only when that pass fails.
+The retry path is cask-only in two places:
+
+- `desktop_app_cask_records` parses group comments and `cask "` lines only.
+- The retry loop rewrites each record as a single-package Brewfile using
+  `cask "%s"`.
+
+Left unchanged, Maestro would install in the bulk pass but would never be named
+in the desktop app warning marker when installation fails.
+
+The record format grows a declaration kind and the declaration's options, so
+each record carries group, kind, token, and options. The awk program recognizes
+`brew "` lines alongside `cask "` lines, and the retry loop rewrites the
+matching declaration with its options preserved.
+
+The same change fixes an existing defect in that function. Records currently
+carry only the package name, so Orca's `trusted: true` is dropped when a bulk
+failure sends `stablyai/orca/orca` through per-cask retry. Homebrew stores
+trust persistently in `~/.homebrew/trust.json`, so a machine that already
+trusts Orca is unaffected, which is why the defect has gone unnoticed; a
+machine whose bulk pass failed before trust was recorded cannot load the entry
+on retry. Preserving options alongside the kind repairs that path, and Maestro
+depends on the same preservation.
+
+## Command Surface
+
+Both App Group inventory surfaces are populated in the same change:
+
+- `show_setup_option_block` gains a `mobile-dev macOS App Group` case. Because
+  this block prints immediately before the gum confirmation prompt, it is the
+  disclosure the user acts on. It names Android Studio and Maestro and states
+  that the group sets `ANDROID_HOME` and `JAVA_HOME`, since this is the first
+  App Group to modify the shell environment.
+- `print_macos_app_group_status` gains a `mobile-dev` line.
+
+`setup_option_title` emits group names only and needs no inventory text.
+
+`tpod doctor` gains no new check. Optional group installation failures are
+reported through the desktop app warning marker, and this group is not an
+exception to that structure.
+
+## Documentation
+
+- `README.md` and `README.ko.md` gain the group in the App Group inventory list
+  and the machine-local settings table, plus a paragraph stating that Android
+  SDK components and Xcode stay outside Terrapod.
+- `CONTEXT.md` widens the macOS Desktop App Stack definition so it covers
+  companion CLIs delivered through a tap alongside cask-delivered apps, and
+  records the group's membership, the `JAVA_HOME` resolution, and the scope
+  boundary.
+- A new ADR records why SDK components, Xcode, and a separately declared JDK
+  are excluded from the reproduction target.
+
+## Testing
+
+- `tests/chezmoiignore_test.sh`: the `mobile-dev` group renders exactly
+  `android-studio` and the fully-qualified Maestro token with `trusted: true`;
+  other groups and the macOS default render neither; `.zshenv` renders the
+  Android environment only when the group is enabled, and renders it before the
+  `path.d` loop.
+- `tests/terrapod_command_test.sh`: the setup option block and the `tpod status`
+  line name Android Studio, Maestro, `ANDROID_HOME`, and `JAVA_HOME`.
+- `tests/readme_optional_stack_profiles_test.sh` and
+  `tests/readme_korean_test.sh`: both READMEs document the group and the scope
+  boundary.
+- `tests/terrapod_config_test.sh` and `tests/terrapod_installer_test.sh`: each
+  Preset writes the new key, and a config missing the key is treated as
+  incomplete.
+- `tests/zshenv_local_bin_test.sh`: the Android environment does not displace
+  `$HOME/.local/bin` ordering or the Homebrew shellenv block.
+- Reconcile coverage in `tests/chezmoiignore_test.sh`: a bulk failure attributes
+  a failed tap formula to the `mobile-dev` group in the desktop app warning
+  marker, and per-package retry of `stablyai/orca/orca` preserves
+  `trusted: true`.

--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -507,6 +507,9 @@ setup_option_title() {
     "development-apps macOS App Group")
       printf '%s\n' "development-apps"
       ;;
+    "mobile-dev macOS App Group")
+      printf '%s\n' "mobile-dev"
+      ;;
     *)
       return 1
       ;;
@@ -551,6 +554,12 @@ show_setup_option_block() {
     "development-apps macOS App Group")
       printf '%s\n' "  Installs Zed, Orca ADE, and OrbStack."
       printf '%s\n' "  Trusts only the fully-qualified stablyai/orca/orca cask, not the entire stablyai/orca tap."
+      ;;
+    "mobile-dev macOS App Group")
+      printf '%s\n' "  Installs Android Studio and Maestro."
+      printf '%s\n' "  Sets ANDROID_HOME and JAVA_HOME for Android builds."
+      printf '%s\n' "  Trusts only the fully-qualified mobile-dev-inc/tap/maestro formula, not the entire mobile-dev-inc/tap tap."
+      printf '%s\n' "  Android SDK components and Xcode stay outside Terrapod."
       ;;
   esac
   printf '%s\n' ""
@@ -623,12 +632,14 @@ prompt_for_setup_settings() {
     setup_enableMacosAppGroupLauncher="$(prompt_setup_bool "launcher macOS App Group" "$setup_enableMacosAppGroupLauncher")"
     setup_enableMacosAppGroupMonitoring="$(prompt_setup_bool "monitoring macOS App Group" "$setup_enableMacosAppGroupMonitoring")"
     setup_enableMacosAppGroupDevelopmentApps="$(prompt_setup_bool "development-apps macOS App Group" "$setup_enableMacosAppGroupDevelopmentApps")"
+    setup_enableMacosAppGroupMobileDev="$(prompt_setup_bool "mobile-dev macOS App Group" "$setup_enableMacosAppGroupMobileDev")"
   else
     setup_enableMacosAppGroupTerminalApps=false
     setup_enableMacosAppGroupAutomation=false
     setup_enableMacosAppGroupLauncher=false
     setup_enableMacosAppGroupMonitoring=false
     setup_enableMacosAppGroupDevelopmentApps=false
+    setup_enableMacosAppGroupMobileDev=false
     printf '%s\n' "macOS App Groups: not applicable for $(profile_context_label)" >&2
   fi
 
@@ -645,7 +656,8 @@ managed_setup_keys() {
     enableMacosAppGroupAutomation \
     enableMacosAppGroupLauncher \
     enableMacosAppGroupMonitoring \
-    enableMacosAppGroupDevelopmentApps
+    enableMacosAppGroupDevelopmentApps \
+    enableMacosAppGroupMobileDev
 }
 
 config_data_value() {
@@ -1097,6 +1109,11 @@ print_macos_app_group_status() {
   else
     print_indented_colon_state_line "development-apps" "disabled"
   fi
+  if is_enabled "$(config_data_bool "$config_file" enableMacosAppGroupMobileDev)"; then
+    print_indented_colon_state_line "mobile-dev" "enabled" "(Android Studio and Maestro)"
+  else
+    print_indented_colon_state_line "mobile-dev" "disabled"
+  fi
 }
 
 print_key_tool_status() {
@@ -1330,11 +1347,13 @@ show_stack_context() {
   launcher_state="$(config_bool_state_label "$config_file" enableMacosAppGroupLauncher)"
   monitoring_state="$(config_bool_state_label "$config_file" enableMacosAppGroupMonitoring)"
   development_apps_state="$(config_bool_state_label "$config_file" enableMacosAppGroupDevelopmentApps)"
+  mobile_dev_state="$(config_bool_state_label "$config_file" enableMacosAppGroupMobileDev)"
   print_named_state_line "terminal-apps" "$terminal_apps_state"
   print_named_state_line "automation" "$automation_state"
   print_named_state_line "launcher" "$launcher_state"
   print_named_state_line "monitoring" "$monitoring_state"
   print_named_state_line "development-apps" "$development_apps_state"
+  print_named_state_line "mobile-dev" "$mobile_dev_state"
 }
 
 render_chezmoi_command() {
@@ -1797,6 +1816,7 @@ enableMacosAppGroupAutomation = $6
 enableMacosAppGroupLauncher = $7
 enableMacosAppGroupMonitoring = $8
 enableMacosAppGroupDevelopmentApps = $9
+enableMacosAppGroupMobileDev = ${10}
 EOF
 }
 
@@ -1806,13 +1826,13 @@ render_preset_data() {
 
   case "$preset" in
     minimal)
-      render_settings_data "$profile" false false false false false false false false
+      render_settings_data "$profile" false false false false false false false false false
       ;;
     development)
-      render_settings_data "$profile" true true true false false false false false
+      render_settings_data "$profile" true true true false false false false false false
       ;;
     workstation)
-      render_settings_data "$profile" true true true true true true true true
+      render_settings_data "$profile" true true true true true true true true true
       ;;
     *)
       return 1
@@ -1833,6 +1853,7 @@ load_setup_defaults() {
       setup_enableMacosAppGroupLauncher=false
       setup_enableMacosAppGroupMonitoring=false
       setup_enableMacosAppGroupDevelopmentApps=false
+      setup_enableMacosAppGroupMobileDev=false
       ;;
     development)
       setup_enableEditorStack=true
@@ -1843,6 +1864,7 @@ load_setup_defaults() {
       setup_enableMacosAppGroupLauncher=false
       setup_enableMacosAppGroupMonitoring=false
       setup_enableMacosAppGroupDevelopmentApps=false
+      setup_enableMacosAppGroupMobileDev=false
       ;;
     workstation)
       setup_enableEditorStack=true
@@ -1853,6 +1875,7 @@ load_setup_defaults() {
       setup_enableMacosAppGroupLauncher=true
       setup_enableMacosAppGroupMonitoring=true
       setup_enableMacosAppGroupDevelopmentApps=true
+      setup_enableMacosAppGroupMobileDev=true
       ;;
     *)
       return 1
@@ -1872,7 +1895,8 @@ render_setup_data() {
     "$setup_enableMacosAppGroupAutomation" \
     "$setup_enableMacosAppGroupLauncher" \
     "$setup_enableMacosAppGroupMonitoring" \
-    "$setup_enableMacosAppGroupDevelopmentApps"
+    "$setup_enableMacosAppGroupDevelopmentApps" \
+    "$setup_enableMacosAppGroupMobileDev"
 }
 
 validate_preset() {
@@ -2235,6 +2259,7 @@ write_managed_settings() {
           name == "enableMacosAppGroupLauncher" ||
           name == "enableMacosAppGroupMonitoring" ||
           name == "enableMacosAppGroupDevelopmentApps" ||
+          name == "enableMacosAppGroupMobileDev" ||
           name == "enableMacosAppGroupAiApps" ||
           name == "enableMacosDesktopApps" ||
           name == "terrapodPreset"

--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -20,6 +20,29 @@ elif [[ -x /usr/local/bin/brew ]]; then
 fi
 {{ end -}}
 
+{{ if default false (get . "enableMacosAppGroupMobileDev") }}
+# Android tooling from the mobile-dev macOS App Group.
+# The Android SDK Manager owns this directory; the cask does not create it.
+export ANDROID_HOME="$HOME/Library/Android/sdk"
+export ANDROID_SDK_ROOT="$ANDROID_HOME"
+
+# emulator is prepended first so platform-tools ends up ahead of it.
+if [[ -d "$ANDROID_HOME/emulator" ]]; then
+  path=("$ANDROID_HOME/emulator" $path)
+fi
+if [[ -d "$ANDROID_HOME/platform-tools" ]]; then
+  path=("$ANDROID_HOME/platform-tools" $path)
+fi
+
+# Java resolves to the runtime Android Studio bundles, so the command line and
+# the IDE always agree on a version.
+android_studio_jbr="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+if [[ -d "$android_studio_jbr" ]]; then
+  export JAVA_HOME="$android_studio_jbr"
+fi
+unset android_studio_jbr
+{{ end }}
+
 # Explicit machine-local overrides run last.
 if [[ -d "$HOME/.config/zsh/path.d" ]]; then
   for path_snippet in "$HOME"/.config/zsh/path.d/*.zsh(N); do

--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -20,7 +20,7 @@ elif [[ -x /usr/local/bin/brew ]]; then
 fi
 {{ end -}}
 
-{{ if default false (get . "enableMacosAppGroupMobileDev") }}
+{{ if default false (get . "enableMacosAppGroupMobileDev") -}}
 # Android tooling from the mobile-dev macOS App Group.
 # The Android SDK Manager owns this directory; the cask does not create it.
 export ANDROID_HOME="$HOME/Library/Android/sdk"
@@ -41,7 +41,7 @@ if [[ -d "$android_studio_jbr" ]]; then
   export JAVA_HOME="$android_studio_jbr"
 fi
 unset android_studio_jbr
-{{ end }}
+{{ end -}}
 
 # Explicit machine-local overrides run last.
 if [[ -d "$HOME/.config/zsh/path.d" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -773,7 +773,8 @@ managed_setup_keys() {
     enableMacosAppGroupAutomation \
     enableMacosAppGroupLauncher \
     enableMacosAppGroupMonitoring \
-    enableMacosAppGroupDevelopmentApps
+    enableMacosAppGroupDevelopmentApps \
+    enableMacosAppGroupMobileDev
 }
 
 config_data_value() {

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -1026,6 +1026,28 @@ assert_not_contains_text "$macos_brewfile" 'cask "android-studio"' "macOS defaul
 assert_not_contains_text "$macos_brewfile" 'mobile-dev-inc/tap/maestro' "macOS default does not render Maestro"
 assert_not_contains_text "$development_apps_brewfile" 'cask "android-studio"' "development-apps group does not render Android Studio"
 
+mobile_dev_zshenv="$(render_managed_file "$macos_mobile_dev_data" ".zshenv")"
+macos_default_zshenv="$(render_managed_file "$macos_data" ".zshenv")"
+
+assert_contains_text "$mobile_dev_zshenv" 'export ANDROID_HOME="$HOME/Library/Android/sdk"' "mobile-dev group exports ANDROID_HOME"
+assert_contains_text "$mobile_dev_zshenv" 'export ANDROID_SDK_ROOT="$ANDROID_HOME"' "mobile-dev group exports ANDROID_SDK_ROOT"
+assert_contains_text "$mobile_dev_zshenv" 'export JAVA_HOME="$android_studio_jbr"' "mobile-dev group resolves JAVA_HOME to the Android Studio bundled runtime"
+assert_contains_text "$mobile_dev_zshenv" 'if [[ -d "$android_studio_jbr" ]]; then' "JAVA_HOME is guarded so a failed Android Studio install cannot break java"
+assert_contains_text "$mobile_dev_zshenv" 'if [[ -d "$ANDROID_HOME/platform-tools" ]]; then' "platform-tools joins PATH only when the SDK provides it"
+assert_not_contains_text "$mobile_dev_zshenv" '.maestro/bin' "Maestro resolves through the Homebrew prefix instead of its vendor install directory"
+assert_not_contains_text "$mobile_dev_zshenv" 'mise activate' "the Android environment does not repeat the mise activation the managed zshrc already runs"
+assert_not_contains_text "$macos_default_zshenv" 'ANDROID_HOME' "macOS default does not render the Android environment"
+
+mobile_dev_android_line="$(printf '%s\n' "$mobile_dev_zshenv" | grep -n 'export ANDROID_HOME' | head -1 | cut -d: -f1)"
+mobile_dev_override_line="$(printf '%s\n' "$mobile_dev_zshenv" | grep -n 'zsh/path.d' | head -1 | cut -d: -f1)"
+if [ -z "$mobile_dev_android_line" ] || [ -z "$mobile_dev_override_line" ]; then
+  fail "rendered .zshenv should contain both the Android environment and the machine-local override loop"
+fi
+if [ "$mobile_dev_android_line" -ge "$mobile_dev_override_line" ]; then
+  fail "the Android environment must render before the machine-local override loop so explicit overrides still run last"
+fi
+pass "the Android environment renders before the machine-local override loop"
+
 development_apps_zprofile="$(render_managed_file "$macos_development_apps_data" ".zprofile")"
 macos_default_zprofile="$(render_managed_file "$macos_data" ".zprofile")"
 

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -474,7 +474,7 @@ write_brew_bundle_stub() {
     '      printf "%s\n" "visible brew bundle output: $*"' \
     '    fi' \
     '    for formula in ${MACOS_BREW_FAIL_FORMULAE:-}; do' \
-    '      if [ -n "$bundle_file" ] && grep -Fx "brew \"$formula\"" "$bundle_file" >/dev/null 2>&1; then' \
+    '      if [ -n "$bundle_file" ] && grep -Eq "^brew \"$formula\"(,[[:space:]]|$)" "$bundle_file" 2>/dev/null; then' \
     '        exit 42' \
     '      fi' \
     '    done' \
@@ -482,7 +482,7 @@ write_brew_bundle_stub() {
     '      exit 42' \
     '    fi' \
     '    for cask in ${MACOS_BREW_FAIL_CASKS:-}; do' \
-    '      if [ -n "$bundle_file" ] && grep -Fx "cask \"$cask\"" "$bundle_file" >/dev/null 2>&1; then' \
+    '      if [ -n "$bundle_file" ] && grep -Eq "^cask \"$cask\"(,[[:space:]]|$)" "$bundle_file" 2>/dev/null; then' \
     '        exit 42' \
     '      fi' \
     '    done' \
@@ -1023,6 +1023,44 @@ printf '%s\n' "$macos_development_apps_bootstrap" | sed \
   >"$development_apps_bootstrap_script"
 sh -n "$development_apps_bootstrap_script" || fail "development-apps bootstrap script should be valid sh"
 pass "development-apps bootstrap script is valid sh"
+
+package_records_probe="$tmp_dir/package-records-probe.sh"
+package_records_brewfile="$tmp_dir/package-records-brewfile"
+cat >"$package_records_brewfile" <<'PROBE_BREWFILE'
+# development-apps macOS App Group
+cask "zed"
+cask "stablyai/orca/orca", trusted: true
+# mobile-dev macOS App Group
+cask "android-studio"
+brew "mobile-dev-inc/tap/maestro", trusted: true
+PROBE_BREWFILE
+
+sed -n '/^desktop_app_package_records()/,/^}/p' \
+  "$repo_root/.chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl" \
+  >"$package_records_probe"
+printf '%s\n' 'desktop_app_package_records "$1"' >>"$package_records_probe"
+
+package_records_output="$(sh "$package_records_probe" "$package_records_brewfile")"
+
+expected_package_records="$(printf '%s\n' \
+  'development-apps	zed	cask "zed"' \
+  'development-apps	stablyai/orca/orca	cask "stablyai/orca/orca", trusted: true' \
+  'mobile-dev	android-studio	cask "android-studio"' \
+  'mobile-dev	mobile-dev-inc/tap/maestro	brew "mobile-dev-inc/tap/maestro", trusted: true')"
+
+assert_text_equals \
+  "$package_records_output" \
+  "$expected_package_records" \
+  "desktop app package records carry group, token, and the verbatim declaration for casks and tap formulae"
+
+assert_contains_text \
+  "$macos_development_apps_bootstrap" \
+  'read -r app_group token declaration' \
+  "per-package retry reads the declaration field alongside the group and token"
+assert_contains_text \
+  "$macos_development_apps_bootstrap" \
+  '>"$single_package_brewfile"' \
+  "per-package retry writes the recorded declaration so options such as trusted: true survive"
 
 development_apps_failure_bin="$tmp_dir/development-apps-failure-bin"
 development_apps_failure_state="$tmp_dir/development-apps-failure-state"

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -202,6 +202,7 @@ macos_launcher_apps_data='{"chezmoi":{"os":"darwin"},"enableMacosAppGroupTermina
 macos_terminal_launcher_apps_data='{"chezmoi":{"os":"darwin"},"enableMacosAppGroupTerminalApps":true,"enableMacosAppGroupAutomation":false,"enableMacosAppGroupLauncher":true,"enableMacosAppGroupMonitoring":false,"enableMacosAppGroupDevelopmentApps":false}'
 macos_monitoring_apps_data='{"chezmoi":{"os":"darwin"},"enableMacosAppGroupTerminalApps":false,"enableMacosAppGroupAutomation":false,"enableMacosAppGroupLauncher":false,"enableMacosAppGroupMonitoring":true}'
 macos_development_apps_data='{"chezmoi":{"os":"darwin"},"enableMacosAppGroupTerminalApps":false,"enableMacosAppGroupAutomation":false,"enableMacosAppGroupLauncher":false,"enableMacosAppGroupMonitoring":false,"enableMacosAppGroupDevelopmentApps":true}'
+macos_mobile_dev_data='{"chezmoi":{"os":"darwin"},"enableMacosAppGroupTerminalApps":false,"enableMacosAppGroupAutomation":false,"enableMacosAppGroupLauncher":false,"enableMacosAppGroupMonitoring":false,"enableMacosAppGroupDevelopmentApps":false,"enableMacosAppGroupMobileDev":true}'
 macos_terminal_apps_managed_targets="$(managed_target_paths "$macos_terminal_apps_data")"
 macos_development_apps_managed="$(managed_source_paths "$macos_development_apps_data")"
 macos_ai_cli_tools_data='{"chezmoi":{"os":"darwin"},"enableEditorStack":false,"enableAiCliTools":true,"enableDevelopmentWorkspace":false}'
@@ -264,11 +265,13 @@ automation_apps_brewfile="$(render_template "$macos_automation_apps_data" "Brewf
 launcher_apps_brewfile="$(render_template "$macos_launcher_apps_data" "Brewfile.macos-desktop-apps.tmpl")"
 monitoring_apps_brewfile="$(render_template "$macos_monitoring_apps_data" "Brewfile.macos-desktop-apps.tmpl")"
 development_apps_brewfile="$(render_template "$macos_development_apps_data" "Brewfile.macos-desktop-apps.tmpl")"
+mobile_dev_brewfile="$(render_template "$macos_mobile_dev_data" "Brewfile.macos-desktop-apps.tmpl")"
 ubuntu_homebrew_bootstrap="$(render_template "$ubuntu_data" ".chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl")"
 macos_bootstrap="$(render_template "$macos_data" ".chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl")"
 macos_terminal_apps_bootstrap="$(render_template "$macos_terminal_apps_data" ".chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl")"
 macos_terminal_launcher_apps_bootstrap="$(render_template "$macos_terminal_launcher_apps_data" ".chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl")"
 macos_development_apps_bootstrap="$(render_template "$macos_development_apps_data" ".chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl")"
+macos_mobile_dev_bootstrap="$(render_template "$macos_mobile_dev_data" ".chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl")"
 macos_development_workspace_bootstrap="$(render_template "$macos_development_workspace_data" ".chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl")"
 macos_mise_tools_installer="$(render_template "$macos_data" ".chezmoiscripts/run_after_20-install-mise-tools.sh.tmpl")"
 macos_jetendard_installer="$(render_template "$macos_data" ".chezmoiscripts/run_onchange_after_65-install-jetendard-font.sh.tmpl")"
@@ -1000,6 +1003,29 @@ assert_text_equals \
   "$expected_development_apps_casks" \
   "development-apps group renders exactly the expected casks"
 
+assert_contains_text "$mobile_dev_brewfile" 'cask "android-studio"' "mobile-dev group renders Android Studio"
+assert_contains_text "$mobile_dev_brewfile" 'brew "mobile-dev-inc/tap/maestro", trusted: true' "mobile-dev group trusts only the fully-qualified Maestro formula, not the entire mobile-dev-inc/tap tap"
+assert_not_contains_text "$mobile_dev_brewfile" 'cask "maestro"' "mobile-dev group does not render the unrelated homebrew-cask maestro"
+assert_not_contains_text "$mobile_dev_brewfile" 'tap "mobile-dev-inc/tap"' "mobile-dev group taps on demand through the fully-qualified token instead of trusting the whole tap"
+assert_not_contains_text "$mobile_dev_brewfile" 'android-platform-tools' "mobile-dev group leaves platform tools to the Android SDK"
+assert_not_contains_text "$mobile_dev_brewfile" 'cask "temurin"' "mobile-dev group resolves Java through the Android Studio bundled runtime instead of a declared JDK"
+assert_not_contains_text "$mobile_dev_brewfile" 'cask "zed"' "mobile-dev group does not render development-apps casks"
+
+mobile_dev_packages="$(
+  printf '%s\n' "$mobile_dev_brewfile" |
+    awk '/^[[:space:]]*(cask|brew)[[:space:]]+"/ { print }'
+)"
+expected_mobile_dev_packages='cask "android-studio"
+brew "mobile-dev-inc/tap/maestro", trusted: true'
+assert_text_equals \
+  "$mobile_dev_packages" \
+  "$expected_mobile_dev_packages" \
+  "mobile-dev group renders exactly the expected packages"
+
+assert_not_contains_text "$macos_brewfile" 'cask "android-studio"' "macOS default does not render Android Studio"
+assert_not_contains_text "$macos_brewfile" 'mobile-dev-inc/tap/maestro' "macOS default does not render Maestro"
+assert_not_contains_text "$development_apps_brewfile" 'cask "android-studio"' "development-apps group does not render Android Studio"
+
 development_apps_zprofile="$(render_managed_file "$macos_development_apps_data" ".zprofile")"
 macos_default_zprofile="$(render_managed_file "$macos_data" ".zprofile")"
 
@@ -1083,6 +1109,38 @@ pass "Orca desktop app bundle failure records a homebrew-desktop-apps marker"
 development_apps_failure_marker_text="$(cat "$development_apps_failure_marker")"
 assert_contains_text "$development_apps_failure_marker_text" "failed casks: stablyai/orca/orca" "Orca failure attribution preserves its fully-qualified cask source"
 assert_contains_text "$development_apps_failure_marker_text" "App Groups: development-apps" "Orca failure attribution identifies the development-apps group"
+
+mobile_dev_bootstrap_script="$tmp_dir/macos-mobile-dev-bootstrap.sh"
+printf '%s\n' "$macos_mobile_dev_bootstrap" | sed \
+  -e "s#/opt/homebrew/bin/brew#$tmp_dir/mobile-dev-failure-bin/brew#g" \
+  -e "s#/usr/local/bin/brew#$tmp_dir/mobile-dev-failure-bin/brew#g" \
+  >"$mobile_dev_bootstrap_script"
+sh -n "$mobile_dev_bootstrap_script" || fail "mobile-dev bootstrap script should be valid sh"
+pass "mobile-dev bootstrap script is valid sh"
+
+mobile_dev_failure_bin="$tmp_dir/mobile-dev-failure-bin"
+mobile_dev_failure_state="$tmp_dir/mobile-dev-failure-state"
+mobile_dev_failure_home="$tmp_dir/mobile-dev-failure-home"
+mobile_dev_failure_log="$tmp_dir/mobile-dev-failure-brew.log"
+mkdir -p "$mobile_dev_failure_bin" "$mobile_dev_failure_home"
+write_brew_bundle_stub "$mobile_dev_failure_bin/brew"
+
+if ! HOME="$mobile_dev_failure_home" XDG_STATE_HOME="$mobile_dev_failure_state" MACOS_BREW_LOG="$mobile_dev_failure_log" MACOS_BREW_FAIL_DESKTOP_BULK=1 MACOS_BREW_FAIL_FORMULAE="mobile-dev-inc/tap/maestro" PATH="$mobile_dev_failure_bin:/usr/bin:/bin" \
+  sh "$mobile_dev_bootstrap_script" >"$tmp_dir/mobile-dev-failure.out" 2>"$tmp_dir/mobile-dev-failure.err"; then
+  fail "Maestro desktop app bundle failure does not block bootstrap script"
+fi
+
+mobile_dev_failure_marker="$mobile_dev_failure_state/terrapod/install-warnings/homebrew-desktop-apps"
+if [ ! -f "$mobile_dev_failure_marker" ]; then
+  fail "Maestro formula failure records a homebrew-desktop-apps marker"
+fi
+pass "Maestro formula failure records a homebrew-desktop-apps marker"
+
+mobile_dev_failure_marker_text="$(cat "$mobile_dev_failure_marker")"
+assert_contains_text "$mobile_dev_failure_marker_text" "mobile-dev-inc/tap/maestro" \
+  "a failed tap formula is named in the desktop app warning marker"
+assert_contains_text "$mobile_dev_failure_marker_text" "App Groups: mobile-dev" \
+  "a failed tap formula is attributed to its macOS App Group"
 
 terminal_launcher_bootstrap_script="$tmp_dir/macos-terminal-launcher-bootstrap.sh"
 printf '%s\n' "$macos_terminal_launcher_apps_bootstrap" | sed \

--- a/tests/executable_selection_test.sh
+++ b/tests/executable_selection_test.sh
@@ -245,6 +245,7 @@ enableMacosAppGroupAutomation = false
 enableMacosAppGroupLauncher = false
 enableMacosAppGroupMonitoring = false
 enableMacosAppGroupDevelopmentApps = false
+enableMacosAppGroupMobileDev = false
 EOF
 cat >"$integration_bin/chezmoi" <<'EOF'
 #!/bin/sh

--- a/tests/readme_korean_test.sh
+++ b/tests/readme_korean_test.sh
@@ -167,6 +167,12 @@ assert_contains "$korean_readme" 'development-apps group은 OrbStack이 설치�
   "README.ko.md documents where the OrbStack shell integration comes from"
 assert_contains "$korean_readme" 'Terrapod은 Orca를 설치할 때 fully-qualified `stablyai/orca/orca` cask만 trust하며, `stablyai/orca` tap 전체를 trust하지 않습니다.' \
   "README.ko.md documents Orca's cask-specific trust boundary"
+assert_contains "$korean_readme" '`mobile-dev`: Android Studio와 Maestro(`mobile-dev-inc/tap/maestro`).' \
+  "README.ko.md documents Android Studio and Maestro in the mobile-dev inventory"
+assert_contains "$korean_readme" '| `enableMacosAppGroupMobileDev` | `false` | mobile-dev macOS App Group인 Android Studio와 Maestro(`mobile-dev-inc/tap/maestro`)를 설치합니다. |' \
+  "README.ko.md documents the mobile-dev option row"
+assert_contains "$korean_readme" 'Terrapod은 Android SDK component와 Xcode를 설치하지 않습니다. SDK는 Android Studio의 SDK Manager가 소유하고, Xcode는 App Store로 배포됩니다.' \
+  "README.ko.md documents the mobile development scope boundary"
 assert_not_contains "$korean_readme" 'Terminal font cask' \
   "README.ko.md no longer documents terminal font casks"
 assert_contains "$korean_readme" '최신 안정 GitHub release에서 제공하는 Jetendard terminal font' \

--- a/tests/readme_korean_test.sh
+++ b/tests/readme_korean_test.sh
@@ -169,7 +169,7 @@ assert_contains "$korean_readme" 'Terrapod은 Orca를 설치할 때 fully-qualif
   "README.ko.md documents Orca's cask-specific trust boundary"
 assert_contains "$korean_readme" '`mobile-dev`: Android Studio와 Maestro(`mobile-dev-inc/tap/maestro`).' \
   "README.ko.md documents Android Studio and Maestro in the mobile-dev inventory"
-assert_contains "$korean_readme" '| `enableMacosAppGroupMobileDev` | `false` | mobile-dev macOS App Group인 Android Studio와 Maestro(`mobile-dev-inc/tap/maestro`)를 설치합니다. |' \
+assert_contains "$korean_readme" '| `enableMacosAppGroupMobileDev` | `false` | mobile-dev macOS App Group인 Android Studio와 Maestro(`mobile-dev-inc/tap/maestro`)를 설치합니다. `ANDROID_HOME`과 `JAVA_HOME`도 함께 설정합니다. |' \
   "README.ko.md documents the mobile-dev option row"
 assert_contains "$korean_readme" 'Terrapod은 Android SDK component와 Xcode를 설치하지 않습니다. SDK는 Android Studio의 SDK Manager가 소유하고, Xcode는 App Store로 배포됩니다.' \
   "README.ko.md documents the mobile development scope boundary"

--- a/tests/readme_optional_stack_profiles_test.sh
+++ b/tests/readme_optional_stack_profiles_test.sh
@@ -141,6 +141,15 @@ assert_key_row_contains '`enableMacosAppGroupDevelopmentApps`' 'stablyai/orca/or
 assert_contains 'When installing Orca, Terrapod trusts only the fully-qualified `stablyai/orca/orca` cask, not the entire `stablyai/orca` tap.' \
   "README documents Orca's cask-specific trust boundary"
 
+assert_key_row_contains '`enableMacosAppGroupMobileDev`' 'mobile-dev' \
+  "README documents mobile-dev group on its option row"
+assert_key_row_contains '`enableMacosAppGroupMobileDev`' 'Android Studio' \
+  "README documents Android Studio on the mobile-dev option row"
+assert_key_row_contains '`enableMacosAppGroupMobileDev`' 'mobile-dev-inc/tap/maestro' \
+  "README documents Maestro's fully-qualified formula source"
+assert_contains 'Terrapod does not install Android SDK components or Xcode. Android Studio'"'"'s SDK Manager owns the SDK, and Xcode is distributed through the App Store.' \
+  "README documents the mobile development scope boundary"
+
 assert_contains 'The development-apps group also sources the OrbStack shell integration from the managed `.zprofile` when OrbStack is installed.' \
   "README documents where the OrbStack shell integration comes from"
 

--- a/tests/readme_optional_stack_profiles_test.sh
+++ b/tests/readme_optional_stack_profiles_test.sh
@@ -97,7 +97,8 @@ for key in \
   enableMacosAppGroupAutomation \
   enableMacosAppGroupLauncher \
   enableMacosAppGroupMonitoring \
-  enableMacosAppGroupDevelopmentApps
+  enableMacosAppGroupDevelopmentApps \
+  enableMacosAppGroupMobileDev
 do
   assert_contains "\`$key\`" "README documents $key option"
   if ! awk -F '|' -v key="\`$key\`" '$0 ~ key { gsub(/^[[:space:]]+|[[:space:]]+$/, "", $3); if ($3 == "`false`") found=1 } END { exit found ? 0 : 1 }' "$readme"; then

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -595,6 +595,7 @@ enableMacosAppGroupAutomation = false
 enableMacosAppGroupLauncher = $launcher
 enableMacosAppGroupMonitoring = false
 enableMacosAppGroupDevelopmentApps = false
+enableMacosAppGroupMobileDev = false
 EOF
 }
 
@@ -1413,7 +1414,7 @@ setup_responses="$tmp_dir/setup.responses"
 setup_gum_log="$tmp_dir/setup-gum.log"
 setup_config="$setup_xdg/chezmoi/chezmoi.toml"
 mkdir -p "$setup_home"
-write_gum_responses "$setup_responses" development yes yes yes yes yes yes yes
+write_gum_responses "$setup_responses" development yes yes yes yes yes yes yes yes
 
 if ! run_terrapod_setup_command macos-terminal "$setup_responses" "$setup_home" "$setup_xdg" "$setup_output" "$setup_gum_log"; then
   sed 's/^/  /' "$setup_output" >&2
@@ -1445,6 +1446,8 @@ assert_contains "$setup_output_text" "  Installs Hammerspoon, Karabiner-Elements
 assert_contains "$setup_output_text" "development-apps" "gum setup leads development-apps App Group prompt with the group name"
 assert_contains "$setup_output_text" "  Installs Zed, Orca ADE, and OrbStack." "gum setup lists Zed, Orca ADE, and OrbStack in the development-apps App Group"
 assert_contains "$setup_output_text" "  Trusts only the fully-qualified stablyai/orca/orca cask, not the entire stablyai/orca tap." "gum setup discloses Orca's cask-specific trust boundary"
+assert_contains "$setup_output_text" "  Installs Android Studio and Maestro." "gum setup lists Android Studio and Maestro in the mobile-dev App Group"
+assert_contains "$setup_output_text" "  Sets ANDROID_HOME and JAVA_HOME for Android builds." "gum setup discloses that the mobile-dev App Group changes the shell environment"
 assert_contains "$setup_output_text" "enableEditorStack = true" "gum setup summary includes concrete Editor Stack setting"
 assert_contains "$setup_output_text" "enableMacosAppGroupMonitoring = true" "gum setup summary includes concrete macOS App Group setting"
 assert_contains "$setup_output_text" "enableMacosAppGroupDevelopmentApps = true" "gum setup summary includes concrete development-apps App Group setting"
@@ -1739,6 +1742,7 @@ enableMacosAppGroupAutomation = true
 enableMacosAppGroupLauncher = true
 enableMacosAppGroupMonitoring = false
 enableMacosAppGroupDevelopmentApps = true
+enableMacosAppGroupMobileDev = true
 TOML
 
 macos_standard_brew_prefix="$tmp_dir/macos-standard-homebrew"
@@ -1864,6 +1868,7 @@ assert_contains "$macos_status_output" "automation                    : enabled 
 assert_contains "$macos_status_output" "launcher                      : enabled (Raycast and 1Password CLI)" "Terrapod status reports enabled launcher macOS App Group"
 assert_contains "$macos_status_output" "monitoring                    : disabled" "Terrapod status reports disabled monitoring macOS App Group"
 assert_contains "$macos_status_output" "development-apps              : enabled (Zed, Orca ADE, and OrbStack)" "Terrapod status lists Zed, Orca ADE, and OrbStack in the enabled development-apps App Group"
+assert_contains "$macos_status_output" "mobile-dev                    : enabled (Android Studio and Maestro)" "Terrapod status lists Android Studio and Maestro in the enabled mobile-dev App Group"
 assert_contains "$macos_status_output" "chezmoi                       : available" "Terrapod status reports chezmoi availability"
 assert_contains "$macos_status_output" "brew                          : available" "Terrapod status reports macOS Bootstrap Package Manager availability"
 assert_contains "$macos_status_output" "Warnings: none" "Terrapod status reports no warnings when enabled tools are present"
@@ -1923,6 +1928,7 @@ data.enableMacosAppGroupLauncher = false
 data.enableMacosAppGroupMonitoring = false
 data.enableMacosAppGroupTerminalApps = true
 data.enableMacosAppGroupDevelopmentApps = true
+data.enableMacosAppGroupMobileDev = true
 TOML
 
 dotted_status_path="$(status_doctor_path dotted chezmoi git zsh mise brew nvim agy claude codex zellij)"
@@ -1936,6 +1942,7 @@ assert_contains "$dotted_status_output" "Optional Editor Stack         : enabled
 assert_contains "$dotted_status_output" "Optional AI Tool Stack        : enabled (tools available: agy, claude, codex)" "Terrapod status reads root dotted data keys for effective AI stack state"
 assert_contains "$dotted_status_output" "terminal-apps                 : enabled (Ghostty)" "Terrapod status reads root dotted data keys for Ghostty-only macOS App Groups"
 assert_contains "$dotted_status_output" "development-apps              : enabled (Zed, Orca ADE, and OrbStack)" "Terrapod status reads root dotted data keys for Zed, Orca ADE, and OrbStack in development-apps"
+assert_contains "$dotted_status_output" "mobile-dev                    : enabled (Android Studio and Maestro)" "Terrapod status reads root dotted data keys for the mobile-dev App Group"
 assert_contains "$dotted_status_output" "Warnings: none" "Terrapod status has no warnings for root dotted data keys when tools are present"
 
 status_ubuntu_config="$tmp_dir/status-ubuntu.toml"
@@ -1951,6 +1958,7 @@ enableMacosAppGroupAutomation = false
 enableMacosAppGroupLauncher = false
 enableMacosAppGroupMonitoring = false
 enableMacosAppGroupDevelopmentApps = false
+enableMacosAppGroupMobileDev = false
 TOML
 write_os_release "$status_ubuntu_os_release" ubuntu 24.04 "Ubuntu 24.04 LTS"
 
@@ -2129,6 +2137,7 @@ enableMacosAppGroupAutomation = false
 enableMacosAppGroupLauncher = false
 enableMacosAppGroupMonitoring = false
 enableMacosAppGroupDevelopmentApps = false
+enableMacosAppGroupMobileDev = false
 TOML
 chmod 000 "$status_unreadable_config"
 
@@ -2199,6 +2208,7 @@ enableMacosAppGroupAutomation = false
 enableMacosAppGroupLauncher = false
 enableMacosAppGroupMonitoring = false
 enableMacosAppGroupDevelopmentApps = false
+enableMacosAppGroupMobileDev = false
 TOML
 
 status_shadow_path="$(status_doctor_path shadow chezmoi git zsh mise nvim zellij apt brew agy claude codex)"
@@ -2280,6 +2290,7 @@ enableMacosAppGroupAutomation = false
 enableMacosAppGroupLauncher = false
 enableMacosAppGroupMonitoring = false
 enableMacosAppGroupDevelopmentApps = false
+enableMacosAppGroupMobileDev = false
 TOML
 write_os_release "$doctor_os_release" ubuntu 24.04 "Ubuntu 24.04 LTS"
 
@@ -2388,6 +2399,7 @@ enableMacosAppGroupAutomation = false
 enableMacosAppGroupLauncher = false
 enableMacosAppGroupMonitoring = false
 enableMacosAppGroupDevelopmentApps = false
+enableMacosAppGroupMobileDev = false
 TOML
 chmod 000 "$doctor_unreadable_config"
 
@@ -2595,6 +2607,7 @@ enableMacosAppGroupAutomation = false
 enableMacosAppGroupLauncher = false
 enableMacosAppGroupMonitoring = false
 enableMacosAppGroupDevelopmentApps = false
+enableMacosAppGroupMobileDev = false
 TOML
 
 if ! HOME="$update_home" XDG_CONFIG_HOME="$update_xdg" PATH="$tmp_dir/bin:/usr/bin:/bin" \
@@ -2711,6 +2724,7 @@ enableMacosAppGroupAutomation = false
 enableMacosAppGroupLauncher = false
 enableMacosAppGroupMonitoring = false
 enableMacosAppGroupDevelopmentApps = false
+enableMacosAppGroupMobileDev = false
 TOML
 
 rm -f "$CHEZMOI_CALL_FILE" "$CHEZMOI_INVOKED_FILE"
@@ -2808,6 +2822,7 @@ enableMacosAppGroupAutomation = false
 enableMacosAppGroupLauncher = true
 enableMacosAppGroupMonitoring = false
 enableMacosAppGroupDevelopmentApps = true
+enableMacosAppGroupMobileDev = true
 TOML
 
 if ! HOME="$diff_home" XDG_CONFIG_HOME="$diff_xdg" PATH="$tmp_dir/bin:/usr/bin:/bin" \
@@ -3073,7 +3088,7 @@ fi
 
 apply_inline_config="$tmp_dir/apply-inline-table.toml"
 cat >"$apply_inline_config" <<'TOML'
-data = { profile = "vps-shell", enableEditorStack = false, enableAiCliTools = false, enableDevelopmentWorkspace = false, enableMacosAppGroupTerminalApps = false, enableMacosAppGroupAutomation = false, enableMacosAppGroupLauncher = false, enableMacosAppGroupMonitoring = false, enableMacosAppGroupDevelopmentApps = false }
+data = { profile = "vps-shell", enableEditorStack = false, enableAiCliTools = false, enableDevelopmentWorkspace = false, enableMacosAppGroupTerminalApps = false, enableMacosAppGroupAutomation = false, enableMacosAppGroupLauncher = false, enableMacosAppGroupMonitoring = false, enableMacosAppGroupDevelopmentApps = false, enableMacosAppGroupMobileDev = false }
 TOML
 rm -f "$CHEZMOI_APPLY_INVOKED_FILE" "$CHEZMOI_MANAGED_ARGS_FILE"
 

--- a/tests/terrapod_config_test.sh
+++ b/tests/terrapod_config_test.sh
@@ -489,6 +489,7 @@ assert_data_key_once_with_value "$new_config" "enableMacosAppGroupAutomation" "f
 assert_data_key_once_with_value "$new_config" "enableMacosAppGroupLauncher" "false" "minimal Preset disables launcher macOS App Group exactly once in data"
 assert_data_key_once_with_value "$new_config" "enableMacosAppGroupMonitoring" "false" "minimal Preset disables monitoring macOS App Group exactly once in data"
 assert_data_key_once_with_value "$new_config" "enableMacosAppGroupDevelopmentApps" "false" "minimal Preset disables development-apps macOS App Group exactly once in data"
+assert_data_key_once_with_value "$new_config" "enableMacosAppGroupMobileDev" "false" "minimal Preset disables mobile-dev macOS App Group exactly once in data"
 assert_not_contains "$new_config" "enableMacosDesktopApps" "minimal Preset does not write the legacy all-in desktop app toggle"
 assert_not_contains "$new_config" "terrapodPreset" "minimal Preset stores concrete values instead of a dynamic Preset"
 assert_backup_count "$new_config" 0 "new config creation does not create a backup"
@@ -515,6 +516,7 @@ assert_data_key_once_with_value "$development_config" "enableMacosAppGroupAutoma
 assert_data_key_once_with_value "$development_config" "enableMacosAppGroupLauncher" "false" "development Preset disables launcher macOS App Group in a new config"
 assert_data_key_once_with_value "$development_config" "enableMacosAppGroupMonitoring" "false" "development Preset disables monitoring macOS App Group in a new config"
 assert_data_key_once_with_value "$development_config" "enableMacosAppGroupDevelopmentApps" "false" "development Preset disables development-apps macOS App Group in a new config"
+assert_data_key_once_with_value "$development_config" "enableMacosAppGroupMobileDev" "false" "development Preset disables mobile-dev macOS App Group in a new config"
 assert_not_contains "$development_config" "enableMacosDesktopApps" "development Preset does not write the legacy all-in desktop app toggle"
 assert_not_contains "$development_config" "terrapodPreset" "development Preset stores concrete values instead of a dynamic Preset"
 assert_backup_count "$development_config" 0 "development config creation does not create a backup"
@@ -540,6 +542,7 @@ assert_data_key_once_with_value "$workstation_config" "enableMacosAppGroupAutoma
 assert_data_key_once_with_value "$workstation_config" "enableMacosAppGroupLauncher" "true" "workstation Preset enables launcher macOS App Group exactly once in data"
 assert_data_key_once_with_value "$workstation_config" "enableMacosAppGroupMonitoring" "true" "workstation Preset enables monitoring macOS App Group exactly once in data"
 assert_data_key_once_with_value "$workstation_config" "enableMacosAppGroupDevelopmentApps" "true" "workstation Preset enables development-apps macOS App Group exactly once in data"
+assert_data_key_once_with_value "$workstation_config" "enableMacosAppGroupMobileDev" "true" "workstation Preset enables mobile-dev macOS App Group exactly once in data"
 assert_not_contains "$workstation_config" "enableMacosDesktopApps" "workstation Preset does not write the legacy all-in desktop app toggle"
 assert_not_contains "$workstation_config" "terrapodPreset" "workstation Preset stores concrete values instead of a dynamic Preset"
 assert_backup_count "$workstation_config" 0 "workstation config creation does not create a backup"
@@ -559,6 +562,7 @@ pass "no-gum minimal Preset creates a chezmoi config file"
 assert_data_key_once_with_value "$nogum_minimal_config" "enableEditorStack" "false" "no-gum minimal writes concrete Editor Stack setting"
 assert_data_key_once_with_value "$nogum_minimal_config" "enableDevelopmentWorkspace" "false" "no-gum minimal writes concrete Development Workspace setting"
 assert_data_key_once_with_value "$nogum_minimal_config" "enableMacosAppGroupDevelopmentApps" "false" "no-gum minimal writes concrete development-apps App Group setting"
+assert_data_key_once_with_value "$nogum_minimal_config" "enableMacosAppGroupMobileDev" "false" "no-gum minimal writes concrete mobile-dev App Group setting"
 assert_not_contains "$nogum_minimal_config" "terrapodPreset" "no-gum minimal stores concrete values instead of a dynamic Preset"
 
 nogum_development_home="$tmp_dir/nogum-development-home"
@@ -577,6 +581,7 @@ assert_data_key_once_with_value "$nogum_development_config" "enableEditorStack" 
 assert_data_key_once_with_value "$nogum_development_config" "enableDevelopmentWorkspace" "true" "no-gum development writes concrete Development Workspace setting"
 assert_data_key_once_with_value "$nogum_development_config" "enableMacosAppGroupTerminalApps" "false" "no-gum development writes concrete macOS App Group setting"
 assert_data_key_once_with_value "$nogum_development_config" "enableMacosAppGroupDevelopmentApps" "false" "no-gum development writes concrete development-apps App Group setting"
+assert_data_key_once_with_value "$nogum_development_config" "enableMacosAppGroupMobileDev" "false" "no-gum development writes concrete mobile-dev App Group setting"
 assert_not_contains "$nogum_development_config" "terrapodPreset" "no-gum development stores concrete values instead of a dynamic Preset"
 
 nogum_macos_minimal_home="$tmp_dir/nogum-macos-minimal-home"
@@ -594,6 +599,7 @@ pass "no-gum macOS minimal Preset creates a chezmoi config file"
 assert_data_key_once_with_value "$nogum_macos_minimal_config" "enableEditorStack" "false" "no-gum macOS minimal writes concrete Editor Stack setting"
 assert_data_key_once_with_value "$nogum_macos_minimal_config" "enableDevelopmentWorkspace" "false" "no-gum macOS minimal writes concrete Development Workspace setting"
 assert_data_key_once_with_value "$nogum_macos_minimal_config" "enableMacosAppGroupDevelopmentApps" "false" "no-gum macOS minimal writes concrete development-apps App Group setting"
+assert_data_key_once_with_value "$nogum_macos_minimal_config" "enableMacosAppGroupMobileDev" "false" "no-gum macOS minimal writes concrete mobile-dev App Group setting"
 assert_not_contains "$nogum_macos_minimal_config" "terrapodPreset" "no-gum macOS minimal stores concrete values instead of a dynamic Preset"
 
 nogum_macos_development_home="$tmp_dir/nogum-macos-development-home"
@@ -612,6 +618,7 @@ assert_data_key_once_with_value "$nogum_macos_development_config" "enableEditorS
 assert_data_key_once_with_value "$nogum_macos_development_config" "enableDevelopmentWorkspace" "true" "no-gum macOS development writes concrete Development Workspace setting"
 assert_data_key_once_with_value "$nogum_macos_development_config" "enableMacosAppGroupTerminalApps" "false" "no-gum macOS development writes concrete macOS App Group setting"
 assert_data_key_once_with_value "$nogum_macos_development_config" "enableMacosAppGroupDevelopmentApps" "false" "no-gum macOS development writes concrete development-apps App Group setting"
+assert_data_key_once_with_value "$nogum_macos_development_config" "enableMacosAppGroupMobileDev" "false" "no-gum macOS development writes concrete mobile-dev App Group setting"
 assert_not_contains "$nogum_macos_development_config" "terrapodPreset" "no-gum macOS development stores concrete values instead of a dynamic Preset"
 
 nogum_workstation_home="$tmp_dir/nogum-workstation-home"
@@ -630,6 +637,7 @@ assert_data_key_once_with_value "$nogum_workstation_config" "enableEditorStack" 
 assert_data_key_once_with_value "$nogum_workstation_config" "enableDevelopmentWorkspace" "true" "no-gum workstation writes concrete Development Workspace setting"
 assert_data_key_once_with_value "$nogum_workstation_config" "enableMacosAppGroupMonitoring" "true" "no-gum workstation writes concrete macOS App Group setting"
 assert_data_key_once_with_value "$nogum_workstation_config" "enableMacosAppGroupDevelopmentApps" "true" "no-gum workstation writes concrete development-apps App Group setting"
+assert_data_key_once_with_value "$nogum_workstation_config" "enableMacosAppGroupMobileDev" "true" "no-gum workstation writes concrete mobile-dev App Group setting"
 assert_not_contains "$nogum_workstation_config" "terrapodPreset" "no-gum workstation stores concrete values instead of a dynamic Preset"
 
 setup_workstation_home="$tmp_dir/setup-workstation-home"
@@ -638,6 +646,7 @@ setup_workstation_config="$setup_workstation_xdg/chezmoi/chezmoi.toml"
 mkdir -p "$setup_workstation_home"
 
 if ! run_terrapod_setup macos-terminal 'workstation
+
 
 
 
@@ -668,6 +677,7 @@ assert_data_key_once_with_value "$setup_workstation_config" "enableMacosAppGroup
 assert_data_key_once_with_value "$setup_workstation_config" "enableMacosAppGroupLauncher" "true" "confirmed setup enables launcher macOS App Group exactly once in data"
 assert_data_key_once_with_value "$setup_workstation_config" "enableMacosAppGroupMonitoring" "true" "confirmed setup enables monitoring macOS App Group exactly once in data"
 assert_data_key_once_with_value "$setup_workstation_config" "enableMacosAppGroupDevelopmentApps" "true" "confirmed setup enables development-apps macOS App Group exactly once in data"
+assert_data_key_once_with_value "$setup_workstation_config" "enableMacosAppGroupMobileDev" "true" "confirmed setup enables mobile-dev macOS App Group exactly once in data"
 assert_not_contains "$setup_workstation_config" "enableMacosDesktopApps" "confirmed setup does not write the legacy all-in desktop app toggle"
 assert_not_contains "$setup_workstation_config" "terrapodPreset" "confirmed setup stores concrete values instead of a dynamic Preset"
 assert_backup_count "$setup_workstation_config" 0 "confirmed setup new config creation does not create a backup"
@@ -685,6 +695,7 @@ n
 y
 n
 y
+n
 n
 y
 ' "$setup_custom_workspace_home" "$setup_custom_workspace_xdg" >"$tmp_dir/setup-custom-workspace.out" 2>"$tmp_dir/setup-custom-workspace.err"; then
@@ -711,6 +722,7 @@ assert_contains "$tmp_dir/setup-custom-workspace.out" "enableMacosAppGroupAutoma
 assert_contains "$tmp_dir/setup-custom-workspace.out" "enableMacosAppGroupLauncher = false" "macOS setup summary reflects customized launcher App Group"
 assert_contains "$tmp_dir/setup-custom-workspace.out" "enableMacosAppGroupMonitoring = true" "macOS setup summary reflects customized monitoring App Group"
 assert_contains "$tmp_dir/setup-custom-workspace.out" "enableMacosAppGroupDevelopmentApps = false" "macOS setup summary reflects customized development-apps App Group"
+assert_contains "$tmp_dir/setup-custom-workspace.out" "enableMacosAppGroupMobileDev = false" "macOS setup summary reflects customized mobile-dev App Group"
 
 if [ ! -f "$setup_custom_workspace_config" ]; then
   fail "macOS customized setup creates a chezmoi config file"
@@ -725,6 +737,7 @@ assert_data_key_once_with_value "$setup_custom_workspace_config" "enableMacosApp
 assert_data_key_once_with_value "$setup_custom_workspace_config" "enableMacosAppGroupLauncher" "false" "workspace-enabled setup writes customized launcher App Group"
 assert_data_key_once_with_value "$setup_custom_workspace_config" "enableMacosAppGroupMonitoring" "true" "workspace-enabled setup writes customized monitoring App Group"
 assert_data_key_once_with_value "$setup_custom_workspace_config" "enableMacosAppGroupDevelopmentApps" "false" "workspace-enabled setup writes customized development-apps App Group"
+assert_data_key_once_with_value "$setup_custom_workspace_config" "enableMacosAppGroupMobileDev" "false" "workspace-enabled setup writes customized mobile-dev App Group"
 
 gum_equivalent_home="$tmp_dir/gum-equivalent-home"
 gum_equivalent_xdg="$tmp_dir/gum-equivalent-xdg"
@@ -737,6 +750,7 @@ n
 y
 n
 y
+n
 n
 y
 ' "$gum_equivalent_home" "$gum_equivalent_xdg" >"$tmp_dir/gum-equivalent.out" 2>"$tmp_dir/gum-equivalent.err"; then
@@ -758,6 +772,7 @@ assert_data_key_once_with_value "$gum_equivalent_config" "enableMacosAppGroupAut
 assert_data_key_once_with_value "$gum_equivalent_config" "enableMacosAppGroupLauncher" "false" "gum setup writes customized launcher App Group"
 assert_data_key_once_with_value "$gum_equivalent_config" "enableMacosAppGroupMonitoring" "true" "gum setup writes customized monitoring App Group"
 assert_data_key_once_with_value "$gum_equivalent_config" "enableMacosAppGroupDevelopmentApps" "false" "gum setup writes customized development-apps App Group"
+assert_data_key_once_with_value "$gum_equivalent_config" "enableMacosAppGroupMobileDev" "false" "gum setup writes customized mobile-dev App Group"
 
 if ! cmp -s "$setup_custom_workspace_config" "$gum_equivalent_config"; then
   printf '%s\n' "first gum setup config:" >&2
@@ -780,6 +795,7 @@ if ! run_terrapod_setup macos-terminal 'development
 
 
 
+
 y
 ' "$gum_development_home" "$gum_development_xdg" >"$tmp_dir/gum-development.out" 2>"$tmp_dir/gum-development.err"; then
   printf '%s\n' "gum development stdout:" >&2
@@ -796,6 +812,7 @@ assert_data_key_once_with_value "$gum_development_config" "enableAiCliTools" "tr
 assert_data_key_once_with_value "$gum_development_config" "enableDevelopmentWorkspace" "true" "gum development writes development workspace setting"
 assert_data_key_once_with_value "$gum_development_config" "enableMacosAppGroupTerminalApps" "false" "gum development keeps terminal-apps disabled for development"
 assert_data_key_once_with_value "$gum_development_config" "enableMacosAppGroupDevelopmentApps" "false" "gum development keeps development-apps disabled for development"
+assert_data_key_once_with_value "$gum_development_config" "enableMacosAppGroupMobileDev" "false" "gum development keeps mobile-dev disabled for development"
 
 gum_vps_home="$tmp_dir/gum-vps-home"
 gum_vps_xdg="$tmp_dir/gum-vps-xdg"
@@ -830,6 +847,7 @@ assert_data_key_once_with_value "$gum_vps_config" "enableMacosAppGroupAutomation
 assert_data_key_once_with_value "$gum_vps_config" "enableMacosAppGroupLauncher" "false" "gum VPS setup writes launcher App Group disabled"
 assert_data_key_once_with_value "$gum_vps_config" "enableMacosAppGroupMonitoring" "false" "gum VPS setup writes monitoring App Group disabled"
 assert_data_key_once_with_value "$gum_vps_config" "enableMacosAppGroupDevelopmentApps" "false" "gum VPS setup writes development-apps App Group disabled"
+assert_data_key_once_with_value "$gum_vps_config" "enableMacosAppGroupMobileDev" "false" "gum VPS setup writes mobile-dev App Group disabled"
 
 setup_leaf_home="$tmp_dir/setup-leaf-home"
 setup_leaf_xdg="$tmp_dir/setup-leaf-xdg"
@@ -845,6 +863,7 @@ n
 y
 n
 y
+n
 y
 ' "$setup_leaf_home" "$setup_leaf_xdg" >"$tmp_dir/setup-leaf.out" 2>"$tmp_dir/setup-leaf.err"; then
   printf '%s\n' "setup stdout:" >&2
@@ -859,6 +878,7 @@ assert_contains "$tmp_dir/setup-leaf.out" "enableEditorStack = false" "workspace
 assert_contains "$tmp_dir/setup-leaf.out" "enableAiCliTools = true" "workspace-disabled setup summary reflects customized Optional AI Tool Stack"
 assert_contains "$tmp_dir/setup-leaf.out" "enableDevelopmentWorkspace = false" "workspace-disabled setup summary reflects disabled Optional Development Workspace"
 assert_contains "$tmp_dir/setup-leaf.out" "enableMacosAppGroupDevelopmentApps = true" "workspace-disabled setup summary reflects customized development-apps App Group"
+assert_contains "$tmp_dir/setup-leaf.out" "enableMacosAppGroupMobileDev = false" "workspace-disabled setup summary reflects customized mobile-dev App Group"
 
 if [ ! -f "$setup_leaf_config" ]; then
   fail "workspace-disabled customized setup creates a chezmoi config file"
@@ -873,6 +893,7 @@ assert_data_key_once_with_value "$setup_leaf_config" "enableMacosAppGroupAutomat
 assert_data_key_once_with_value "$setup_leaf_config" "enableMacosAppGroupLauncher" "true" "workspace-disabled setup writes customized launcher App Group"
 assert_data_key_once_with_value "$setup_leaf_config" "enableMacosAppGroupMonitoring" "false" "workspace-disabled setup writes customized monitoring App Group"
 assert_data_key_once_with_value "$setup_leaf_config" "enableMacosAppGroupDevelopmentApps" "true" "workspace-disabled setup writes customized development-apps App Group"
+assert_data_key_once_with_value "$setup_leaf_config" "enableMacosAppGroupMobileDev" "false" "workspace-disabled setup writes customized mobile-dev App Group"
 
 setup_vps_custom_home="$tmp_dir/setup-vps-custom-home"
 setup_vps_custom_xdg="$tmp_dir/setup-vps-custom-xdg"
@@ -917,6 +938,7 @@ assert_data_key_once_with_value "$setup_vps_custom_config" "enableMacosAppGroupA
 assert_data_key_once_with_value "$setup_vps_custom_config" "enableMacosAppGroupLauncher" "false" "VPS setup writes launcher App Group disabled"
 assert_data_key_once_with_value "$setup_vps_custom_config" "enableMacosAppGroupMonitoring" "false" "VPS setup writes monitoring App Group disabled"
 assert_data_key_once_with_value "$setup_vps_custom_config" "enableMacosAppGroupDevelopmentApps" "false" "VPS setup writes development-apps App Group disabled"
+assert_data_key_once_with_value "$setup_vps_custom_config" "enableMacosAppGroupMobileDev" "false" "VPS setup writes mobile-dev App Group disabled"
 
 setup_vps_workstation_error_home="$tmp_dir/setup-vps-workstation-error-home"
 setup_vps_workstation_error_xdg="$tmp_dir/setup-vps-workstation-error-xdg"
@@ -974,6 +996,7 @@ if run_terrapod_setup macos-terminal 'development
 
 
 
+
 n
 ' "$setup_cancel_home" "$setup_cancel_xdg" >"$tmp_dir/setup-cancel.out" 2>"$tmp_dir/setup-cancel.err"; then
   fail "cancelled setup exits non-zero"
@@ -1002,6 +1025,7 @@ TOML
 cp "$setup_existing_cancel_config" "$tmp_dir/setup-existing-cancel-before.toml"
 
 if run_terrapod_setup macos-terminal 'development
+
 
 
 
@@ -1058,6 +1082,7 @@ email = "minu@example.com"
 enableEditorStack = false
 enableAiCliTools = false
 enableDevelopmentWorkspace = false
+enableMacosAppGroupMobileDev = true
 enableMacosAppGroupAiApps = true
 enableMacosDesktopApps = true
 terrapodPreset = "minimal"
@@ -1081,6 +1106,7 @@ assert_data_key_once_with_value "$existing_config" "enableMacosAppGroupAutomatio
 assert_data_key_once_with_value "$existing_config" "enableMacosAppGroupLauncher" "false" "development Preset disables launcher macOS App Group exactly once in data"
 assert_data_key_once_with_value "$existing_config" "enableMacosAppGroupMonitoring" "false" "development Preset disables monitoring macOS App Group exactly once in data"
 assert_data_key_once_with_value "$existing_config" "enableMacosAppGroupDevelopmentApps" "false" "development Preset writes development-apps exactly once in data"
+assert_data_key_once_with_value "$existing_config" "enableMacosAppGroupMobileDev" "false" "development Preset writes mobile-dev exactly once in data"
 assert_not_contains "$existing_config" "enableMacosAppGroupAiApps" "explicit config migration removes deprecated ai-apps key"
 assert_not_contains "$existing_config" "enableMacosDesktopApps" "existing update removes the legacy all-in desktop app toggle"
 assert_not_contains "$existing_config" "terrapodPreset" "existing update removes stale dynamic Preset key"

--- a/tests/terrapod_installer_test.sh
+++ b/tests/terrapod_installer_test.sh
@@ -894,6 +894,7 @@ enableMacosAppGroupAutomation = false
 enableMacosAppGroupLauncher = false
 enableMacosAppGroupMonitoring = false
 enableMacosAppGroupDevelopmentApps = false
+enableMacosAppGroupMobileDev = false
 TOML
 }
 
@@ -922,6 +923,7 @@ data.enableMacosAppGroupAutomation = false
 data.enableMacosAppGroupLauncher = false
 data.enableMacosAppGroupMonitoring = false
 data.enableMacosAppGroupDevelopmentApps = false
+data.enableMacosAppGroupMobileDev = false
 TOML
 }
 
@@ -940,6 +942,7 @@ write_quoted_complete_setup_config() {
 "enableMacosAppGroupLauncher" = false
 "enableMacosAppGroupMonitoring" = false
 "enableMacosAppGroupDevelopmentApps" = false
+"enableMacosAppGroupMobileDev" = false
 TOML
 }
 
@@ -958,6 +961,7 @@ enableMacosAppGroupAutomation = false
 enableMacosAppGroupLauncher = false
 enableMacosAppGroupMonitoring = false
 enableMacosAppGroupDevelopmentApps = false
+enableMacosAppGroupMobileDev = false
 TOML
 }
 
@@ -976,6 +980,7 @@ enableMacosAppGroupAutomation = false
 enableMacosAppGroupLauncher = false
 enableMacosAppGroupMonitoring = false
 enableMacosAppGroupDevelopmentApps = false
+enableMacosAppGroupMobileDev = false
 notes = """
 unsupported multiline value
 """
@@ -987,7 +992,7 @@ write_unsupported_inline_table_setup_config() {
 
   mkdir -p "$(dirname "$config_file")"
   cat >"$config_file" <<'TOML'
-data = { profile = "macos-terminal", enableEditorStack = false, enableAiCliTools = false, enableDevelopmentWorkspace = false, enableMacosAppGroupTerminalApps = false, enableMacosAppGroupAutomation = false, enableMacosAppGroupLauncher = false, enableMacosAppGroupMonitoring = false, enableMacosAppGroupDevelopmentApps = false }
+data = { profile = "macos-terminal", enableEditorStack = false, enableAiCliTools = false, enableDevelopmentWorkspace = false, enableMacosAppGroupTerminalApps = false, enableMacosAppGroupAutomation = false, enableMacosAppGroupLauncher = false, enableMacosAppGroupMonitoring = false, enableMacosAppGroupDevelopmentApps = false, enableMacosAppGroupMobileDev = false }
 TOML
 }
 
@@ -1006,6 +1011,7 @@ enableMacosAppGroupAutomation = false
 enableMacosAppGroupLauncher = false
 enableMacosAppGroupMonitoring = false
 enableMacosAppGroupDevelopmentApps = false
+enableMacosAppGroupMobileDev = false
 matrix = [
 [1, 2]
 ]

--- a/tests/zshenv_local_bin_test.sh
+++ b/tests/zshenv_local_bin_test.sh
@@ -180,3 +180,13 @@ assert_linuxbrew_shellenv_rendering \
   '{"chezmoi":{"os":"darwin"},"enableAiCliTools":true,"enableDevelopmentWorkspace":false}' \
   absent \
   "macOS keeps Linuxbrew shell setup out of zshenv"
+
+render_zshenv '{"chezmoi":{"os":"darwin"},"enableMacosAppGroupMobileDev":true}'
+rendered_macos_mobiledev_zshenv="$(cat "$tmp_dir/home/.zshenv")"
+
+assert_contains "$rendered_macos_mobiledev_zshenv" 'path=("$HOME/.local/bin" $path)' \
+  "mobile-dev App Group does not remove the \$HOME/.local/bin guard"
+assert_order "$rendered_macos_mobiledev_zshenv" 'path=("$HOME/.local/bin" $path)' '/opt/homebrew/bin/brew shellenv' \
+  "mobile-dev App Group does not displace \$HOME/.local/bin ahead of the Homebrew shellenv block"
+assert_order "$rendered_macos_mobiledev_zshenv" '/opt/homebrew/bin/brew shellenv' 'for path_snippet in "$HOME"/.config/zsh/path.d/*.zsh(N); do' \
+  "mobile-dev App Group does not displace the Homebrew shellenv block ahead of machine-local overrides"

--- a/tests/zshenv_local_bin_test.sh
+++ b/tests/zshenv_local_bin_test.sh
@@ -190,3 +190,15 @@ assert_order "$rendered_macos_mobiledev_zshenv" 'path=("$HOME/.local/bin" $path)
   "mobile-dev App Group does not displace \$HOME/.local/bin ahead of the Homebrew shellenv block"
 assert_order "$rendered_macos_mobiledev_zshenv" '/opt/homebrew/bin/brew shellenv' 'for path_snippet in "$HOME"/.config/zsh/path.d/*.zsh(N); do' \
   "mobile-dev App Group does not displace the Homebrew shellenv block ahead of machine-local overrides"
+
+assert_contains "$rendered_macos_mobiledev_zshenv" 'export ANDROID_HOME="$HOME/Library/Android/sdk"' \
+  "mobile-dev App Group renders the Android SDK environment block"
+assert_order "$rendered_macos_mobiledev_zshenv" '/opt/homebrew/bin/brew shellenv' 'export ANDROID_HOME="$HOME/Library/Android/sdk"' \
+  "mobile-dev App Group's Android block renders after the Homebrew shellenv block so brew's prefix is already on PATH"
+assert_order "$rendered_macos_mobiledev_zshenv" 'android_studio_jbr="/Applications/Android Studio.app/Contents/jbr/Contents/Home"' 'for path_snippet in "$HOME"/.config/zsh/path.d/*.zsh(N); do' \
+  "mobile-dev App Group's Android block renders before the machine-local path.d override loop"
+
+if printf '%s\n' "$rendered_macos_zshenv" | grep -F 'export ANDROID_HOME="$HOME/Library/Android/sdk"' >/dev/null; then
+  fail "macOS zshenv omits the Android SDK block when the mobile-dev App Group is disabled"
+fi
+pass "macOS zshenv omits the Android SDK block when the mobile-dev App Group is disabled"


### PR DESCRIPTION
## Changes

- Added a `mobile-dev` macOS App Group installing `android-studio` and `mobile-dev-inc/tap/maestro`, gated on the new machine-local setting key `enableMacosAppGroupMobileDev`.
- Rendered the Android and Java shell environment from `dot_zshenv.tmpl` under the same key, guarded so a missing install cannot break `java` or add dead PATH entries.
- Wired the setting key through `managed_setup_keys` in both the command and the installer, the awk managed-key list, all three Presets, the setup confirmation prompt, and `tpod status`.
- Generalized the Homebrew reconcile script's per-package retry path to carry each declaration verbatim, so tap formulae are retried and attributed to their App Group.
- Documented the group and its scope boundary in both READMEs and `CONTEXT.md`, and recorded ADR 0013.
- Committed the design spec and implementation plan under `docs/superpowers/`.

## Background

Comparing Terrapod's declared state against a configured workstation showed Android development running entirely outside it: Android Studio installed by hand in `/Applications`, Maestro from its own vendor script, and a hand-added `~/.zshrc` tail exporting `ANDROID_HOME`, `ANDROID_SDK_ROOT`, `JAVA_HOME`, and the SDK PATH entries. Because Terrapod owns `.zshrc`, applying the declared state deleted that tail with nothing to replace it.

The group covers entry points only. Android SDK components stay with Android Studio's SDK Manager because they are license-gated multi-gigabyte downloads, and Xcode stays with the App Store because it needs Apple account authentication — neither belongs inside a non-interactive `tpod apply`. `JAVA_HOME` resolves to the runtime Android Studio bundles rather than a separately declared JDK, so the command line and the IDE always agree on a Java version. ADR 0013 records those decisions.

Maestro needed the reconcile change. Its formula lives in a non-official tap, so it is declared as a fully-qualified token with `trusted: true`, exactly as Orca already is. The per-package retry path rebuilt each record as a bare `cask "<name>"`, which understood neither formulae nor declaration options. Carrying the verbatim declaration fixes both, and incidentally repairs an existing defect where Orca's `trusted: true` was dropped on retry — harmless on a machine that already recorded the trust, but unrecoverable on one whose bulk pass failed first.

Note that the `maestro` cask in homebrew-cask is an unrelated product. The fully-qualified token keeps that collision from resolving to the wrong package, and a test asserts the group never renders it.

## User Impact

macOS machines that enable the group get Android Studio and Maestro from `tpod apply`, plus a managed Android environment that survives future applies. The setup prompt discloses both the packages and the fact that the group sets `ANDROID_HOME` and `JAVA_HOME` before asking for confirmation.

Two consequences worth calling out:

- **Already-configured machines are asked to rerun setup.** Adding a key changes managed setup config completeness, so `tpod apply` and `tpod update` stop before delegating to chezmoi with a message naming the missing key. `tpod status` and `doctor` warn and exit 0. This matches every previous App Group addition.
- **`tpod configure workstation` now installs Android Studio.** The `workstation` Preset enables every App Group. `tpod setup` shows the disclosure prompt; `tpod configure` does not, by design.

Machines that leave the group disabled render an unchanged `.zshenv`, byte-identical to `main`. The Ubuntu VPS profile is unaffected: the reconcile gate compiles the desktop bundle out entirely, the shell block does not render, and setup forces the key false for non-macOS profiles so VPS configs stay complete.

Existing vendor-installed Maestro under `~/.maestro/bin` is left in place; the managed environment simply no longer adds that directory to PATH.

## Verification

- Full shell test suite and the zsh test
- `sh tests/chezmoiignore_test.sh` — group rendering, package-record parsing, the conditional `.zshenv` block, and a bulk-failure run asserting a failed tap formula is named and attributed to `mobile-dev`
- `sh tests/zshenv_local_bin_test.sh` — ordering assertions verified to fail against a template with the Android block relocated above the Homebrew shellenv block
- `sh tests/terrapod_config_test.sh`, `sh tests/terrapod_installer_test.sh`, `sh tests/executable_selection_test.sh`, `sh tests/bootstrap_ubuntu_test.sh`
- `sh tests/readme_optional_stack_profiles_test.sh`, `sh tests/readme_korean_test.sh`
- Rendered `.zshenv` diffed against `main` with the group disabled for both linux and darwin data: identical
- `sh -n` on `install.sh` and `dot_local/bin/executable_terrapod`; `zsh -n` on the rendered `.zshenv`

`tests/jetendard_font_test.sh`, `tests/jetendard_settings_test.sh`, and `tests/terrapod_command_test.sh` fail in this environment and fail identically on `main`; `terrapod_command_test.sh` aborts early on a Jetendard font assertion, so its two new status assertions are unexecuted and were verified by running the scenario directly. `tests/terrapod_config_test.sh` is flaky under `script` TTY emulation during a full sweep and passes on its own. `tests/homebrew_ubuntu_smoke.sh` requires Docker and was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)