### PR TITLE
Take back the c shortcut from the SCM Breeze repo index

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -67,6 +67,8 @@ alias ..="cd .."
 alias ...="cd ../.."
 alias zj="zellij"
 
+unalias c 2>/dev/null
+
 function c() {
   clear
   if command -v fastfetch &>/dev/null; then

--- a/tests/zshrc_clear_test.zsh
+++ b/tests/zshrc_clear_test.zsh
@@ -42,7 +42,15 @@ render_zshrc() {
     >"$tmp_dir/home/.zshrc"
 }
 
-mkdir -p "$tmp_dir/bin" "$tmp_dir/clear-only-bin" "$tmp_dir/home"
+mkdir -p "$tmp_dir/bin" "$tmp_dir/clear-only-bin" "$tmp_dir/home" "$tmp_dir/home/.scm_breeze"
+
+cat >"$tmp_dir/home/.scm_breeze/scm_breeze.sh" <<'STUB'
+function git_index() {
+  print "git_index" >>"$CLEAR_TEST_LOG"
+}
+
+alias c=git_index
+STUB
 
 cat >"$tmp_dir/bin/clear" <<'STUB'
 #!/bin/sh
@@ -62,8 +70,9 @@ chezmoi_bin="$(command -v chezmoi)" || fail "chezmoi is required to render templ
 
 export HOME="$tmp_dir/home"
 export PATH="$tmp_dir/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-export CLAUDECODE=1
 export CLEAR_TEST_LOG="$tmp_dir/clear.log"
+# Empty rather than unset: .zshrc reads $CLAUDECODE and this test runs under set -u.
+export CLAUDECODE=""
 
 : >"$tmp_dir/chezmoi.toml"
 : >"$CLEAR_TEST_LOG"
@@ -110,3 +119,23 @@ if command grep -F "fastfetch" "$CLEAR_TEST_LOG" >/dev/null 2>&1; then
 fi
 
 pass "c skips system information when fastfetch is unavailable"
+
+if alias c >/dev/null 2>&1; then
+  fail "the SCM Breeze repo index alias should not shadow the clear helper"
+fi
+
+pass "the SCM Breeze repo index alias does not shadow the clear helper"
+
+: >"$CLEAR_TEST_LOG"
+c
+if command grep -F "git_index" "$CLEAR_TEST_LOG" >/dev/null 2>&1; then
+  fail "c should not fall through to the SCM Breeze repo index"
+fi
+
+pass "c does not fall through to the SCM Breeze repo index"
+
+if ! whence -w git_index >/dev/null 2>&1; then
+  fail "SCM Breeze should keep its repo index under its full command name"
+fi
+
+pass "SCM Breeze keeps its repo index under its full command name"


### PR DESCRIPTION
Follow-up to #146, which shipped a `c` shortcut that never ran on a real machine.

## Changes

- Added `unalias c 2>/dev/null` before the `c()` definition in `dot_zshrc.tmpl`, matching the existing `unalias zi` guard that keeps zoxide's function reachable.
- Extended `tests/zshrc_clear_test.zsh` with an SCM Breeze stub that defines `alias c=git_index`, and dropped the `CLAUDECODE=1` export that made the rendered `.zshrc` skip SCM Breeze entirely. The test now asserts that no `c` alias survives, that `c` never reaches `git_index`, and that `git_index` remains callable by its full name.

## Background

SCM Breeze's installer writes `git_index_alias="c"` into `~/.git.scmbrc`, so every Terrapod machine gets `alias c=git_index` when `.zshrc` sources SCM Breeze. Zsh resolves aliases before functions, so the shortcut ran `git_index` and failed with `no such file or directory: ~/code` on machines without a `$GIT_REPO_DIR`.

The test added in #146 exported `CLAUDECODE=1`, which takes the branch that skips SCM Breeze, so the collision never appeared. SCM Breeze's repo index stays available as `git_index`, and can be rebound to another letter through `git_index_alias`.

## Testing

- `zsh tests/zshrc_clear_test.zsh` fails at the first assertion without the `unalias`, and passes with it.
- Every test file under `tests/` passes (`tests/homebrew_ubuntu_smoke.sh` needs Docker and was not run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)