### PR TITLE
Prune orphaned install warning markers on apply

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -217,7 +217,7 @@ _Avoid_: separate Korean introduction, independent README, self-labeled translat
 - Scripted readiness checks should run `tpod doctor` rather than interpreting first-run warning completion as full machine readiness.
 - Non-blocking first-run installer failures are recorded as Terrapod install warnings so first-run completion and `tpod doctor` can surface incomplete machine profile readiness without relying on brittle command-output parsing.
 - Terrapod install warnings are machine-local recovery state stored outside the **Terrapod Source Repository** and managed dotfiles, under the user's XDG state area such as `${XDG_STATE_HOME:-$HOME/.local/state}/terrapod/install-warnings/<category>`.
-- Terrapod install warnings are category-scoped markers that remain actionable until the same installer category completes successfully; interrupted or failed reruns must not hide the previous recovery signal.
+- Terrapod install warnings are category-scoped markers that, while their category exists, remain actionable until the same installer category completes successfully; interrupted or failed reruns must not hide the previous recovery signal.
 - A successful rerun of an installer category clears that category's warning marker, while a failed rerun replaces it with the current failure summary and guidance.
 - Mandatory stack warning markers such as Homebrew core, Ubuntu bootstrap, shell integrations, and mise tools are cleared only by successful reruns because their desired state cannot be disabled by optional settings.
 - Optional stack or app-group warning marker content may be cleared or reduced when the corresponding desired optional setting is disabled.
@@ -226,7 +226,10 @@ _Avoid_: separate Korean introduction, independent README, self-labeled translat
 - Terrapod install warning markers use shell-friendly key/value content with stable category, summary, guidance, and `updated_at` fields instead of free-form logs or captured stack traces.
 - Terrapod install warning marker values stay single-line so shell parsing remains predictable; longer human-readable explanations belong in `tpod doctor` output.
 - Terrapod install warning marker `updated_at` values use UTC ISO 8601 timestamps such as `2026-06-02T03:12:45Z`.
-- Terrapod install warning marker writes should be atomic at the category file level, and marker clears remove only the matching category file.
+- Terrapod install warning marker writes should be atomic at the category file level, and `terrapod_install_warning_clear()` removes only the matching category file.
+- The Terrapod install warning directory is Terrapod-owned; its only valid filenames are current categories, the legacy aliases Terrapod still reads, and in-flight staging files.
+- `tpod apply` removes install warning marker files whose names are not valid and prints one line per removal; `tpod status` and `tpod doctor` stay read-only.
+- Install warning marker prune failures print a warning and do not change the exit status of `tpod apply`.
 - Terrapod install warnings do not include a retained installer log; recovery guidance should direct users to rerun the relevant apply path for fresh command output.
 - Terrapod install warning marker path resolution, atomic write, timestamp creation, and clear behavior should be implemented through shared shell helper logic rather than duplicated independently in each installer script.
 - Source-side installer scripts and installed `tpod` commands should share the same Terrapod install warning marker contract even if the helper file placement is decided during implementation.

--- a/docs/adr/0014-prune-unrecognized-install-warning-markers.md
+++ b/docs/adr/0014-prune-unrecognized-install-warning-markers.md
@@ -1,0 +1,41 @@
+# Prune unrecognized install warning markers on apply
+
+The Terrapod install warning directory is owned exclusively by Terrapod. The
+only valid filenames in it are the current categories from
+`terrapod_install_warning_categories()`, the legacy aliases Terrapod still
+reads, and in-flight `mktemp` staging files. `tpod apply` removes every other
+regular file in that directory and reports each removal on one line.
+
+Retiring a category therefore requires no second edit. Removing the name from
+the category list is sufficient, and machines that already hold the marker are
+cleaned by their next apply.
+
+## Considered Options
+
+- Keep a list of retired category names and delete only those: rejected because
+  it requires a person to remember a second edit at retirement time, and
+  forgetting exactly that edit is what produced issue #143. A mechanism whose
+  correctness depends on remembering the step that was already forgotten is not
+  a fix.
+- Delete only files that parse as the four-key marker format: rejected because
+  it adds a parser and a second reporting path to protect files that, under
+  Terrapod-only ownership, should not exist.
+- Report orphans from `tpod doctor` instead of removing them: rejected because
+  `tpod doctor` is read-only for markers, so the files would still accumulate.
+
+## Consequences
+
+- No future feature may stage a marker file in the install warning directory
+  under a name that is not yet a category. A feature needing staged state
+  introduces its own state location or lands its category first.
+- Legacy aliases are derived from `terrapod_install_warning_legacy_path()`
+  rather than restated, so adding an alias cannot desynchronize from the prune.
+- Dot-prefixed staging files survive because the prune iterates a POSIX glob,
+  which does not match a leading dot. An implementation switching to `find` or
+  `ls -a` must reintroduce the exclusion.
+- Prune failures print a warning and do not change the exit status of
+  `tpod apply`; the remaining files are retried on the next apply.
+- `tpod status` and `tpod doctor` are unchanged and remain read-only for
+  markers.
+- The `managed-package-migration` markers left by ADR 0012's retirement are
+  removed by the general rule, with no category-specific code.

