### PR TITLE
Load the Jetendard helpers under Python 3.9

### DIFF
--- a/dot_local/lib/terrapod/executable_jetendard-font
+++ b/dot_local/lib/terrapod/executable_jetendard-font
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 import argparse
 import hashlib
 import json

--- a/dot_local/lib/terrapod/executable_jetendard-settings
+++ b/dot_local/lib/terrapod/executable_jetendard-settings
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 import argparse
 from dataclasses import dataclass
 import json

--- a/tests/jetendard_font_test.sh
+++ b/tests/jetendard_font_test.sh
@@ -11,6 +11,17 @@ trap 'rm -rf "$tmp_dir"' EXIT INT TERM
 fail() { printf '%s\n' "not ok - $1" >&2; exit 1; }
 pass() { printf '%s\n' "ok - $1"; }
 
+first_statement="$(awk 'NR == 1 && /^#!/ { next } /^[[:space:]]*$/ { next } { print; exit }' "$helper")"
+[ "$first_statement" = "from __future__ import annotations" ] || fail "helper defers annotation evaluation so Python 3.9 can import it"
+pass "helper defers annotation evaluation so Python 3.9 can import it"
+
+if [ -x /usr/bin/python3 ]; then
+  /usr/bin/python3 "$helper" --help >/dev/null || fail "helper loads under the system interpreter"
+  pass "helper loads under the system interpreter"
+else
+  pass "system interpreter check is skipped when /usr/bin/python3 is absent"
+fi
+
 home_dir="$tmp_dir/home"
 state_dir="$tmp_dir/state"
 fixture_dir="$tmp_dir/fixture"
@@ -401,16 +412,15 @@ data = json.loads(manifest.read_text())
 data["files"].append("Jetendard-Legacy.ttf")
 manifest.write_text(json.dumps(data) + "\n")
 before = snapshot(home, state)
-real_unlink = module.os.unlink
+real_unlink = module.Path.unlink
 failed = False
-def fail_obsolete(path, *args, **kwargs):
+def fail_obsolete(self, *args, **kwargs):
     global failed
-    candidate = Path(path)
-    if candidate.name == "Jetendard-Legacy.ttf" and not failed:
+    if self.name == "Jetendard-Legacy.ttf" and not failed:
         failed = True
         raise OSError("injected obsolete cleanup failure")
-    return real_unlink(path, *args, **kwargs)
-module.os.unlink = fail_obsolete
+    return real_unlink(self, *args, **kwargs)
+module.Path.unlink = fail_obsolete
 try:
     module.install(home)
 except OSError as error:
@@ -418,7 +428,7 @@ except OSError as error:
 else:
     raise AssertionError("obsolete cleanup failure was not injected")
 finally:
-    module.os.unlink = real_unlink
+    module.Path.unlink = real_unlink
 assert_snapshot(home, state, before)
 assert not (state / "terrapod" / "jetendard" / "recovery").exists()
 module.install(home)
@@ -513,27 +523,27 @@ data = json.loads(manifest.read_text())
 data["files"].append("Jetendard-Legacy.ttf")
 manifest.write_text(json.dumps(data) + "\n")
 before = snapshot(home, state)
-real_unlink = module.os.unlink
+real_unlink = module.Path.unlink
 forward_failed = False
 restore_failed = False
-def fail_cleanup(path, *args, **kwargs):
+def fail_cleanup(self, *args, **kwargs):
     global forward_failed
-    if Path(path).name == "Jetendard-Legacy.ttf" and not forward_failed:
+    if self.name == "Jetendard-Legacy.ttf" and not forward_failed:
         forward_failed = True
         raise OSError("injected forward cleanup failure")
-    return real_unlink(path, *args, **kwargs)
+    return real_unlink(self, *args, **kwargs)
 def fail_manifest_restore(source, destination):
     global restore_failed
     if forward_failed and Path(destination) == manifest and not restore_failed:
         restore_failed = True
         raise OSError("injected manifest restore failure")
     return real_replace(source, destination)
-module.os.unlink = fail_cleanup
+module.Path.unlink = fail_cleanup
 module.os.replace = fail_manifest_restore
 try:
     result, stdout, stderr = cli_install(home)
 finally:
-    module.os.unlink = real_unlink
+    module.Path.unlink = real_unlink
     module.os.replace = real_replace
 assert result == 1 and not stdout
 assert stderr.count("\n") == 1

--- a/tests/jetendard_settings_test.sh
+++ b/tests/jetendard_settings_test.sh
@@ -19,6 +19,17 @@ pass() {
   printf '%s\n' "ok - $1"
 }
 
+first_statement="$(awk 'NR == 1 && /^#!/ { next } /^[[:space:]]*$/ { next } { print; exit }' "$helper")"
+[ "$first_statement" = "from __future__ import annotations" ] || fail "helper defers annotation evaluation so Python 3.9 can import it"
+pass "helper defers annotation evaluation so Python 3.9 can import it"
+
+if [ -x /usr/bin/python3 ]; then
+  /usr/bin/python3 "$helper" --help >/dev/null || fail "helper loads under the system interpreter"
+  pass "helper loads under the system interpreter"
+else
+  pass "system interpreter check is skipped when /usr/bin/python3 is absent"
+fi
+
 home_dir="$tmp_dir/home"
 zed_dir="$home_dir/.config/zed"
 profiles_dir="$home_dir/Library/Application Support/orca/profiles"


### PR DESCRIPTION
## Changes

- Added `from __future__ import annotations` to `dot_local/lib/terrapod/executable_jetendard-font` and `executable_jetendard-settings`, so their PEP 604 `X | None` annotations are no longer evaluated at import time.
- Added a two-part regression guard to `tests/jetendard_font_test.sh` and `tests/jetendard_settings_test.sh`: a static assertion that the future import is each helper's first statement, and a run of the helper's `--help` under `/usr/bin/python3` when that interpreter exists.
- Switched the two obsolete-cleanup fault injections in `tests/jetendard_font_test.sh` from `module.os.unlink` to `module.Path.unlink`, so they fire at the intended call site on every supported interpreter.

## Background

The helpers run under whatever `python3` resolves to on PATH. On a macOS machine where the Xcode Command Line Tools interpreter wins that is 3.9.6, which evaluates annotations eagerly and rejects `dict[str, tuple[Token, "Node"]] | None` with a `TypeError` at import. Jetendard was therefore never installed on such machines, and Ghostty, Zed, and Orca silently fell back from their declared `font-family = Jetendard`.

ADR 0012 keeps the "python resolves to `/usr/bin/python3`" advisory non-enforcing, so the helpers have to tolerate the system interpreter rather than assume the canonical one. Pinning the shebang or the call sites to the mise interpreter is not an option either, because these helpers also run during bootstrap, before mise is guaranteed to exist. Deferring annotation evaluation is sufficient: neither helper reads its own annotations at runtime, and neither contains any other 3.10+ construct — the `match` at `executable_jetendard-settings:256` is a local holding a `re.match` result, not a match statement.

Fixing the import exposed a second 3.9 incompatibility, this one in the test harness rather than the helper. The obsolete-cleanup scenarios patch `os.unlink` and match on basename to inject a failure into the helper's `candidate.unlink()`. Python 3.9's `pathlib` binds `os.unlink` into `_NormalAccessor` at import time, so `Path.unlink()` never sees a later patch; 3.12 removed that accessor layer and calls through the module every time. On 3.9 the intended injection therefore never fired, the install completed, and the patch instead fired inside `shutil.rmtree`'s `os.unlink(entry.name, dir_fd=topfd)` against the transaction's backup copy of the same basename — a different call site, after the operation the test meant to interrupt had already succeeded, leaving the rollback assertions comparing against a fully installed tree. Patching the `Path.unlink` class attribute reaches the same call site on both interpreters and leaves `shutil.rmtree` alone.

## User Impact

Affected macOS machines install Jetendard on the next `tpod apply`, and Ghostty, Zed, and Orca stop falling back from their declared `font-family = Jetendard`. `tpod doctor` stops reporting the font and settings checks as `warn` with a traceback, and `tpod status` stops reporting `Jetendard font : missing`. Machines whose `python3` already resolves to 3.10+ see no behavior change; the future import only defers annotation evaluation, and neither helper inspects its own annotations.

The failure was non-blocking — `tpod doctor` still exited 0 — so its visible symptom was three failing test files. #141 recorded them as failing identically on `main` and set them aside as environment noise; this is the actual cause, and that PR's caveat no longer applies.

## Verification

- Full shell test suite (18 files) and the zsh test: all exit 0, no regressions.
- Baseline confirmed before the fix: `tests/jetendard_font_test.sh`, `tests/jetendard_settings_test.sh`, and `tests/terrapod_command_test.sh` each failed at the point the issue describes.
- Both Jetendard test files run under 3.9.6 and 3.13.13, reporting the same eight assertions and exit 0 on both.
- Negative check on the new guard: deleting either future import makes the test fail with `not ok - helper defers annotation evaluation so Python 3.9 can import it` instead of a traceback.
- The harness diagnosis was confirmed from the injected exception's traceback, which named `cleanup_transaction` → `shutil.rmtree` → `_rmtree_safe_fd` as the firing site on 3.9, and by a direct probe showing `Path.unlink` reaching a patched `os.unlink` on 3.13.13 but not on 3.9.6.
- `tests/homebrew_ubuntu_smoke.sh` requires Docker and was not run.

Not addressed here: the issue also notes that `tpod doctor` exits 0 despite the traceback, which is what made this easy to miss. Whether a helper crash should become blocking is a change to the exit semantics ADR 0012 defines, independent of this bug.

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)