--- a/docs/superpowers/plans/2026-08-22-install-warning-marker-pruning.md
+++ b/docs/superpowers/plans/2026-08-22-install-warning-marker-pruning.md
@@ -1,0 +1,533 @@
+# Install Warning Marker Pruning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `tpod apply` delete install warning marker files whose names no longer correspond to any category Terrapod knows, so retiring a category stops leaving a dead file on every machine forever.
+
+**Architecture:** Two new functions in the shared POSIX shell library `dot_local/lib/terrapod/install-warnings.sh` — one that derives the set of recognized filenames from the existing category list and legacy-alias mapping, one that walks the marker directory and removes everything else. `run_apply()` in the `tpod` command calls the prune before delegating to `chezmoi apply` and reports each removal on one line. Failures never change apply's exit status.
+
+**Tech Stack:** POSIX `sh` (the library must stay `sh -n` clean and must not use `local`), chezmoi templates, the repo's hand-rolled test harness in `tests/terrapod_command_test.sh`.
+
+**Spec:** `docs/superpowers/specs/2026-08-22-install-warning-marker-pruning-design.md`
+
+## Global Constraints
+
+- **POSIX `sh` only.** No `local`, no bashisms, no arrays. `dot_local/lib/terrapod/install-warnings.sh` and `dot_local/bin/executable_terrapod` are both validated by `sh -n` in the test suite.
+- **`dot_local/bin/executable_terrapod` runs under `set -eu`.** Never write `cmd && continue` or `cmd && something` as a bare statement where `cmd` failing is an expected case — a failing `A && B` list aborts the shell. Use an `if` block.
+- **No `local` means no variable scoping.** Helper functions invoked through command substitution (`x="$(f)"`) run in a subshell and are safe. Helpers called directly share the caller's variables.
+- **Marker directory resolution always goes through `terrapod_install_warning_dir()`**, which honours `XDG_STATE_HOME` and falls back to `$HOME/.local/state`. Never hardcode a path.
+- **Recognized filenames are:** the eight names from `terrapod_install_warning_categories()` (`homebrew-core`, `homebrew-desktop-apps`, `ubuntu-bootstrap`, `shell-integrations`, `mise-tools`, `optional-ai-cli-tools`, `jetendard-font`, `jetendard-settings`), plus every legacy alias produced by `terrapod_install_warning_legacy_path()` (currently only `ai-cli-tools`, for `optional-ai-cli-tools`).
+- **Dot-prefixed files must survive.** `terrapod_install_warning_write()` stages atomic writes via `mktemp "$marker_dir/.$category.XXXXXX"`. Protection comes from POSIX glob semantics — `"$dir"/*` does not match a leading dot. Do not switch to `find` or `ls -a`.
+- **Removal output text is exactly:** `Removed retired install warning marker: <name>`
+- **Prune failure warning text is exactly:** `could not remove some retired install warning markers`
+- **Run the full suite with:** `sh tests/terrapod_command_test.sh` — it exits 0 and prints `ok - ...` lines. Baseline before this work: 483 passing assertions, exit 0.
+- **Commit style:** imperative subject, no `feat:`/`fix:` prefixes (see `git log`), and every commit ends with:
+  ```
+  Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+  ```
+
+---
+
+### Task 1: Prune functions in the shared library
+
+Adds the two library functions and their unit tests. Nothing calls them yet, so this task is reviewable purely as library behavior.
+
+**Files:**
+- Modify: `dot_local/lib/terrapod/install-warnings.sh` — insert between `terrapod_install_warning_clear()` (ends line 155) and `terrapod_install_warning_list()` (starts line 157)
+- Test: `tests/terrapod_command_test.sh` — insert after line 1099, the line reading `pass "install warning marker write stores Optional AI CLI warnings only under the stable category slug"`, and before line 1101 `fake_warning_bin="$tmp_dir/fake-warning-bin"`
+
+**Interfaces:**
+- Consumes: existing `terrapod_install_warning_dir()`, `terrapod_install_warning_categories()`, `terrapod_install_warning_legacy_path()` from the same file.
+- Produces:
+  - `terrapod_install_warning_known_names()` — no arguments. Prints every recognized marker filename, one per line, in category order with each category immediately followed by its legacy alias when one exists. Always returns 0.
+  - `terrapod_install_warning_prune()` — no arguments. Prints the basename of each marker file it removed, one per line, and nothing else. Returns 0 normally, 1 if at least one `rm` failed. Returns 0 with no output when the marker directory does not exist. Task 2 depends on exactly this contract.
+
+- [ ] **Step 1: Write the failing tests**
+
+Insert this block into `tests/terrapod_command_test.sh` immediately after line 1099 (`pass "install warning marker write stores Optional AI CLI warnings only under the stable category slug"`):
+
+```sh
+prune_marker_home="$tmp_dir/prune-marker-home"
+prune_marker_state="$tmp_dir/prune-marker-state"
+prune_marker_dir="$prune_marker_state/terrapod/install-warnings"
+mkdir -p "$prune_marker_home" "$prune_marker_dir/subdir"
+
+printf '%s\n' "category='managed-package-migration'" >"$prune_marker_dir/managed-package-migration"
+printf '%s\n' "category='homebrew-core'" >"$prune_marker_dir/homebrew-core"
+printf '%s\n' "category='optional-ai-cli-tools'" >"$prune_marker_dir/ai-cli-tools"
+printf '%s\n' "category='homebrew-core'" >"$prune_marker_dir/.homebrew-core.aB3xY9"
+
+prune_removed="$(
+  HOME="$prune_marker_home" XDG_STATE_HOME="$prune_marker_state" sh -c '. "$1"; terrapod_install_warning_prune' sh "$install_warnings_lib"
+)"
+
+if [ "$prune_removed" != "managed-package-migration" ]; then
+  printf '%s\n' "expected pruned names: managed-package-migration" >&2
+  printf '%s\n' "actual pruned names:" >&2
+  printf '%s\n' "$prune_removed" | sed 's/^/  /' >&2
+  fail "install warning marker prune removes and reports only unrecognized marker files"
+fi
+pass "install warning marker prune removes and reports only unrecognized marker files"
+
+if [ -e "$prune_marker_dir/managed-package-migration" ]; then
+  fail "install warning marker prune deletes retired category marker files"
+fi
+pass "install warning marker prune deletes retired category marker files"
+
+if [ ! -f "$prune_marker_dir/homebrew-core" ]; then
+  fail "install warning marker prune keeps current category marker files"
+fi
+pass "install warning marker prune keeps current category marker files"
+
+if [ ! -f "$prune_marker_dir/ai-cli-tools" ]; then
+  fail "install warning marker prune keeps legacy alias marker files"
+fi
+pass "install warning marker prune keeps legacy alias marker files"
+
+if [ ! -f "$prune_marker_dir/.homebrew-core.aB3xY9" ]; then
+  fail "install warning marker prune keeps in-flight mktemp staging files"
+fi
+pass "install warning marker prune keeps in-flight mktemp staging files"
+
+if [ ! -d "$prune_marker_dir/subdir" ]; then
+  fail "install warning marker prune keeps directories"
+fi
+pass "install warning marker prune keeps directories"
+
+prune_remaining_list="$(
+  HOME="$prune_marker_home" XDG_STATE_HOME="$prune_marker_state" sh -c '. "$1"; terrapod_install_warning_list' sh "$install_warnings_lib"
+)"
+expected_prune_remaining_list="$(printf '%s\n' homebrew-core optional-ai-cli-tools)"
+
+if [ "$prune_remaining_list" != "$expected_prune_remaining_list" ]; then
+  printf '%s\n' "expected remaining categories:" >&2
+  printf '%s\n' "$expected_prune_remaining_list" | sed 's/^/  /' >&2
+  printf '%s\n' "actual remaining categories:" >&2
+  printf '%s\n' "$prune_remaining_list" | sed 's/^/  /' >&2
+  fail "install warning marker prune leaves current and legacy categories readable"
+fi
+pass "install warning marker prune leaves current and legacy categories readable"
+
+prune_missing_state="$tmp_dir/prune-missing-state"
+if ! HOME="$prune_marker_home" XDG_STATE_HOME="$prune_missing_state" \
+  sh -c '. "$1"; terrapod_install_warning_prune' sh "$install_warnings_lib" >"$tmp_dir/prune-missing.out"; then
+  fail "install warning marker prune succeeds when the marker directory is missing"
+fi
+
+if [ -s "$tmp_dir/prune-missing.out" ]; then
+  fail "install warning marker prune prints nothing when the marker directory is missing"
+fi
+pass "install warning marker prune succeeds quietly when the marker directory is missing"
+
+if [ "$(id -u)" = 0 ]; then
+  pass "install warning marker prune reports removal failures (skipped as root)"
+else
+  prune_locked_state="$tmp_dir/prune-locked-state"
+  prune_locked_dir="$prune_locked_state/terrapod/install-warnings"
+  mkdir -p "$prune_locked_dir"
+  printf '%s\n' "category='managed-package-migration'" >"$prune_locked_dir/managed-package-migration"
+  chmod 555 "$prune_locked_dir"
+
+  prune_locked_status=0
+  HOME="$prune_marker_home" XDG_STATE_HOME="$prune_locked_state" \
+    sh -c '. "$1"; terrapod_install_warning_prune' sh "$install_warnings_lib" \
+    >"$tmp_dir/prune-locked.out" 2>/dev/null || prune_locked_status="$?"
+  chmod 755 "$prune_locked_dir"
+
+  if [ "$prune_locked_status" -eq 0 ]; then
+    fail "install warning marker prune returns non-zero when a removal fails"
+  fi
+
+  if [ -s "$tmp_dir/prune-locked.out" ]; then
+    fail "install warning marker prune does not report files it failed to remove"
+  fi
+  pass "install warning marker prune reports removal failures through its exit status"
+fi
+```
+
+The last block is skipped under `root`, where a read-only directory does not
+stop a removal. Every other case runs unconditionally.
+
+Why the `prune_remaining_list` assertion matters: it proves the legacy alias is not merely present on disk but still resolvable through `terrapod_install_warning_list()` after a prune. The `ai-cli-tools` case is the one place this design can destroy live state.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+sh tests/terrapod_command_test.sh
+```
+
+Expected: FAIL. The run stops at `not ok - install warning marker prune removes and reports only unrecognized marker files`, because `terrapod_install_warning_prune` does not exist and the command substitution yields an empty string. (`set -eu` is on in the test file, but a command substitution assignment does not abort on the inner command's failure, so the mismatch check is what fires.)
+
+- [ ] **Step 3: Write the implementation**
+
+Insert into `dot_local/lib/terrapod/install-warnings.sh` between `terrapod_install_warning_clear()` and `terrapod_install_warning_list()`:
+
+```sh
+terrapod_install_warning_known_names() {
+  for category in $(terrapod_install_warning_categories); do
+    printf '%s\n' "$category"
+
+    legacy_path="$(terrapod_install_warning_legacy_path "$category" 2>/dev/null)" || continue
+    printf '%s\n' "${legacy_path##*/}"
+  done
+}
+
+terrapod_install_warning_prune() {
+  marker_dir="$(terrapod_install_warning_dir)"
+  [ -d "$marker_dir" ] || return 0
+
+  known_names="$(terrapod_install_warning_known_names)"
+  prune_status=0
+
+  for marker_path in "$marker_dir"/*; do
+    [ -f "$marker_path" ] || continue
+
+    marker_name="${marker_path##*/}"
+    if printf '%s\n' "$known_names" | grep -Fx "$marker_name" >/dev/null; then
+      continue
+    fi
+
+    if rm -f "$marker_path"; then
+      printf '%s\n' "$marker_name"
+    else
+      prune_status=1
+    fi
+  done
+
+  return "$prune_status"
+}
+```
+
+Three things that are easy to get wrong here:
+
+- The recognized-name check is an `if` block, not `grep … && continue`. Under `set -eu` — which `tpod` uses — a failing `A && B` list aborts the shell, and grep failing is the ordinary case for a file about to be pruned.
+- `"$marker_dir"/*` deliberately does not match dot-prefixed files. That is the whole protection for in-flight `mktemp` staging files. The `[ -f "$marker_path" ] || continue` guard also handles the unmatched-glob case, where the literal `.../\*` string is not a file.
+- Derive aliases from `terrapod_install_warning_legacy_path()`. Do not add a second `case` statement listing alias names — splitting that mapping across two places recreates the exact bug this change fixes.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+sh tests/terrapod_command_test.sh
+```
+
+Expected: exit 0, with the eight new `ok -` lines present and the pre-existing 483 assertions still passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dot_local/lib/terrapod/install-warnings.sh tests/terrapod_command_test.sh
+git commit -F - <<'EOF'
+Add install warning marker pruning to the shared library
+
+terrapod_install_warning_prune removes marker files whose names are not
+current categories or legacy aliases. Recognized names are derived from
+the existing category list and legacy path mapping so retiring a category
+needs no second edit.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+EOF
+```
+
+---
+
+### Task 2: Call the prune from `tpod apply`
+
+Wires the library function into the only apply entry point and gives it user-visible output. `tpod update` ends in `exec "$installed_tpod" apply` and the first-run installer calls `TERRAPOD_FIRST_RUN_APPLY=1 "$tpod_bin" apply`, so this one call site covers every real apply path.
+
+**Files:**
+- Modify: `dot_local/bin/executable_terrapod` — add a helper immediately before `run_apply()` (line 1498) and one call inside `run_apply()` after `run_apply_preflight "$config_file"`
+- Test: `tests/terrapod_command_test.sh` — two insertions described in Step 1
+
+**Interfaces:**
+- Consumes: `terrapod_install_warning_prune()` from Task 1 (no arguments; removed names on stdout one per line; exit 1 if any removal failed). Also the existing `print_warning_line "$message"` helper at line 122 and the existing `TERRAPOD_INSTALL_WARNINGS_LOADED` guard convention used by `print_remaining_install_warnings()` at line 1644.
+- Produces: nothing consumed by later tasks. Task 3 documents this behavior but does not call it.
+
+- [ ] **Step 1: Write the failing tests**
+
+Two insertions.
+
+**1a.** In the successful-apply block, the existing setup at lines 3137-3140 writes a `mise-tools` marker into `$apply_marker_state` before running apply. Add the orphan and a control file right after that `sh -c` invocation ends (after the line `sh "$install_warnings_lib"` at line 3140, before the `if ! HOME="$diff_home" ...` at line 3142):
+
+```sh
+apply_marker_dir="$apply_marker_state/terrapod/install-warnings"
+printf '%s\n' "category='managed-package-migration'" >"$apply_marker_dir/managed-package-migration"
+printf '%s\n' "category='optional-ai-cli-tools'" >"$apply_marker_dir/ai-cli-tools"
+```
+
+Then, after the existing `apply_output="$(cat "$tmp_dir/apply.out")"` assignment (line 3151), add:
+
+```sh
+assert_line \
+  "$apply_output" \
+  "Removed retired install warning marker: managed-package-migration" \
+  "Terrapod apply reports each retired install warning marker it removed"
+
+if [ -e "$apply_marker_dir/managed-package-migration" ]; then
+  fail "Terrapod apply removes retired install warning marker files"
+fi
+pass "Terrapod apply removes retired install warning marker files"
+
+if [ ! -f "$apply_marker_dir/mise-tools" ]; then
+  fail "Terrapod apply keeps current install warning marker files"
+fi
+pass "Terrapod apply keeps current install warning marker files"
+
+if [ ! -f "$apply_marker_dir/ai-cli-tools" ]; then
+  fail "Terrapod apply keeps legacy alias install warning marker files"
+fi
+pass "Terrapod apply keeps legacy alias install warning marker files"
+```
+
+**1b.** In the failing-apply block, the stub chezmoi at lines ~3446-3468 exits 91 and `$apply_failure_marker_state` is declared at line 3470. Add the orphan setup right after that declaration and before the `if HOME="$diff_home" ... sh "$terrapod" apply` at line 3472:
+
+```sh
+apply_failure_marker_dir="$apply_failure_marker_state/terrapod/install-warnings"
+mkdir -p "$apply_failure_marker_dir"
+printf '%s\n' "category='managed-package-migration'" >"$apply_failure_marker_dir/managed-package-migration"
+```
+
+Then, after the existing `apply_failure_output="$(cat "$tmp_dir/apply-failure.out")"` assignment (line 3477), add:
+
+```sh
+if [ -e "$apply_failure_marker_dir/managed-package-migration" ]; then
+  fail "Terrapod apply prunes retired install warning markers even when delegated chezmoi apply fails"
+fi
+pass "Terrapod apply prunes retired install warning markers even when delegated chezmoi apply fails"
+
+assert_line \
+  "$apply_failure_output" \
+  "Removed retired install warning marker: managed-package-migration" \
+  "Terrapod apply reports pruned markers before delegating to chezmoi apply"
+```
+
+This second block is the one that pins the ordering decision. If someone later moves the call after `run_chezmoi_command apply`, the early-return failure branch skips it and both of these assertions fail.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+sh tests/terrapod_command_test.sh
+```
+
+Expected: FAIL at `not ok - Terrapod apply reports each retired install warning marker it removed`. The orphan file is still on disk and no removal line appears in the output.
+
+- [ ] **Step 3: Write the implementation**
+
+Add this helper to `dot_local/bin/executable_terrapod` immediately before `run_apply()` at line 1498:
+
+```sh
+prune_retired_install_warnings() {
+  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" != "1" ]; then
+    return
+  fi
+
+  prune_status=0
+  removed_markers="$(terrapod_install_warning_prune)" || prune_status=1
+
+  if [ -n "$removed_markers" ]; then
+    printf '%s\n' "$removed_markers" | while IFS= read -r removed_marker; do
+      printf 'Removed retired install warning marker: %s\n' "$removed_marker"
+    done
+  fi
+
+  if [ "$prune_status" -ne 0 ]; then
+    print_warning_line "could not remove some retired install warning markers"
+  fi
+}
+```
+
+The `|| prune_status=1` is what keeps `set -e` from killing apply when a removal fails, and it also preserves the removed names so they are still reported alongside the warning. The `while` loop reads from a pipeline rather than iterating `$removed_markers` unquoted, so a stray filename containing whitespace or glob characters cannot split or expand.
+
+Then in `run_apply()`, insert one call after the preflight:
+
+```sh
+  config_file="$(chezmoi_config_file)"
+  show_apply_context "$config_file"
+  run_apply_preflight "$config_file"
+  prune_retired_install_warnings
+
+  if ! run_chezmoi_command apply; then
+```
+
+Placement is deliberate. Pruning does not depend on apply succeeding, and the `run_chezmoi_command apply` failure branch returns early — running first means the directory is consistent on that branch too.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+sh tests/terrapod_command_test.sh
+```
+
+Expected: exit 0, with the six new `ok -` lines from this task and all earlier assertions still passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dot_local/bin/executable_terrapod tests/terrapod_command_test.sh
+git commit -F - <<'EOF'
+Prune retired install warning markers on tpod apply
+
+Apply removes marker files under unrecognized names before delegating to
+chezmoi, so the state directory stays consistent even when the delegated
+apply fails. Removals are reported one line each and never change the
+apply exit status.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+EOF
+```
+
+---
+
+### Task 3: Record the ownership decision
+
+The substance of this change is the decision that the marker directory is Terrapod-owned, not the twenty lines of shell. Without it recorded, the next reader sees the prune contradicting a CONTEXT.md invariant and reverts it.
+
+**Files:**
+- Create: `docs/adr/0014-prune-unrecognized-install-warning-markers.md`
+- Modify: `CONTEXT.md` — amend line 229, amend line 220, add three invariants after line 229
+
+**Interfaces:**
+- Consumes: the behavior built in Tasks 1 and 2.
+- Produces: nothing.
+
+- [ ] **Step 1: Write the ADR**
+
+Create `docs/adr/0014-prune-unrecognized-install-warning-markers.md`. Match the structure of `docs/adr/0012-keep-package-source-migration-advisory-only.md`: an untitled opening statement of the decision, then `## Considered Options`, then `## Consequences`.
+
+```markdown
+# Prune unrecognized install warning markers on apply
+
+The Terrapod install warning directory is owned exclusively by Terrapod. The
+only valid filenames in it are the current categories from
+`terrapod_install_warning_categories()`, the legacy aliases Terrapod still
+reads, and in-flight `mktemp` staging files. `tpod apply` removes every other
+regular file in that directory and reports each removal on one line.
+
+Retiring a category therefore requires no second edit. Removing the name from
+the category list is sufficient, and machines that already hold the marker are
+cleaned by their next apply.
+
+## Considered Options
+
+- Keep a list of retired category names and delete only those: rejected because
+  it requires a person to remember a second edit at retirement time, and
+  forgetting exactly that edit is what produced issue #143. A mechanism whose
+  correctness depends on remembering the step that was already forgotten is not
+  a fix.
+- Delete only files that parse as the four-key marker format: rejected because
+  it adds a parser and a second reporting path to protect files that, under
+  Terrapod-only ownership, should not exist.
+- Report orphans from `tpod doctor` instead of removing them: rejected because
+  `tpod doctor` is read-only for markers, so the files would still accumulate.
+
+## Consequences
+
+- No future feature may stage a marker file in the install warning directory
+  under a name that is not yet a category. A feature needing staged state
+  introduces its own state location or lands its category first.
+- Legacy aliases are derived from `terrapod_install_warning_legacy_path()`
+  rather than restated, so adding an alias cannot desynchronize from the prune.
+- Dot-prefixed staging files survive because the prune iterates a POSIX glob,
+  which does not match a leading dot. An implementation switching to `find` or
+  `ls -a` must reintroduce the exclusion.
+- Prune failures print a warning and do not change the exit status of
+  `tpod apply`; the remaining files are retried on the next apply.
+- `tpod status` and `tpod doctor` are unchanged and remain read-only for
+  markers.
+- The `managed-package-migration` markers left by ADR 0012's retirement are
+  removed by the general rule, with no category-specific code.
+```
+
+- [ ] **Step 2: Amend the conflicting CONTEXT.md invariants**
+
+Line 229 currently reads:
+
+```
+- Terrapod install warning marker writes should be atomic at the category file level, and marker clears remove only the matching category file.
+```
+
+Replace it with:
+
+```
+- Terrapod install warning marker writes should be atomic at the category file level, and `terrapod_install_warning_clear()` removes only the matching category file.
+```
+
+Line 220 currently reads:
+
+```
+- Terrapod install warnings are category-scoped markers that remain actionable until the same installer category completes successfully; interrupted or failed reruns must not hide the previous recovery signal.
+```
+
+Replace it with:
+
+```
+- Terrapod install warnings are category-scoped markers that, while their category exists, remain actionable until the same installer category completes successfully; interrupted or failed reruns must not hide the previous recovery signal.
+```
+
+Both edits exist so the new prune does not read as a violation of a flat prohibition. The first scopes the clause to the clearing function; the second adds the qualifier the prune depends on.
+
+- [ ] **Step 3: Add the new invariants**
+
+Insert these three lines after the amended line 229, keeping the surrounding one-bullet-per-line style:
+
+```
+- The Terrapod install warning directory is Terrapod-owned; its only valid filenames are current categories, the legacy aliases Terrapod still reads, and in-flight staging files.
+- `tpod apply` removes install warning marker files whose names are not valid and prints one line per removal; `tpod status` and `tpod doctor` stay read-only.
+- Install warning marker prune failures print a warning and do not change the exit status of `tpod apply`.
+```
+
+- [ ] **Step 4: Verify nothing regressed**
+
+```bash
+sh tests/terrapod_command_test.sh
+```
+
+Expected: exit 0. This task changes only documentation, so the suite must be unchanged from Task 2. If `tests/readme_korean_test.sh` or `tests/chezmoiignore_test.sh` cover docs, run those too:
+
+```bash
+sh tests/chezmoiignore_test.sh && sh tests/readme_korean_test.sh
+```
+
+Expected: exit 0 for both.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/adr/0014-prune-unrecognized-install-warning-markers.md CONTEXT.md
+git commit -F - <<'EOF'
+Record Terrapod ownership of the install warning directory
+
+ADR 0014 states that unrecognized filenames in the install warning
+directory are unreachable by definition, which is what lets apply prune
+them without per-retirement bookkeeping. Scopes the clear-only-matching
+invariant to terrapod_install_warning_clear so the prune does not read as
+a violation of it.
+
+Closes #143
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+EOF
+```
+
+---
+
+## Verification
+
+After all three tasks:
+
+```bash
+sh tests/terrapod_command_test.sh
+```
+
+Expected: exit 0 with 497 `ok -` assertions — the 483 baseline plus eight from Task 1 and six from Task 2.
+
+Manual check against the machine state that produced the issue, using a throwaway state directory so the real one is untouched:
+
+```bash
+tmp_state="$(mktemp -d)"
+mkdir -p "$tmp_state/terrapod/install-warnings"
+printf "category='managed-package-migration'\n" >"$tmp_state/terrapod/install-warnings/managed-package-migration"
+XDG_STATE_HOME="$tmp_state" sh -c '. dot_local/lib/terrapod/install-warnings.sh; terrapod_install_warning_prune'
+ls -A "$tmp_state/terrapod/install-warnings"
+rm -rf "$tmp_state"
+```
+
+Expected: prints `managed-package-migration`, then `ls -A` prints nothing.

--- a/docs/superpowers/plans/2026-08-22-install-warning-marker-pruning.md
+++ b/docs/superpowers/plans/2026-08-22-install-warning-marker-pruning.md
@@ -210,7 +210,7 @@ Three things that are easy to get wrong here:
 sh tests/terrapod_command_test.sh
 ```
 
-Expected: exit 0, with the eight new `ok -` lines present and the pre-existing 483 assertions still passing.
+Expected: exit 0, with the nine new `ok -` lines present and the pre-existing 483 assertions still passing.
 
 - [ ] **Step 5: Commit**
 
@@ -236,7 +236,7 @@ Wires the library function into the only apply entry point and gives it user-vis
 
 **Files:**
 - Modify: `dot_local/bin/executable_terrapod` — add a helper immediately before `run_apply()` (line 1498) and one call inside `run_apply()` after `run_apply_preflight "$config_file"`
-- Test: `tests/terrapod_command_test.sh` — two insertions described in Step 1
+- Test: `tests/terrapod_command_test.sh` — two insertions described in Step 1. **Line numbers below are pre-Task-1 and are approximate; locate every insertion point by its quoted text anchor.**
 
 **Interfaces:**
 - Consumes: `terrapod_install_warning_prune()` from Task 1 (no arguments; removed names on stdout one per line; exit 1 if any removal failed). Also the existing `print_warning_line "$message"` helper at line 122 and the existing `TERRAPOD_INSTALL_WARNINGS_LOADED` guard convention used by `print_remaining_install_warnings()` at line 1644.
@@ -517,7 +517,7 @@ After all three tasks:
 sh tests/terrapod_command_test.sh
 ```
 
-Expected: exit 0 with 497 `ok -` assertions — the 483 baseline plus eight from Task 1 and six from Task 2.
+Expected: exit 0 with 498 `ok -` assertions — the 483 baseline plus nine from Task 1 and six from Task 2.
 
 Manual check against the machine state that produced the issue, using a throwaway state directory so the real one is untouched:
 

--- a/docs/superpowers/specs/2026-08-22-install-warning-marker-pruning-design.md
+++ b/docs/superpowers/specs/2026-08-22-install-warning-marker-pruning-design.md
@@ -151,7 +151,9 @@ terrapod_install_warning_prune() {
   for marker_path in "$marker_dir"/*; do
     [ -f "$marker_path" ] || continue
     name="${marker_path##*/}"
-    printf '%s\n' "$known" | grep -Fx "$name" >/dev/null && continue
+    if printf '%s\n' "$known" | grep -Fx "$name" >/dev/null; then
+      continue
+    fi
 
     if rm -f "$marker_path"; then
       printf '%s\n' "$name"
@@ -172,6 +174,12 @@ with no output.
 `known_names` runs inside a command substitution, so its `category` and
 `legacy_path` assignments stay in a subshell and do not leak into the caller,
 which matters in a POSIX shell library with no `local`.
+
+The recognized-name check is written as an `if` block rather than
+`grep … && continue`. `dot_local/bin/executable_terrapod` runs under `set -eu`,
+where an `A && B` list whose `A` fails is a failing statement and aborts the
+shell. Since `grep` failing is the ordinary case for a file being pruned, the
+`&&` form would kill `tpod apply` on the first orphan it found.
 
 ## Apply Integration
 

--- a/docs/superpowers/specs/2026-08-22-install-warning-marker-pruning-design.md
+++ b/docs/superpowers/specs/2026-08-22-install-warning-marker-pruning-design.md
@@ -1,0 +1,288 @@
+# Install Warning Marker Pruning Design
+
+## Goal
+
+Make retiring an install warning category self-cleaning. When a category leaves
+`terrapod_install_warning_categories()`, the marker files earlier versions wrote
+must stop surviving forever on machines that already have them.
+
+`tpod apply` gains one step: it removes marker files whose names no longer
+correspond to anything Terrapod knows, and reports what it removed. No
+bookkeeping is required when a future category is retired.
+
+This resolves issue #143.
+
+## Current State
+
+`~/.local/state/terrapod/install-warnings/` on the configured workstation holds
+a `managed-package-migration` marker written by the code from #135. ADR 0012
+retired that category in #137 and removed it from the allowlist, but nothing
+removed the file.
+
+`terrapod_install_warning_list()` iterates the allowlist rather than the
+directory:
+
+```sh
+terrapod_install_warning_list() {
+  for category in $(terrapod_install_warning_categories); do
+    if terrapod_install_warning_existing_path "$category" >/dev/null; then
+      printf '%s\n' "$category"
+    fi
+  done
+}
+```
+
+A retired category therefore becomes invisible to `tpod status`, `tpod doctor`,
+and every clearing path at the same moment. The file is unreachable by any code
+path and survives every future apply. Both commands report the directory as
+empty while the file sits there, which sends anyone inspecting the machine down
+a false trail.
+
+Two facts about the directory shape the design and are not obvious from the
+issue:
+
+- `terrapod_install_warning_legacy_path()` still resolves `optional-ai-cli-tools`
+  to the older filename `ai-cli-tools`, and `terrapod_install_warning_read()`
+  and `terrapod_install_warning_value()` still read it. That name is live state
+  under a name the allowlist does not contain.
+- `terrapod_install_warning_write()` stages atomic writes through
+  `mktemp "$marker_dir/.$category.XXXXXX"`, so dot-prefixed temporary files
+  appear in the same directory while a write is in flight.
+
+A rule that deleted every file not in `terrapod_install_warning_categories()`
+would destroy both.
+
+## Ownership Decision
+
+The marker directory is Terrapod-only. The valid names in it are the current
+categories, the legacy aliases Terrapod still reads, and in-flight temporary
+files. Any other name is unreachable by definition, so apply may delete it.
+
+This is the decision the issue asked to be made deliberately, and it is what
+makes the mechanism self-maintaining. It also forecloses one thing: no future
+feature may stage a marker file under a name that is not yet a category. A
+feature that needs staged state introduces its own state location or lands its
+category first.
+
+## Considered Approaches
+
+### Prune unrecognized marker files on apply
+
+Apply walks the directory and removes regular files whose names are not
+recognized. This is the selected approach.
+
+It needs no bookkeeping when a category is retired, which matters because
+missing exactly that bookkeeping is what produced this issue. It also subsumes
+the issue's first request: the known `managed-package-migration` orphan needs no
+special-case code, because the general rule already covers it.
+
+Its cost is the ownership constraint above, and the need to enumerate legacy
+aliases correctly. Both are addressed below.
+
+### Keep a list of retired category names
+
+A `terrapod_install_warning_retired_categories()` list would name
+`managed-package-migration` and grow by one entry each retirement. Apply would
+delete only those names.
+
+Rejected. It leaves the directory open to unknown names, which is not a property
+this project needs, and in exchange it requires a person to remember a second
+edit at retirement time. The failure mode of forgetting that edit is silent and
+indefinite, which is exactly this issue. A mechanism whose correctness depends
+on remembering the thing that was already forgotten is not a fix.
+
+### Delete only files matching the marker format
+
+Apply would parse each unrecognized file and delete it only if it carried the
+four expected keys, leaving anything else for `tpod doctor` to report.
+
+Rejected. It adds a parser and a second reporting path to protect files that,
+under the ownership decision, should not exist. The directory is not a shared
+namespace.
+
+## Prune Rule
+
+For each entry directly inside `terrapod_install_warning_dir()`:
+
+| Entry | Action | Reason |
+| --- | --- | --- |
+| A name in `terrapod_install_warning_categories()` | keep | current category |
+| A legacy alias such as `ai-cli-tools` | keep | still read by `terrapod_install_warning_read()` |
+| A dot-prefixed name such as `.homebrew-core.aB3xY9` | keep | `mktemp` staging file for an in-flight write |
+| A directory or other non-regular file | keep | not a marker; narrows the blast radius to files |
+| Any other regular file | **remove** | unreachable retired marker |
+
+"Regular file" is the `[ -f ]` test, which follows symbolic links. A symlink
+pointing at a regular file under an unrecognized name is removed; the link is
+unreachable state under the ownership decision like any other such name.
+
+Dot-prefixed files are protected by POSIX glob semantics: `"$marker_dir"/*` does
+not match a leading dot. This is a deliberate dependency rather than an
+accident, so it is stated here and pinned by a test. An implementation that
+switches to `find` or `ls -a` must reintroduce the exclusion explicitly.
+
+Legacy aliases are derived from the existing mapping rather than restated. A
+second `case` statement listing alias names would split the mapping across two
+places, and the next alias added to one and not the other reproduces this
+issue's failure mode in a new form.
+
+```sh
+terrapod_install_warning_known_names() {
+  for category in $(terrapod_install_warning_categories); do
+    printf '%s\n' "$category"
+    legacy_path="$(terrapod_install_warning_legacy_path "$category" 2>/dev/null)" || continue
+    printf '%s\n' "${legacy_path##*/}"
+  done
+}
+```
+
+## Library Interface
+
+`dot_local/lib/terrapod/install-warnings.sh` gains
+`terrapod_install_warning_known_names()` above and the prune itself.
+
+```sh
+terrapod_install_warning_prune() {
+  marker_dir="$(terrapod_install_warning_dir)"
+  [ -d "$marker_dir" ] || return 0
+  known="$(terrapod_install_warning_known_names)"
+  prune_status=0
+
+  for marker_path in "$marker_dir"/*; do
+    [ -f "$marker_path" ] || continue
+    name="${marker_path##*/}"
+    printf '%s\n' "$known" | grep -Fx "$name" >/dev/null && continue
+
+    if rm -f "$marker_path"; then
+      printf '%s\n' "$name"
+    else
+      prune_status=1
+    fi
+  done
+
+  return "$prune_status"
+}
+```
+
+The contract separates the two things a caller needs. Standard output carries
+the names actually removed, one per line, and nothing else. The exit status is
+non-zero only when at least one removal failed. A missing directory is success
+with no output.
+
+`known_names` runs inside a command substitution, so its `category` and
+`legacy_path` assignments stay in a subshell and do not leak into the caller,
+which matters in a POSIX shell library with no `local`.
+
+## Apply Integration
+
+`run_apply()` in `dot_local/bin/executable_terrapod` calls the prune after
+`run_apply_preflight` and before delegating to `chezmoi apply`.
+
+Ordering before the delegation is deliberate. Pruning is hygiene that does not
+depend on apply succeeding, and the failure branch of `run_chezmoi_command
+apply` returns early. Running first means the directory is consistent even on
+that branch.
+
+`tpod apply` is the only apply entry point that needs the call. `tpod update`
+ends in `exec "$installed_tpod" apply`, and the first-run installer invokes
+`TERRAPOD_FIRST_RUN_APPLY=1 "$tpod_bin" apply`. A `.chezmoiscripts` entry would
+additionally cover a bare `tpod chezmoi -- apply`, at the cost of a new template
+file, another copy of the library-loading boilerplate, and an OS gate on an
+OS-independent operation. That escape hatch catches up on the next `tpod apply`.
+
+Output appears only when something was removed, between the apply context block
+and chezmoi's own output:
+
+```
+Terrapod apply
+  Profile: ...
+  Delegating declared-state apply to: chezmoi apply
+Removed retired install warning marker: managed-package-migration
+```
+
+The call is guarded the way the command's other marker calls are, so a `tpod`
+running without `install-warnings.sh` loaded skips the step silently.
+
+## Error Handling
+
+No prune failure changes the exit status of `tpod apply`. This follows the
+existing invariant that apply's exit status reflects the declared-state apply
+itself.
+
+- **A removal fails** (permissions, read-only state directory): the names that
+  were removed are still reported, and `print_warning_line` adds
+  `could not remove some retired install warning markers`. The remaining files
+  are retried on the next apply; the operation is idempotent.
+- **The directory does not exist**: no work, success. This is the first-run
+  path.
+- **The library is not loaded**: the step is skipped silently.
+
+Deliberately excluded: backing up removed files, prompting before removal, and
+logging removed contents. These files are by definition unreadable by any code
+path, and a backup directory would recreate the accumulation this change exists
+to stop.
+
+## Testing
+
+Both harnesses already exist in `tests/terrapod_command_test.sh`: the
+`marker_home` / `marker_xdg_state` pattern for library behavior and the chezmoi
+stub pattern for `tpod apply`.
+
+**Library.** One directory populated with all five cases, one prune run:
+
+| Fixture | Expected |
+| --- | --- |
+| `managed-package-migration` | removed, name on standard output |
+| `homebrew-core` | kept |
+| `ai-cli-tools` | kept |
+| `.optional-ai-cli-tools.aB3xY9` | kept |
+| `subdir/` | kept |
+
+Then `terrapod_install_warning_list` reports `homebrew-core` only, and a prune
+against a missing directory exits 0.
+
+The `ai-cli-tools` case is the most important test in this change. It is the one
+place where the design can destroy live state, and the issue's original second
+option would have failed exactly there.
+
+**Command.** With a stub chezmoi, `tpod apply` removes the orphan, prints
+`Removed retired install warning marker: managed-package-migration`, and leaves
+a known marker in place. A second run with a failing chezmoi stub confirms the
+prune still completed, pinning the decision to run before delegation.
+
+`sh -n` validation of the library already runs, so the new functions are covered
+for POSIX syntax without a new test.
+
+## Documentation
+
+**ADR 0014, "Prune unrecognized install warning markers on apply."** The
+substance of this change is the ownership decision, not the code. #135 and #137
+were recorded as ADR 0011 and 0012, and the reasoning for rejecting a retired
+name list belongs in the same series.
+
+**CONTEXT.md.** Three invariants are added:
+
+- The install warning directory is Terrapod-owned; the only valid names are
+  current categories and the legacy aliases Terrapod still reads.
+- `tpod apply` removes marker files whose names are not valid, and reports each
+  removal on one line.
+- Marker prune failures do not fail `tpod apply`.
+
+One existing invariant is amended. "Terrapod install warning marker writes
+should be atomic at the category file level, and marker clears remove only the
+matching category file" must scope its second clause to
+`terrapod_install_warning_clear()`. Left as written, it reads as a flat
+prohibition on the new behavior. The related invariant that markers remain until
+their category completes successfully needs the qualifier "while that category
+exists" for the same reason: without it, the next reader can mistake the prune
+for a violation and revert it.
+
+## Out of Scope
+
+`tpod status` and `tpod doctor` stay read-only and unchanged. They report the
+directory as empty today and will report it as empty after the prune, so a
+single apply removes the disagreement the issue describes.
+
+The three executable selection advisories on the same machine are working as
+designed under ADR 0012. The `python` advisory's downstream consequence is
+tracked in #142.

--- a/docs/superpowers/specs/2026-08-22-install-warning-marker-pruning-design.md
+++ b/docs/superpowers/specs/2026-08-22-install-warning-marker-pruning-design.md
@@ -205,6 +205,8 @@ and chezmoi's own output:
 Terrapod apply
   Profile: ...
   Delegating declared-state apply to: chezmoi apply
+Preflight: chezmoi is available
+Preflight: config file is readable
 Removed retired install warning marker: managed-package-migration
 ```
 

--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -1495,6 +1495,25 @@ show_apply_context() {
   printf '%s\n' "Delegating declared-state apply to: $(render_chezmoi_command apply)"
 }
 
+prune_retired_install_warnings() {
+  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" != "1" ]; then
+    return
+  fi
+
+  prune_status=0
+  removed_markers="$(terrapod_install_warning_prune)" || prune_status=1
+
+  if [ -n "$removed_markers" ]; then
+    printf '%s\n' "$removed_markers" | while IFS= read -r removed_marker; do
+      printf 'Removed retired install warning marker: %s\n' "$removed_marker"
+    done
+  fi
+
+  if [ "$prune_status" -ne 0 ]; then
+    print_warning_line "could not remove some retired install warning markers"
+  fi
+}
+
 run_apply() {
   if [ "$#" -ne 0 ]; then
     fail_usage "apply accepts no arguments"
@@ -1503,6 +1522,7 @@ run_apply() {
   config_file="$(chezmoi_config_file)"
   show_apply_context "$config_file"
   run_apply_preflight "$config_file"
+  prune_retired_install_warnings
 
   if ! run_chezmoi_command apply; then
     print_remaining_install_warnings

--- a/dot_local/lib/terrapod/install-warnings.sh
+++ b/dot_local/lib/terrapod/install-warnings.sh
@@ -15,14 +15,15 @@ terrapod_install_warning_categories() {
 }
 
 terrapod_install_warning_is_category() {
-  case "$1" in
-    homebrew-core|homebrew-desktop-apps|ubuntu-bootstrap|shell-integrations|mise-tools|optional-ai-cli-tools|jetendard-font|jetendard-settings)
+  wanted_category="$1"
+
+  for known_category in $(terrapod_install_warning_categories); do
+    if [ "$known_category" = "$wanted_category" ]; then
       return 0
-      ;;
-    *)
-      return 1
-      ;;
-  esac
+    fi
+  done
+
+  return 1
 }
 
 terrapod_install_warning_dir() {
@@ -174,7 +175,7 @@ terrapod_install_warning_prune() {
     [ -f "$marker_path" ] || continue
 
     marker_name="${marker_path##*/}"
-    if printf '%s\n' "$known_names" | grep -Fx "$marker_name" >/dev/null; then
+    if printf '%s\n' "$known_names" | grep -Fx -- "$marker_name" >/dev/null; then
       continue
     fi
 

--- a/dot_local/lib/terrapod/install-warnings.sh
+++ b/dot_local/lib/terrapod/install-warnings.sh
@@ -154,6 +154,40 @@ terrapod_install_warning_clear() {
   rm -f "$legacy_marker_path"
 }
 
+terrapod_install_warning_known_names() {
+  for category in $(terrapod_install_warning_categories); do
+    printf '%s\n' "$category"
+
+    legacy_path="$(terrapod_install_warning_legacy_path "$category" 2>/dev/null)" || continue
+    printf '%s\n' "${legacy_path##*/}"
+  done
+}
+
+terrapod_install_warning_prune() {
+  marker_dir="$(terrapod_install_warning_dir)"
+  [ -d "$marker_dir" ] || return 0
+
+  known_names="$(terrapod_install_warning_known_names)"
+  prune_status=0
+
+  for marker_path in "$marker_dir"/*; do
+    [ -f "$marker_path" ] || continue
+
+    marker_name="${marker_path##*/}"
+    if printf '%s\n' "$known_names" | grep -Fx "$marker_name" >/dev/null; then
+      continue
+    fi
+
+    if rm -f "$marker_path"; then
+      printf '%s\n' "$marker_name"
+    else
+      prune_status=1
+    fi
+  done
+
+  return "$prune_status"
+}
+
 terrapod_install_warning_list() {
   for category in $(terrapod_install_warning_categories); do
     if terrapod_install_warning_existing_path "$category" >/dev/null; then

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -3237,6 +3237,10 @@ HOME="$tmp_dir/apply-marker-home" XDG_STATE_HOME="$apply_marker_state" sh -c \
   '. "$1"; terrapod_install_warning_write mise-tools "mise tool install needs attention" "Run tpod apply after fixing mise tool installation output."' \
   sh "$install_warnings_lib"
 
+apply_marker_dir="$apply_marker_state/terrapod/install-warnings"
+printf '%s\n' "category='managed-package-migration'" >"$apply_marker_dir/managed-package-migration"
+printf '%s\n' "category='optional-ai-cli-tools'" >"$apply_marker_dir/ai-cli-tools"
+
 if ! HOME="$diff_home" XDG_CONFIG_HOME="$diff_xdg" XDG_STATE_HOME="$apply_marker_state" PATH="$tmp_dir/bin:/usr/bin:/bin" \
   sh "$terrapod" apply >"$tmp_dir/apply.out" 2>"$tmp_dir/apply.err"; then
   printf '%s\n' "apply stdout:" >&2
@@ -3247,6 +3251,26 @@ if ! HOME="$diff_home" XDG_CONFIG_HOME="$diff_xdg" XDG_STATE_HOME="$apply_marker
 fi
 
 apply_output="$(cat "$tmp_dir/apply.out")"
+
+assert_line \
+  "$apply_output" \
+  "Removed retired install warning marker: managed-package-migration" \
+  "Terrapod apply reports each retired install warning marker it removed"
+
+if [ -e "$apply_marker_dir/managed-package-migration" ]; then
+  fail "Terrapod apply removes retired install warning marker files"
+fi
+pass "Terrapod apply removes retired install warning marker files"
+
+if [ ! -f "$apply_marker_dir/mise-tools" ]; then
+  fail "Terrapod apply keeps current install warning marker files"
+fi
+pass "Terrapod apply keeps current install warning marker files"
+
+if [ ! -f "$apply_marker_dir/ai-cli-tools" ]; then
+  fail "Terrapod apply keeps legacy alias install warning marker files"
+fi
+pass "Terrapod apply keeps legacy alias install warning marker files"
 
 assert_call_args \
   "$CHEZMOI_APPLY_ARGS_FILE" \
@@ -3565,6 +3589,9 @@ write_stub "$tmp_dir/bin/chezmoi" \
   'exit 92'
 
 apply_failure_marker_state="$tmp_dir/apply-failure-marker-state"
+apply_failure_marker_dir="$apply_failure_marker_state/terrapod/install-warnings"
+mkdir -p "$apply_failure_marker_dir"
+printf '%s\n' "category='managed-package-migration'" >"$apply_failure_marker_dir/managed-package-migration"
 
 if HOME="$diff_home" XDG_CONFIG_HOME="$diff_xdg" XDG_STATE_HOME="$apply_failure_marker_state" TERRAPOD_APPLY_FAILURE_MARKER_LIB="$install_warnings_lib" PATH="$tmp_dir/bin:/usr/bin:/bin" \
   sh "$terrapod" apply >"$tmp_dir/apply-failure.out" 2>"$tmp_dir/apply-failure.err"; then
@@ -3573,6 +3600,16 @@ fi
 
 apply_failure_output="$(cat "$tmp_dir/apply-failure.out")"
 apply_failure_error="$(cat "$tmp_dir/apply-failure.err")"
+
+if [ -e "$apply_failure_marker_dir/managed-package-migration" ]; then
+  fail "Terrapod apply prunes retired install warning markers even when delegated chezmoi apply fails"
+fi
+pass "Terrapod apply prunes retired install warning markers even when delegated chezmoi apply fails"
+
+assert_line \
+  "$apply_failure_output" \
+  "Removed retired install warning marker: managed-package-migration" \
+  "Terrapod apply reports pruned markers before delegating to chezmoi apply"
 
 assert_contains \
   "$apply_failure_error" \

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -1098,6 +1098,103 @@ if [ ! -f "$legacy_marker_dir/optional-ai-cli-tools" ] || [ -e "$legacy_ai_cli_m
 fi
 pass "install warning marker write stores Optional AI CLI warnings only under the stable category slug"
 
+prune_marker_home="$tmp_dir/prune-marker-home"
+prune_marker_state="$tmp_dir/prune-marker-state"
+prune_marker_dir="$prune_marker_state/terrapod/install-warnings"
+mkdir -p "$prune_marker_home" "$prune_marker_dir/subdir"
+
+printf '%s\n' "category='managed-package-migration'" >"$prune_marker_dir/managed-package-migration"
+printf '%s\n' "category='homebrew-core'" >"$prune_marker_dir/homebrew-core"
+printf '%s\n' "category='optional-ai-cli-tools'" >"$prune_marker_dir/ai-cli-tools"
+printf '%s\n' "category='homebrew-core'" >"$prune_marker_dir/.homebrew-core.aB3xY9"
+
+prune_removed="$(
+  HOME="$prune_marker_home" XDG_STATE_HOME="$prune_marker_state" sh -c '. "$1"; terrapod_install_warning_prune' sh "$install_warnings_lib"
+)"
+
+if [ "$prune_removed" != "managed-package-migration" ]; then
+  printf '%s\n' "expected pruned names: managed-package-migration" >&2
+  printf '%s\n' "actual pruned names:" >&2
+  printf '%s\n' "$prune_removed" | sed 's/^/  /' >&2
+  fail "install warning marker prune removes and reports only unrecognized marker files"
+fi
+pass "install warning marker prune removes and reports only unrecognized marker files"
+
+if [ -e "$prune_marker_dir/managed-package-migration" ]; then
+  fail "install warning marker prune deletes retired category marker files"
+fi
+pass "install warning marker prune deletes retired category marker files"
+
+if [ ! -f "$prune_marker_dir/homebrew-core" ]; then
+  fail "install warning marker prune keeps current category marker files"
+fi
+pass "install warning marker prune keeps current category marker files"
+
+if [ ! -f "$prune_marker_dir/ai-cli-tools" ]; then
+  fail "install warning marker prune keeps legacy alias marker files"
+fi
+pass "install warning marker prune keeps legacy alias marker files"
+
+if [ ! -f "$prune_marker_dir/.homebrew-core.aB3xY9" ]; then
+  fail "install warning marker prune keeps in-flight mktemp staging files"
+fi
+pass "install warning marker prune keeps in-flight mktemp staging files"
+
+if [ ! -d "$prune_marker_dir/subdir" ]; then
+  fail "install warning marker prune keeps directories"
+fi
+pass "install warning marker prune keeps directories"
+
+prune_remaining_list="$(
+  HOME="$prune_marker_home" XDG_STATE_HOME="$prune_marker_state" sh -c '. "$1"; terrapod_install_warning_list' sh "$install_warnings_lib"
+)"
+expected_prune_remaining_list="$(printf '%s\n' homebrew-core optional-ai-cli-tools)"
+
+if [ "$prune_remaining_list" != "$expected_prune_remaining_list" ]; then
+  printf '%s\n' "expected remaining categories:" >&2
+  printf '%s\n' "$expected_prune_remaining_list" | sed 's/^/  /' >&2
+  printf '%s\n' "actual remaining categories:" >&2
+  printf '%s\n' "$prune_remaining_list" | sed 's/^/  /' >&2
+  fail "install warning marker prune leaves current and legacy categories readable"
+fi
+pass "install warning marker prune leaves current and legacy categories readable"
+
+prune_missing_state="$tmp_dir/prune-missing-state"
+if ! HOME="$prune_marker_home" XDG_STATE_HOME="$prune_missing_state" \
+  sh -c '. "$1"; terrapod_install_warning_prune' sh "$install_warnings_lib" >"$tmp_dir/prune-missing.out"; then
+  fail "install warning marker prune succeeds when the marker directory is missing"
+fi
+
+if [ -s "$tmp_dir/prune-missing.out" ]; then
+  fail "install warning marker prune prints nothing when the marker directory is missing"
+fi
+pass "install warning marker prune succeeds quietly when the marker directory is missing"
+
+if [ "$(id -u)" = 0 ]; then
+  pass "install warning marker prune reports removal failures (skipped as root)"
+else
+  prune_locked_state="$tmp_dir/prune-locked-state"
+  prune_locked_dir="$prune_locked_state/terrapod/install-warnings"
+  mkdir -p "$prune_locked_dir"
+  printf '%s\n' "category='managed-package-migration'" >"$prune_locked_dir/managed-package-migration"
+  chmod 555 "$prune_locked_dir"
+
+  prune_locked_status=0
+  HOME="$prune_marker_home" XDG_STATE_HOME="$prune_locked_state" \
+    sh -c '. "$1"; terrapod_install_warning_prune' sh "$install_warnings_lib" \
+    >"$tmp_dir/prune-locked.out" 2>/dev/null || prune_locked_status="$?"
+  chmod 755 "$prune_locked_dir"
+
+  if [ "$prune_locked_status" -eq 0 ]; then
+    fail "install warning marker prune returns non-zero when a removal fails"
+  fi
+
+  if [ -s "$tmp_dir/prune-locked.out" ]; then
+    fail "install warning marker prune does not report files it failed to remove"
+  fi
+  pass "install warning marker prune reports removal failures through its exit status"
+fi
+
 fake_warning_bin="$tmp_dir/fake-warning-bin"
 fake_warning_calls="$tmp_dir/fake-warning.calls"
 mkdir -p "$fake_warning_bin"

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -1170,15 +1170,16 @@ if [ -s "$tmp_dir/prune-missing.out" ]; then
 fi
 pass "install warning marker prune succeeds quietly when the marker directory is missing"
 
-if [ "$(id -u)" = 0 ]; then
-  pass "install warning marker prune reports removal failures (skipped as root)"
-else
-  prune_locked_state="$tmp_dir/prune-locked-state"
-  prune_locked_dir="$prune_locked_state/terrapod/install-warnings"
-  mkdir -p "$prune_locked_dir"
-  printf '%s\n' "category='managed-package-migration'" >"$prune_locked_dir/managed-package-migration"
-  chmod 555 "$prune_locked_dir"
+prune_locked_state="$tmp_dir/prune-locked-state"
+prune_locked_dir="$prune_locked_state/terrapod/install-warnings"
+mkdir -p "$prune_locked_dir"
+printf '%s\n' "category='managed-package-migration'" >"$prune_locked_dir/managed-package-migration"
+chmod 555 "$prune_locked_dir"
 
+if [ -w "$prune_locked_dir" ]; then
+  chmod 755 "$prune_locked_dir"
+  pass "install warning marker prune removal-failure case is skipped when chmod 555 remains writable"
+else
   prune_locked_status=0
   HOME="$prune_marker_home" XDG_STATE_HOME="$prune_locked_state" \
     sh -c '. "$1"; terrapod_install_warning_prune' sh "$install_warnings_lib" \
@@ -3238,6 +3239,7 @@ HOME="$tmp_dir/apply-marker-home" XDG_STATE_HOME="$apply_marker_state" sh -c \
   sh "$install_warnings_lib"
 
 apply_marker_dir="$apply_marker_state/terrapod/install-warnings"
+mkdir -p "$apply_marker_dir"
 printf '%s\n' "category='managed-package-migration'" >"$apply_marker_dir/managed-package-migration"
 printf '%s\n' "category='optional-ai-cli-tools'" >"$apply_marker_dir/ai-cli-tools"
 


### PR DESCRIPTION
## Changes

- Added `terrapod_install_warning_known_names()` and `terrapod_install_warning_prune()` to `dot_local/lib/terrapod/install-warnings.sh`. The prune removes regular files in the marker directory whose names are not recognized, prints each removed basename, and returns non-zero only when a removal fails.
- Called the prune from `run_apply()` in `dot_local/bin/executable_terrapod`, after the preflight and before delegating to `chezmoi apply`, reporting each removal on one line.
- Derived `terrapod_install_warning_is_category()` from `terrapod_install_warning_categories()` instead of restating the eight slugs in a second `case` statement.
- Added fifteen assertions to `tests/terrapod_command_test.sh`: nine at the library level covering every row of the prune rule plus the missing-directory and removal-failure paths, and six at the command level covering both the success and the chezmoi-failure branches of `tpod apply`.
- Recorded ADR 0014 and amended two `CONTEXT.md` invariants that otherwise read as forbidding the new behavior.
- Committed the design spec and implementation plan under `docs/superpowers/`.

## Background

Every marker lookup iterates the known-category allowlist rather than the directory:

```sh
terrapod_install_warning_list() {
  for category in $(terrapod_install_warning_categories); do
    if terrapod_install_warning_existing_path "$category" >/dev/null; then
      printf '%s\n' "$category"
    fi
  done
}
```

So retiring a category makes its marker invisible to `tpod status`, `tpod doctor`, and every clearing path at the same moment. The file becomes unreachable by any code path and survives every future apply. ADR 0012 retired `managed-package-migration` in #137; the marker written by #135 is still sitting on the configured workstation while both commands report the directory as empty, which is what sent me down a false trail during an unrelated verification.

The issue proposed two mechanisms and asked for a deliberate choice. A list of retired names was rejected: it requires a person to remember a second edit at retirement time, and forgetting exactly that edit is what produced the issue. A mechanism whose correctness depends on remembering the step that was already forgotten is not a fix. Pruning unrecognized names needs no bookkeeping, and it subsumes the issue's first request — the known orphan needs no special-case code because the general rule covers it. Its cost is a real constraint, recorded in ADR 0014: the marker directory is Terrapod-owned, so no future feature may stage a marker file under a name that is not yet a category.

Two live filenames sit outside the category list and would have been destroyed by a naive rule. `terrapod_install_warning_legacy_path()` still resolves `optional-ai-cli-tools` to the older `ai-cli-tools`, and both `_read()` and `_value()` still read it. And `terrapod_install_warning_write()` stages atomic writes through `mktemp "$marker_dir/.$category.XXXXXX"`, so dot-prefixed files appear in the same directory while a write is in flight. Legacy aliases are therefore derived from the existing mapping rather than restated, and staging files are protected by POSIX glob semantics — `"$marker_dir"/*` does not match a leading dot. Both are pinned by tests, including a round-trip proving `ai-cli-tools` is still resolvable through `terrapod_install_warning_list()` after a prune, not merely present on disk.

The `is_category` change is not incidental cleanup. `terrapod_install_warning_write()` validated against that `case` statement while the prune's recognized-name set came from the list function. Adding a category to one and not the other used to mean the marker was invisible; with the prune in place it means `_write` accepts the marker, writes it, and the next `tpod apply` deletes it. This change converted a visibility bug into a data-deletion bug, so closing it belongs here. A cross-check test is not sufficient — it can only catch a name present in the list and missing from the `case`, while the dangerous direction is the reverse, which cannot be enumerated from outside the function.

The derivation is a POSIX loop rather than `grep -Fx`, because `tpod status` and `tpod doctor` run under a fully isolated test PATH that symlinks an explicit binary allowlist with no `/usr/bin` fallback. The old `case` needed no external binary; a `grep`-based replacement exits 127 there. The loop variable is `known_category` rather than `category` for a related reason: with no `local` in POSIX sh, `terrapod_install_warning_path()` and `terrapod_install_warning_write()` both assign the global `category="$1"` and re-read it in their failure-path error messages after calling `is_category`, so a loop named `category` would exhaust to `jetendard-settings` on any rejection and corrupt both messages.

Deletion runs on an apply path, not in `status` or `doctor`, because those are read-only for markers. It runs before the delegation rather than after because pruning does not depend on apply succeeding and the `chezmoi apply` failure branch returns early; a test on that branch pins the ordering. A prune failure prints a warning and leaves the exit status alone, matching the existing invariant that apply's exit status reflects the declared-state apply itself.

## User Impact

Machines carrying a retired marker have it removed on their next `tpod apply`, with one line naming what was removed. After that the state directory and the `status` / `doctor` output agree again. Machines with a clean marker directory see no change — the prune prints nothing when it removes nothing, and is a no-op when the directory does not exist, which is the first-run path.

Retiring a future category now requires only removing its name from `terrapod_install_warning_categories()`.

## Verification

- Six shell suites at HEAD, all exit 0: `terrapod_command_test.sh` 498 assertions, `terrapod_installer_test.sh` 353, `terrapod_config_test.sh` 385, `chezmoiignore_test.sh` 272, `readme_korean_test.sh` 50, `shell_integrations_test.sh` 45. Baseline before the branch was 483 on `terrapod_command_test.sh`.
- TDD on both implementation tasks: tests added first and observed failing, then the implementation, then observed passing.
- The ordering decision was verified by regression rather than by inspection — moving `prune_retired_install_warnings` to after `run_chezmoi_command apply` makes the failure-path test fail with `not ok - Terrapod apply prunes retired install warning markers even when delegated chezmoi apply fails`.
- Adversarial checks on the delete path found no way to destroy reachable state: filenames containing whitespace, glob metacharacters, and a literal `*` are all removed and reported correctly with no word-splitting or re-globbing; a symlink under an unrecognized name has the link removed and its target left intact; a dangling symlink is kept; a marker directory under an unusual `XDG_STATE_HOME` cannot aim the prune outside `<state>/terrapod/install-warnings`.
- Concurrency was checked across all seven `.chezmoiscripts` writers. Every one goes through `terrapod_install_warning_write()`, which stages under a dot-prefixed `mktemp` name and `mv`s to a name that is always a valid category, so there is no window in which a live marker exists under a prunable name. The prune also runs before `chezmoi apply`, so the installer scripts that write markers run strictly after it.
- Failure handling was exercised against a `chmod 555` marker directory under `set -eu`: the warning prints, the function returns 0, and execution continues past the call.
- End to end against a scratch `XDG_STATE_HOME`: `managed-package-migration` removed and reported; `ai-cli-tools`, `homebrew-core`, and `.homebrew-core.aB3xY9` kept; `terrapod_install_warning_list` still resolves both `homebrew-core` and `optional-ai-cli-tools` afterward.
- `tests/homebrew_ubuntu_smoke.sh` requires Docker and was not run.

Not addressed here: `validate_managed_target` at `dot_local/bin/executable_terrapod:1449` has the same missing `--` on a `grep -Fx` that this branch fixed in the prune. It is pre-existing code this branch does not otherwise touch, and its pattern is a chezmoi managed-target path rather than a filename, so it is not reachable the same way.

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)
