### PR TITLE
Scope the Optional AI Tool Stack to macOS

### DIFF
--- a/.chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl
+++ b/.chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl
@@ -31,7 +31,7 @@ clear_install_warning() {
   fi
 }
 
-{{ if not (or (default false (get . "enableAiCliTools")) (default false (get . "enableDevelopmentWorkspace"))) }}
+{{ if not (and (eq .chezmoi.os "darwin") (or (default false (get . "enableAiCliTools")) (default false (get . "enableDevelopmentWorkspace")))) }}
 clear_install_warning "$AI_CLI_WARNING_CATEGORY"
 exit 0
 {{ else }}

--- a/Brewfile.ai-cli-tools.tmpl
+++ b/Brewfile.ai-cli-tools.tmpl
@@ -1,4 +1,4 @@
-{{- if or (default false (get . "enableAiCliTools")) (default false (get . "enableDevelopmentWorkspace")) -}}
+{{- if and (eq .chezmoi.os "darwin") (or (default false (get . "enableAiCliTools")) (default false (get . "enableDevelopmentWorkspace"))) -}}
 cask "antigravity-cli"
 cask "claude-code"
 cask "codex"

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,8 +29,8 @@ The opt-in rich editor configuration that is excluded from every machine profile
 _Avoid_: core shell editor, mandatory editor config, default LazyVim setup
 
 **Optional AI Tool Stack**:
-The opt-in command-line AI tools that may be installed on selected development machines.
-_Avoid_: core shell tools, mandatory AI tools
+The opt-in command-line AI tools that may be installed on selected **macOS Terminal Profile** development machines.
+_Avoid_: core shell tools, mandatory AI tools, cross-profile AI tools
 
 **Optional Development Workspace**:
 The opt-in full development stack bundle for machines that need rich editor configuration, AI tools, and an integrated terminal workspace together.
@@ -179,9 +179,10 @@ _Avoid_: separate Korean introduction, independent README, self-labeled translat
 - pnpm belongs to the **Development Runtime Stack** through Node.js Corepack, not as a mise-managed tool.
 - Rich Neovim configuration belongs to the **Optional Editor Stack**, not the **Core Shell Stack**, and is opt-in for every machine profile.
 - Antigravity CLI, Claude Code, and Codex belong to the **Optional AI Tool Stack**, not the **Core Shell Stack**.
-- The **Optional AI Tool Stack** installs Homebrew casks `antigravity-cli`, `claude-code`, and `codex` on both supported machine profiles.
-- `Brewfile.ai-cli-tools.tmpl` is the canonical cross-profile declaration for Optional AI Tool Stack packages.
-- The **Modern CLI Provider** installs the 20 mandatory formulae declared in `Brewfile` on both supported profiles and owns the three Optional AI Tool Stack casks when that stack is enabled.
+- The **Optional AI Tool Stack** installs Homebrew casks `antigravity-cli`, `claude-code`, and `codex` on the **macOS Terminal Profile** only; Homebrew publishes those three as casks, which Linux Homebrew does not install.
+- The **Optional AI Tool Stack** is not applicable on the **VPS Shell Profile**. Terrapod Setup does not offer it there, the development **Preset** writes it disabled there, and `tpod status` and `tpod doctor` report it as not applicable rather than missing.
+- `Brewfile.ai-cli-tools.tmpl` is the canonical declaration for Optional AI Tool Stack packages and renders empty outside the **macOS Terminal Profile**.
+- The **Modern CLI Provider** installs the 20 mandatory formulae declared in `Brewfile` on both supported profiles and owns the three Optional AI Tool Stack casks on macOS when that stack is enabled.
 - The **VPS Shell Profile** installs Homebrew at `/home/linuxbrew/.linuxbrew` for every **Preset** on supported `x86_64` and `aarch64` systems.
 - The **VPS Shell Profile** supports one non-root management user with initial sudo access; it does not manage multi-user Homebrew prefix ownership.
 - The recommended **VPS Shell Profile** floor is 1 vCPU, 1 GiB RAM, and 3 GiB free disk, with 2 GiB RAM comfortable; the installer warns below 3 GiB but does not make this recommendation a hard gate.
@@ -190,11 +191,11 @@ _Avoid_: separate Korean introduction, independent README, self-labeled translat
 - **Optional AI Tool Stack** installer failures do not block first-run declared-state apply; missing optional AI tools are reported by `tpod status` and `tpod doctor`.
 - Homebrew bundle apply uses `HOMEBREW_NO_AUTO_UPDATE=1 brew bundle --no-upgrade`; Terrapod apply restores missing declared packages without auto-updating or upgrading.
 - `tpod apply`, `tpod status`, and `tpod doctor` compare active command-bearing declarations with canonical provider installation and executable paths.
-- When the **Optional AI Tool Stack** is disabled, `tpod apply` clears the optional AI CLI tools warning marker because those tools are no longer part of desired machine readiness.
+- When the **Optional AI Tool Stack** is disabled or not applicable for the machine profile, `tpod apply` clears the optional AI CLI tools warning marker because those tools are no longer part of desired machine readiness.
 - Existing alternate-provider payloads remain user-managed and are never removed by Terrapod.
 - Enabling only the **Optional AI Tool Stack** does not imply the **Optional Editor Stack** or **Optional Development Workspace**.
 - Development-specific terminal layouts belong to the **Optional Development Workspace**, not the **Core Shell Stack**.
-- Enabling the **Optional Development Workspace** also enables the **Optional Editor Stack** and **Optional AI Tool Stack**.
+- Enabling the **Optional Development Workspace** also enables the **Optional Editor Stack**, and the **Optional AI Tool Stack** where that stack is applicable.
 - The **Optional Development Workspace** is a stack bundle that takes precedence over disabled optional stack flags.
 - Zellij and its general launcher alias belong to the **Core Shell Stack**, while development-specific Zellij layouts and aliases belong to the **Optional Development Workspace**.
 - Disabling an optional stack excludes its files from management but does not remove files already present on a machine.

--- a/README.ko.md
+++ b/README.ko.md
@@ -50,7 +50,7 @@ tpod update
 
 - macOS terminal workstation과 Ubuntu 24.04 VPS를 위한 machine profile.
 - 구체적인 machine-local setting으로 펼쳐지는 Preset.
-- 풍부한 editor configuration, AI CLI tools, development workspace surface를 위한 optional stack.
+- 풍부한 editor configuration, macOS 전용 AI CLI tools, development workspace surface를 위한 optional stack.
 - 선택한 desktop tool을 묶는 macOS App Group.
 
 ## Choose a Preset
@@ -62,7 +62,7 @@ initial apply 전에 확정할 수 있습니다.
 | Preset | 적합한 용도 | 구성 |
 | --- | --- | --- |
 | `minimal` | 작은 VPS, 깨끗한 shell, recovery install | Core shell과 runtime baseline만 |
-| `development` | active coding에 쓰는 machine | Optional Editor Stack, Optional AI Tool Stack, Optional Development Workspace |
+| `development` | active coding에 쓰는 machine | Optional Editor Stack, Optional Development Workspace, 그리고 macOS에서는 Optional AI Tool Stack |
 | `workstation` | 개인 macOS workstation | Development setup에 모든 macOS App Group 추가 |
 
 Setup은 확인을 받은 뒤 구체적인 machine-local settings를 씁니다. Preset은
@@ -199,11 +199,14 @@ Ubuntu에서는 initial apply가 VPS shell profile을 위한 setup script를 실
 - mise를 통한 Bun, Node.js 24, Python 3.13, uv/uvx
 - Node.js Corepack을 통한 pnpm
 - login shell을 zsh로 전환
-- 해당 stack이 활성화된 경우 Homebrew를 통한 Optional AI Tool Stack cask
 
 VPS Shell Profile은 headless입니다. macOS App Group과 다른 GUI application은 optional
-macOS Desktop App Stack에만 속하며 Ubuntu에는 설치되지 않습니다. VPS에서 write
-access가 나중에 필요할 때만 GitHub authentication을 설정하세요.
+macOS Desktop App Stack에만 속하며 Ubuntu에는 설치되지 않습니다. Optional AI Tool Stack도
+macOS 전용입니다. Homebrew가 Antigravity CLI, Claude Code, Codex를 cask로 배포하는데
+Linux Homebrew는 cask를 설치하지 않기 때문입니다. VPS에서는 setup이 이 stack을 묻지 않고,
+`development` Preset도 비활성 상태로 기록하며, `tpod status`와 `tpod doctor`는 not
+applicable로 보고합니다. VPS에서 write access가 나중에 필요할 때만 GitHub
+authentication을 설정하세요.
 
 login shell이 자동으로 바뀌지 않았다면 first apply 이후 직접 전환하고 다시 접속합니다.
 
@@ -215,8 +218,8 @@ bootstrap 이후의 일반 관리는 Terrapod이 처리합니다. 특이한 reco
 
 ### Intentional Upgrades
 
-Homebrew는 양쪽 profile의 shared user-facing CLI tool과 enabled Optional AI Tool Stack을
-담당합니다. APT는 Ubuntu system 및 bootstrap prerequisite만 담당하고, mise는
+Homebrew는 양쪽 profile의 shared user-facing CLI tool을 담당하고, macOS에서는 enabled
+Optional AI Tool Stack도 담당합니다. APT는 Ubuntu system 및 bootstrap prerequisite만 담당하고, mise는
 Development Runtime Stack만 담당합니다.
 
 `tpod apply`는 `HOMEBREW_NO_AUTO_UPDATE=1 brew bundle --no-upgrade`로 누락된 Homebrew
@@ -288,8 +291,8 @@ Optional stack profile과 macOS App Group setting은 기본적으로 disabled입
 | --- | --- | --- |
 | `profile` | setup/configure가 감지 | 활성 Terrapod machine profile을 기록합니다. |
 | `enableEditorStack` | `false` | rich Neovim configuration을 관리하는 Optional Editor Stack을 활성화합니다. Plain Neovim은 어느 쪽이든 Core Shell Stack에 남아 있습니다. |
-| `enableAiCliTools` | `false` | Homebrew cask `antigravity-cli`, `claude-code`, `codex`를 통해 Antigravity CLI, Claude Code, Codex를 설치합니다. |
-| `enableDevelopmentWorkspace` | `false` | Optional Editor Stack, Optional AI Tool Stack, development-specific Zellij workspace surface를 포함하는 Optional Development Workspace preset을 활성화합니다. |
+| `enableAiCliTools` | `false` | Homebrew cask `antigravity-cli`, `claude-code`, `codex`를 통해 Antigravity CLI, Claude Code, Codex를 설치합니다. macOS Terminal Profile 전용이며 VPS Shell Profile에서는 무시됩니다. |
+| `enableDevelopmentWorkspace` | `false` | Optional Editor Stack, 적용 가능한 경우의 Optional AI Tool Stack, development-specific Zellij workspace surface를 포함하는 Optional Development Workspace preset을 활성화합니다. |
 | `enableMacosAppGroupTerminalApps` | `false` | terminal-apps macOS App Group에 포함된 Ghostty를 설치합니다. |
 | `enableMacosAppGroupAutomation` | `false` | automation macOS App Group인 Hammerspoon, Karabiner-Elements, Scroll Reverser를 설치합니다. |
 | `enableMacosAppGroupLauncher` | `false` | launcher macOS App Group인 Raycast와 1Password CLI를 설치합니다. |
@@ -297,7 +300,7 @@ Optional stack profile과 macOS App Group setting은 기본적으로 disabled입
 | `enableMacosAppGroupDevelopmentApps` | `false` | development-apps macOS App Group인 Zed, Orca ADE(`stablyai/orca/orca`), OrbStack을 설치합니다. |
 | `enableMacosAppGroupMobileDev` | `false` | mobile-dev macOS App Group인 Android Studio와 Maestro(`mobile-dev-inc/tap/maestro`)를 설치합니다. `ANDROID_HOME`과 `JAVA_HOME`도 함께 설정합니다. |
 
-`enableDevelopmentWorkspace`가 `true`이면 `enableEditorStack`이나 `enableAiCliTools`가 false로 기록되어 있어도 Optional Editor Stack과 Optional AI Tool Stack이 함께 활성화됩니다.
+`enableDevelopmentWorkspace`가 `true`이면 `enableEditorStack`이나 `enableAiCliTools`가 false로 기록되어 있어도 Optional Editor Stack과 Optional AI Tool Stack이 함께 활성화됩니다. 다만 VPS Shell Profile에서는 Optional AI Tool Stack이 macOS 전용이므로 이 묶음에서 빠집니다.
 
 macOS Desktop App Stack installation은 `enableDevelopmentWorkspace`와 분리되어 있습니다. desktop cask가 한 사용자의 home directory 밖에 있는 shared application에 영향을 줄 수 있기 때문입니다.
 
@@ -344,7 +347,7 @@ Editor-only machine:
 enableEditorStack = true
 ```
 
-AI-only machine:
+AI-only machine (macOS Terminal Profile 전용):
 
 ```toml
 enableAiCliTools = true

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ tpod update
 
 - Machine profiles for a macOS terminal workstation and an Ubuntu 24.04 VPS.
 - Presets that unfold into concrete machine-local settings.
-- Optional stacks for rich editor configuration, AI CLI tools, and development workspace surfaces.
+- Optional stacks for rich editor configuration, macOS-only AI CLI tools, and development workspace surfaces.
 - macOS App Groups for selected desktop tools.
 
 ## Choose a Preset
@@ -63,7 +63,7 @@ those settings before the initial apply.
 | Preset | Best for | Shape |
 | --- | --- | --- |
 | `minimal` | Small VPSs, clean shells, and recovery installs | Core shell and runtime baseline only |
-| `development` | Machines used for active coding | Optional Editor Stack, Optional AI Tool Stack, and Optional Development Workspace |
+| `development` | Machines used for active coding | Optional Editor Stack, Optional Development Workspace, and, on macOS, the Optional AI Tool Stack |
 | `workstation` | Personal macOS workstations | Development setup plus every macOS App Group |
 
 Setup writes the concrete machine-local settings after you confirm them. A
@@ -207,10 +207,14 @@ On Ubuntu, the initial apply runs setup scripts for the VPS shell profile:
 - Bun, Node.js 24, Python 3.13, and uv/uvx through mise
 - pnpm through Node.js Corepack
 - Login shell switch to zsh
-- Optional AI Tool Stack casks through Homebrew when that stack is enabled
 
 The VPS Shell Profile is headless: macOS App Groups and other GUI applications
 remain in the optional macOS Desktop App Stack and are never installed on Ubuntu.
+The Optional AI Tool Stack is also macOS-only, because Homebrew publishes
+Antigravity CLI, Claude Code, and Codex as casks and Homebrew on Linux does not
+install casks. Setup does not offer the stack on a VPS, the `development` Preset
+writes it disabled there, and `tpod status` and `tpod doctor` report it as not
+applicable.
 Only configure GitHub authentication on a VPS if write access is needed later.
 
 If the login shell could not be changed automatically, switch it after the first apply and reconnect.
@@ -226,8 +230,8 @@ result.
 
 ### Intentional Upgrades
 
-Homebrew owns shared user-facing CLI tools and the enabled Optional AI Tool
-Stack on both profiles. APT owns only Ubuntu system and bootstrap prerequisites.
+Homebrew owns shared user-facing CLI tools on both profiles and the enabled
+Optional AI Tool Stack on macOS. APT owns only Ubuntu system and bootstrap prerequisites.
 mise owns only the Development Runtime Stack.
 
 `tpod apply` restores missing Homebrew packages with
@@ -309,8 +313,8 @@ Optional stack profiles and macOS App Group settings are disabled by default.
 | --- | --- | --- |
 | `profile` | Detected by setup/configure | Records the active Terrapod machine profile. |
 | `enableEditorStack` | `false` | Enables the Optional Editor Stack, which manages the rich Neovim configuration. Plain Neovim remains in the Core Shell Stack either way. |
-| `enableAiCliTools` | `false` | Installs Antigravity CLI, Claude Code, and Codex through Homebrew casks `antigravity-cli`, `claude-code`, and `codex`. |
-| `enableDevelopmentWorkspace` | `false` | Enables the Optional Development Workspace preset, including the Optional Editor Stack, Optional AI Tool Stack, and development-specific Zellij workspace surfaces. |
+| `enableAiCliTools` | `false` | Installs Antigravity CLI, Claude Code, and Codex through Homebrew casks `antigravity-cli`, `claude-code`, and `codex`. macOS Terminal Profile only; ignored on the VPS Shell Profile. |
+| `enableDevelopmentWorkspace` | `false` | Enables the Optional Development Workspace preset, including the Optional Editor Stack, the Optional AI Tool Stack where it applies, and development-specific Zellij workspace surfaces. |
 | `enableMacosAppGroupTerminalApps` | `false` | Installs the terminal-apps macOS App Group: Ghostty. |
 | `enableMacosAppGroupAutomation` | `false` | Installs the automation macOS App Group: Hammerspoon, Karabiner-Elements, and Scroll Reverser. |
 | `enableMacosAppGroupLauncher` | `false` | Installs the launcher macOS App Group: Raycast and 1Password CLI. |
@@ -319,7 +323,8 @@ Optional stack profiles and macOS App Group settings are disabled by default.
 | `enableMacosAppGroupMobileDev` | `false` | Installs the mobile-dev macOS App Group: Android Studio and Maestro (`mobile-dev-inc/tap/maestro`). It also sets `ANDROID_HOME` and `JAVA_HOME`. |
 
 When `enableDevelopmentWorkspace` is `true`, it enables both the Optional Editor Stack and Optional AI Tool Stack
-even when `enableEditorStack` or `enableAiCliTools` are recorded as false.
+even when `enableEditorStack` or `enableAiCliTools` are recorded as false. On the VPS Shell Profile the Optional
+AI Tool Stack stays out of that bundle, because it is a macOS-only stack.
 
 macOS Desktop App Stack installation remains separate from `enableDevelopmentWorkspace`
 because desktop casks can affect shared applications outside one user's home directory.
@@ -371,7 +376,7 @@ Editor-only machine:
 enableEditorStack = true
 ```
 
-AI-only machine:
+AI-only machine (macOS Terminal Profile only):
 
 ```toml
 enableAiCliTools = true

--- a/docs/adr/0015-scope-the-optional-ai-tool-stack-to-macos.md
+++ b/docs/adr/0015-scope-the-optional-ai-tool-stack-to-macos.md
@@ -1,0 +1,51 @@
+# Scope the Optional AI Tool Stack to macOS
+
+The **Optional AI Tool Stack** installs Antigravity CLI, Claude Code, and Codex
+only on the **macOS Terminal Profile**. On the **VPS Shell Profile** the stack is
+not applicable: Terrapod Setup does not offer it, the `development` **Preset**
+writes it disabled, `Brewfile.ai-cli-tools.tmpl` renders empty, and the installer
+script only clears a stale `optional-ai-cli-tools` warning marker.
+
+This decision supersedes ADR 0008's claim that the stack installs "from the same
+Homebrew casks on the macOS Terminal Profile and VPS Shell Profile" and its
+consequence that Ubuntu bootstraps Homebrew only when the stack is enabled. ADR
+0010 already made standard-prefix Homebrew mandatory on both profiles, so the
+Optional AI Tool Stack no longer governs Linux Homebrew at all. ADR 0008's choice
+of Homebrew over vendor installers stays in force for macOS.
+
+Homebrew publishes `antigravity-cli`, `claude-code`, and `codex` as casks with no
+formula counterpart, and Homebrew on Linux does not install casks. Handing that
+manifest to `brew bundle` on Ubuntu failed on every apply, permanently recorded an
+`optional-ai-cli-tools` install warning, and kept `tpod doctor` failing.
+
+## Considered Options
+
+- Add a Linux install path through vendor installers or npm: rejected because it
+  reintroduces the split installation, recovery, and upgrade behavior that ADR
+  0008 removed, for three tools whose Linux demand is unproven.
+- Block the `development` **Preset** on the **VPS Shell Profile**: rejected
+  because it would also remove the **Optional Editor Stack** and **Optional
+  Development Workspace**, which work there.
+- Reject `enableAiCliTools = true` on the **VPS Shell Profile** as a
+  configuration error: rejected because **Preset**s are the configuration unit
+  and macOS App Groups already establish "silently not applicable" as the
+  profile-mismatch behavior.
+
+## Consequences
+
+- `Brewfile.ai-cli-tools.tmpl` and
+  `.chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl` gate the stack on
+  `.chezmoi.os` being `darwin`.
+- The installer script still renders on Linux so that it clears a stale
+  `optional-ai-cli-tools` marker left by an earlier apply. Marker pruning only
+  removes unrecognized categories, so no other component would clear it.
+- `effective_ai_cli_tools_enabled` reports `false` outside the **macOS Terminal
+  Profile**, which also stops **Optional Development Workspace** from implying
+  the stack there.
+- The `development` **Preset** stays available on the **VPS Shell Profile** and
+  keeps the **Optional Editor Stack** and **Optional Development Workspace**.
+- `tpod status` and `tpod doctor` report the stack as not applicable on the
+  **VPS Shell Profile**; executable selection does not check `agy`, `claude`, or
+  `codex` there.
+- A machine-local `enableAiCliTools = true` on the **VPS Shell Profile** is
+  ignored rather than rejected.

--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -531,7 +531,9 @@ show_setup_option_block() {
       printf '%s\n' "  Dev Zellij layouts."
       printf '%s\n' "  Includes:"
       printf '%s\n' "    - Optional Editor Stack"
-      printf '%s\n' "    - Optional AI Tool Stack"
+      if ai_cli_tools_supported_profile "${setup_profile:-macos-terminal}"; then
+        printf '%s\n' "    - Optional AI Tool Stack"
+      fi
       ;;
     "Optional Editor Stack")
       printf '%s\n' "  Rich Neovim configuration."
@@ -612,6 +614,7 @@ prompt_for_setup_settings() {
   profile="$2"
 
   load_setup_defaults "$preset"
+  setup_profile="$profile"
 
   printf '%s\n' "Customize Terrapod settings." >&2
 
@@ -622,7 +625,14 @@ prompt_for_setup_settings() {
     setup_enableAiCliTools=true
   else
     setup_enableEditorStack="$(prompt_setup_bool "Optional Editor Stack" "$setup_enableEditorStack")"
-    setup_enableAiCliTools="$(prompt_setup_bool "Optional AI Tool Stack" "$setup_enableAiCliTools")"
+    if ai_cli_tools_supported_profile "$profile"; then
+      setup_enableAiCliTools="$(prompt_setup_bool "Optional AI Tool Stack" "$setup_enableAiCliTools")"
+    fi
+  fi
+
+  if ! ai_cli_tools_supported_profile "$profile"; then
+    setup_enableAiCliTools=false
+    printf '%s\n' "Optional AI Tool Stack: not applicable for $(profile_context_label)" >&2
   fi
 
   if [ "$profile" = "macos-terminal" ]; then
@@ -920,8 +930,18 @@ effective_editor_stack_enabled() {
   fi
 }
 
+ai_cli_tools_supported_profile() {
+  [ "$1" = "macos-terminal" ]
+}
+
 effective_ai_cli_tools_enabled() {
   config_file="$1"
+  profile="$2"
+
+  if ! ai_cli_tools_supported_profile "$profile"; then
+    printf '%s\n' "false"
+    return
+  fi
 
   if [ "$(config_data_bool "$config_file" enableAiCliTools)" = "true" ] ||
     [ "$(config_data_bool "$config_file" enableDevelopmentWorkspace)" = "true" ]; then
@@ -945,7 +965,7 @@ run_executable_selection() {
     "$executable_selection_helper" \
     "$mode" \
     "$profile" \
-    "$(effective_ai_cli_tools_enabled "$config_file")" \
+    "$(effective_ai_cli_tools_enabled "$config_file" "$profile")" \
     "$(config_data_bool "$config_file" enableMacosAppGroupLauncher)"
 }
 
@@ -1271,7 +1291,11 @@ run_status() {
   fi
   print_section "Optional stacks:"
   print_optional_setting_status "Optional Editor Stack" "$(effective_editor_stack_enabled "$config_file")" "rich Neovim configuration"
-  print_stack_status "Optional AI Tool Stack" "$(effective_ai_cli_tools_enabled "$config_file")" agy claude codex
+  if ai_cli_tools_supported_profile "$profile"; then
+    print_stack_status "Optional AI Tool Stack" "$(effective_ai_cli_tools_enabled "$config_file" "$profile")" agy claude codex
+  else
+    print_indented_colon_state_line "Optional AI Tool Stack" "not applicable" "($(profile_context_label))"
+  fi
   print_optional_setting_status "Optional Development Workspace" "$(config_data_bool "$config_file" enableDevelopmentWorkspace)" "development Zellij layouts"
   print_macos_app_group_status "$config_file" "$profile"
   print_key_tool_status "$profile" "$config_file"
@@ -1330,10 +1354,14 @@ show_stack_context() {
 
   print_section "Optional stacks:"
   editor_state="$(effective_optional_stack_state_label "$config_file" enableEditorStack)"
-  ai_state="$(effective_optional_stack_state_label "$config_file" enableAiCliTools)"
   workspace_state="$(config_bool_state_label "$config_file" enableDevelopmentWorkspace)"
   print_named_state_line "Optional Editor Stack" "$editor_state"
-  print_named_state_line "Optional AI Tool Stack" "$ai_state"
+  if ai_cli_tools_supported_profile "$profile"; then
+    ai_state="$(effective_optional_stack_state_label "$config_file" enableAiCliTools)"
+    print_named_state_line "Optional AI Tool Stack" "$ai_state"
+  else
+    print_colon_state_line "Optional AI Tool Stack" "not applicable" "($(profile_context_label))"
+  fi
   print_named_state_line "Optional Development Workspace" "$workspace_state"
 
   if [ "$profile" != "macos-terminal" ]; then
@@ -1739,10 +1767,14 @@ run_doctor() {
     "$(effective_editor_stack_enabled "$config_file")" \
     "rich Neovim configuration"
 
-  doctor_check_optional_setting \
-    "Optional AI Tool Stack" \
-    "$(effective_ai_cli_tools_enabled "$config_file")" \
-    "Antigravity CLI, Claude Code, and Codex"
+  if ai_cli_tools_supported_profile "$profile"; then
+    doctor_check_optional_setting \
+      "Optional AI Tool Stack" \
+      "$(effective_ai_cli_tools_enabled "$config_file" "$profile")" \
+      "Antigravity CLI, Claude Code, and Codex"
+  else
+    doctor_ok "Optional AI Tool Stack is not applicable for $(profile_context_label)"
+  fi
 
   doctor_check_optional_setting \
     "Optional Development Workspace" \
@@ -1849,7 +1881,11 @@ render_preset_data() {
       render_settings_data "$profile" false false false false false false false false false
       ;;
     development)
-      render_settings_data "$profile" true true true false false false false false false
+      if ai_cli_tools_supported_profile "$profile"; then
+        render_settings_data "$profile" true true true false false false false false false
+      else
+        render_settings_data "$profile" true false true false false false false false false
+      fi
       ;;
     workstation)
       render_settings_data "$profile" true true true true true true true true true

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -1816,19 +1816,27 @@ disabled_ai_cli_tools_cleanup="$(render_template "$ubuntu_data" ".chezmoiscripts
 ai_cli_tools_brewfile="$(render_template "$ai_cli_tools_data" "Brewfile.ai-cli-tools.tmpl")"
 development_workspace_ai_brewfile="$(render_template "$development_workspace_data" "Brewfile.ai-cli-tools.tmpl")"
 disabled_ai_cli_tools_brewfile="$(render_template "$ubuntu_data" "Brewfile.ai-cli-tools.tmpl")"
+macos_ai_cli_tools_brewfile="$(render_template "$macos_ai_cli_tools_data" "Brewfile.ai-cli-tools.tmpl")"
+macos_development_workspace_ai_brewfile="$(render_template "$macos_development_workspace_data" "Brewfile.ai-cli-tools.tmpl")"
 
 assert_not_contains_text "$ai_cli_tools_installer" "bootstrap_linux_homebrew" "AI installer no longer owns Linuxbrew bootstrap"
 assert_not_contains_text "$ai_cli_tools_installer" "raw.githubusercontent.com/Homebrew/install" "AI installer never downloads Homebrew"
-assert_contains_text "$ai_cli_tools_installer" "/home/linuxbrew/.linuxbrew/bin/brew" "AI installer uses mandatory standard Linuxbrew"
-assert_contains_text "$ai_cli_tools_installer" "HOMEBREW_NO_AUTO_UPDATE=1" "AI bundle disables Homebrew auto-update"
+assert_not_contains_text "$ai_cli_tools_installer" "HOMEBREW_NO_AUTO_UPDATE=1" "Ubuntu AI installer runs no Homebrew bundle"
+assert_not_contains_text "$ai_cli_tools_installer" "install_ai_cli_bundle" "Ubuntu AI installer renders no Homebrew bundle step"
+assert_not_contains_text "$ai_cli_tools_installer" 'cask "claude-code"' "Ubuntu AI installer renders no macOS-only casks"
+assert_contains_text "$ai_cli_tools_installer" 'clear_install_warning "$AI_CLI_WARNING_CATEGORY"' "Ubuntu AI installer only clears stale optional AI CLI markers"
+assert_contains_text "$macos_ai_cli_tools_installer" "/opt/homebrew/bin/brew" "macOS AI installer uses mandatory standard Homebrew"
+assert_contains_text "$macos_ai_cli_tools_installer" "HOMEBREW_NO_AUTO_UPDATE=1" "AI bundle disables Homebrew auto-update"
 assert_contains_text "$macos_terminal_apps_bootstrap" "HOMEBREW_NO_AUTO_UPDATE=1" "desktop bundle disables Homebrew auto-update"
 
-for rendered_brewfile in "$ai_cli_tools_brewfile" "$development_workspace_ai_brewfile"; do
+for rendered_brewfile in "$macos_ai_cli_tools_brewfile" "$macos_development_workspace_ai_brewfile"; do
   assert_contains_text "$rendered_brewfile" 'cask "antigravity-cli"' "Optional AI Tool Stack declares Antigravity CLI cask"
   assert_contains_text "$rendered_brewfile" 'cask "claude-code"' "Optional AI Tool Stack declares Claude Code cask"
   assert_contains_text "$rendered_brewfile" 'cask "codex"' "Optional AI Tool Stack declares Codex CLI cask"
 done
 assert_text_equals "$disabled_ai_cli_tools_brewfile" "" "disabled Optional AI Tool Stack renders no Homebrew casks"
+assert_text_equals "$ai_cli_tools_brewfile" "" "Ubuntu Optional AI Tool Stack renders no Homebrew casks"
+assert_text_equals "$development_workspace_ai_brewfile" "" "Ubuntu Optional Development Workspace renders no AI Homebrew casks"
 
 assert_contains_text "$disabled_ai_cli_tools_cleanup" "AI_CLI_WARNING_CATEGORY=optional-ai-cli-tools" "disabled Optional AI Tool Stack renders optional AI CLI warning category"
 assert_contains_text "$disabled_ai_cli_tools_cleanup" 'clear_install_warning "$AI_CLI_WARNING_CATEGORY"' "disabled Optional AI Tool Stack renders stale marker cleanup"
@@ -1960,11 +1968,20 @@ write_stub "$linux_ai_brew_bin/uname" \
   '  -m) printf "%s\n" x86_64 ;;' \
   '  *) printf "%s\n" Linux ;;' \
   'esac'
+HOME="$linux_ai_brew_home" XDG_STATE_HOME="$linux_ai_brew_state" sh -c \
+  '. "$1"; terrapod_install_warning_write optional-ai-cli-tools "Optional AI CLI tool install needs attention" "Rerun tpod apply after network access is restored."' \
+  sh "$repo_root/dot_local/lib/terrapod/install-warnings.sh"
 HOME="$linux_ai_brew_home" XDG_STATE_HOME="$linux_ai_brew_state" \
   AI_BREW_BIN="$linux_ai_brew_bin" AI_BREW_LOG="$linux_ai_brew_log" AI_BREW_FAIL=0 \
   PATH="$linux_ai_brew_bin:/usr/bin:/bin" sh "$ai_cli_tools_installer_script"
-assert_contains_text "$(cat "$linux_ai_brew_log")" "brew args:bundle --no-upgrade --file=" "Ubuntu Optional AI Tool Stack installs the common no-upgrade bundle"
-assert_contains_text "$(cat "$linux_ai_brew_log")" "brew auto-update:1" "Ubuntu Optional AI Tool Stack disables Homebrew auto-update"
+if [ -e "$linux_ai_brew_log" ]; then
+  fail "Ubuntu Optional AI Tool Stack should never run Homebrew"
+fi
+pass "Ubuntu Optional AI Tool Stack never runs Homebrew"
+if [ -e "$linux_ai_brew_state/terrapod/install-warnings/optional-ai-cli-tools" ]; then
+  fail "Ubuntu Optional AI Tool Stack should clear stale optional-ai-cli-tools markers"
+fi
+pass "Ubuntu Optional AI Tool Stack clears stale optional AI CLI markers"
 
 ai_cli_failure_state="$tmp_dir/ai-cli-failure-state"
 ai_cli_failure_home="$tmp_dir/ai-cli-failure-home"

--- a/tests/homebrew_manifests_test.sh
+++ b/tests/homebrew_manifests_test.sh
@@ -51,6 +51,35 @@ if ! cmp -s "$tmp_dir/expected-record-formulae" "$tmp_dir/record-formulae"; then
 fi
 pass "doctor command ownership records stay synchronized with Brewfile"
 
+expected_ai_casks="$tmp_dir/expected-ai-casks"
+actual_ai_casks="$tmp_dir/actual-ai-casks"
+printf '%s\n' \
+  'cask "antigravity-cli"' \
+  'cask "claude-code"' \
+  'cask "codex"' >"$expected_ai_casks"
+
+chezmoi execute-template \
+  --source "$repo_root" \
+  --override-data '{"chezmoi":{"os":"darwin"},"enableAiCliTools":true}' \
+  --file "$repo_root/Brewfile.ai-cli-tools.tmpl" >"$actual_ai_casks"
+printf '\n' >>"$actual_ai_casks"
+if ! cmp -s "$expected_ai_casks" "$actual_ai_casks"; then
+  diff -u "$expected_ai_casks" "$actual_ai_casks" >&2 || true
+  fail "Optional AI Tool Stack declares exactly the three macOS casks"
+fi
+pass "Optional AI Tool Stack declares exactly the three macOS casks"
+
+linux_ai_casks="$tmp_dir/linux-ai-casks"
+chezmoi execute-template \
+  --source "$repo_root" \
+  --override-data '{"chezmoi":{"os":"linux"},"enableAiCliTools":true,"enableDevelopmentWorkspace":true}' \
+  --file "$repo_root/Brewfile.ai-cli-tools.tmpl" >"$linux_ai_casks"
+if [ -s "$linux_ai_casks" ]; then
+  cat "$linux_ai_casks" >&2
+  fail "Optional AI Tool Stack declares no packages on Linux"
+fi
+pass "Optional AI Tool Stack declares no packages on Linux"
+
 ubuntu_smoke_fixture="$repo_root/tests/fixtures/homebrew-ubuntu-24.04.Dockerfile"
 if ! grep -F 'args: ["force-bottle"]' "$ubuntu_smoke_fixture" >/dev/null ||
    ! grep -F 'brew bundle --no-upgrade --file=/tmp/Brewfile.bottles' "$ubuntu_smoke_fixture" >/dev/null; then

--- a/tests/readme_optional_stack_profiles_test.sh
+++ b/tests/readme_optional_stack_profiles_test.sh
@@ -47,6 +47,21 @@ assert_key_row_contains() {
   pass "$message"
 }
 
+assert_ubuntu_setup_not_contains() {
+  needle="$1"
+  message="$2"
+
+  if awk '
+    /^### Ubuntu 24.04 VPS$/ { in_ubuntu = 1; next }
+    /^### Intentional Upgrades$/ { in_ubuntu = 0 }
+    in_ubuntu { print }
+  ' "$readme" | grep -F "$needle" >/dev/null; then
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
 assert_ubuntu_setup_contains() {
   needle="$1"
   message="$2"
@@ -228,6 +243,12 @@ assert_contains '## Platform Details' \
   "README moves platform inventory into platform details"
 assert_ubuntu_setup_contains 'GitHub CLI (`gh`)' \
   "README documents gh as part of the Ubuntu Core Shell Stack"
+assert_ubuntu_setup_not_contains 'Optional AI Tool Stack casks through Homebrew' \
+  "README does not promise Optional AI Tool Stack casks on Ubuntu"
+assert_ubuntu_setup_contains 'The Optional AI Tool Stack is also macOS-only' \
+  "README explains the Optional AI Tool Stack is macOS-only"
+assert_key_row_contains '`enableAiCliTools`' 'ignored on the VPS Shell Profile' \
+  "README documents that enableAiCliTools is ignored on the VPS Shell Profile"
 assert_contains 'When `enableDevelopmentWorkspace` is `true`' \
   "README documents enableDevelopmentWorkspace behavior"
 assert_contains 'Optional Editor Stack and Optional AI Tool Stack' \

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -1220,9 +1220,9 @@ write_stub "$fake_warning_bin/brew" \
 fake_ai_cli_installer="$tmp_dir/fake-ai-cli-installer.sh"
 chezmoi execute-template \
   --source "$repo_root" \
-  --override-data '{"chezmoi":{"os":"linux","sourceDir":"/missing-terrapod-source"},"enableAiCliTools":true}' \
+  --override-data '{"chezmoi":{"os":"darwin","sourceDir":"/missing-terrapod-source"},"enableAiCliTools":true}' \
   --file "$repo_root/.chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl" \
-  | sed "s#/home/linuxbrew/.linuxbrew/bin/brew#$fake_warning_bin/brew#g" \
+  | sed "s#/opt/homebrew/bin/brew#$fake_warning_bin/brew#g" \
   >"$fake_ai_cli_installer"
 
 if ! HOME="$fake_ai_cli_home" FAKE_INSTALL_WARNING_CALLS="$fake_warning_calls" TERRAPOD_MACHINE_ARCH=aarch64 PATH="$fake_warning_bin:/usr/bin:/bin" /bin/sh "$fake_ai_cli_installer" >"$tmp_dir/fake-ai-cli-installer.out" 2>"$tmp_dir/fake-ai-cli-installer.err"; then
@@ -1246,9 +1246,9 @@ write_stub "$fake_ai_cli_failure_home/.local/bin/brew" \
 fake_ai_cli_failure_installer="$tmp_dir/fake-ai-cli-failure-installer.sh"
 chezmoi execute-template \
   --source "$repo_root" \
-  --override-data '{"chezmoi":{"os":"linux","sourceDir":"/missing-terrapod-source"},"enableAiCliTools":true}' \
+  --override-data '{"chezmoi":{"os":"darwin","sourceDir":"/missing-terrapod-source"},"enableAiCliTools":true}' \
   --file "$repo_root/.chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl" \
-  | sed "s#/home/linuxbrew/.linuxbrew/bin/brew#$fake_ai_cli_failure_home/.local/bin/brew#g" \
+  | sed "s#/opt/homebrew/bin/brew#$fake_ai_cli_failure_home/.local/bin/brew#g" \
   >"$fake_ai_cli_failure_installer"
 
 fake_ai_cli_failure_status=0
@@ -1281,9 +1281,9 @@ write_stub "$fake_ai_cli_write_failure_home/.local/bin/brew" \
 fake_ai_cli_write_failure_installer="$tmp_dir/fake-ai-cli-write-failure-installer.sh"
 chezmoi execute-template \
   --source "$repo_root" \
-  --override-data "{\"chezmoi\":{\"os\":\"linux\",\"sourceDir\":\"$fake_ai_cli_warning_source\"},\"enableAiCliTools\":true}" \
+  --override-data "{\"chezmoi\":{\"os\":\"darwin\",\"sourceDir\":\"$fake_ai_cli_warning_source\"},\"enableAiCliTools\":true}" \
   --file "$repo_root/.chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl" \
-  | sed "s#/home/linuxbrew/.linuxbrew/bin/brew#$fake_ai_cli_write_failure_home/.local/bin/brew#g" \
+  | sed "s#/opt/homebrew/bin/brew#$fake_ai_cli_write_failure_home/.local/bin/brew#g" \
   >"$fake_ai_cli_write_failure_installer"
 
 fake_ai_cli_write_failure_status=0
@@ -2070,7 +2070,7 @@ ubuntu_status_output="$(
 
 assert_contains "$ubuntu_status_output" "Profile: VPS Shell Profile" "Terrapod status reports VPS Shell Profile context on Ubuntu 24.04"
 assert_contains "$ubuntu_status_output" "Optional Editor Stack         : disabled" "Terrapod status reports disabled Optional Editor Stack without treating nvim as missing"
-assert_contains "$ubuntu_status_output" "Optional AI Tool Stack        : disabled" "Terrapod status reports disabled Optional AI Tool Stack without missing-tool warnings"
+assert_contains "$ubuntu_status_output" "Optional AI Tool Stack        : not applicable (VPS Shell Profile)" "Terrapod status reports the Optional AI Tool Stack as not applicable on the VPS Shell Profile"
 assert_contains "$ubuntu_status_output" "Optional Development Workspace: disabled" "Terrapod status reports disabled Optional Development Workspace without missing-tool warnings"
 assert_contains "$ubuntu_status_output" "macOS App Groups: not applicable for VPS Shell Profile" "Terrapod status omits macOS App Group details on VPS Shell Profile"
 assert_contains "$ubuntu_status_output" "apt                           : available" "Terrapod status reports Ubuntu Bootstrap Package Manager availability"
@@ -2288,10 +2288,10 @@ missing_status_output="$(
 )"
 
 assert_contains "$missing_status_output" "Optional Editor Stack         : enabled (rich Neovim configuration)" "Terrapod status reports enabled Optional Editor Stack as rich config state"
-assert_contains "$missing_status_output" "Optional AI Tool Stack        : enabled (missing tools: agy, claude, codex)" "Terrapod status reports missing tools only for enabled Optional AI Tool Stack"
+assert_contains "$missing_status_output" "Optional AI Tool Stack        : not applicable (VPS Shell Profile)" "Terrapod status keeps a requested Optional AI Tool Stack not applicable on the VPS Shell Profile"
 assert_contains "$missing_status_output" "Optional Development Workspace: enabled (development Zellij layouts)" "Terrapod status reports enabled Optional Development Workspace as layout state"
-assert_contains "$missing_status_output" "brew                          : missing" "enabled Ubuntu Optional AI Tool Stack requires Homebrew"
-assert_contains "$missing_status_output" "Warning: missing key tools: brew" "enabled Ubuntu Optional AI Tool Stack warns when Homebrew is missing"
+assert_contains "$missing_status_output" "brew                          : missing" "Ubuntu reports missing mandatory Homebrew"
+assert_contains "$missing_status_output" "Warning: missing key tools: brew" "Ubuntu warns when mandatory Homebrew is missing"
 assert_not_contains "$missing_status_output" "Warning: Optional AI Tool Stack is enabled but missing tools" "Terrapod status avoids duplicate enabled AI tool warnings"
 
 status_shadow_config="$tmp_dir/status-shadow.toml"
@@ -2360,9 +2360,28 @@ workspace_bundle_status_output="$(
 )"
 
 assert_contains "$workspace_bundle_status_output" "Optional Editor Stack         : enabled (rich Neovim configuration)" "Terrapod status treats Optional Development Workspace as enabling Optional Editor Stack"
-assert_contains "$workspace_bundle_status_output" "Optional AI Tool Stack        : enabled (missing tools: agy, claude, codex)" "Terrapod status treats Optional Development Workspace as enabling Optional AI Tool Stack"
+assert_contains "$workspace_bundle_status_output" "Optional AI Tool Stack        : not applicable (VPS Shell Profile)" "Terrapod status keeps the workspace-implied Optional AI Tool Stack not applicable on the VPS Shell Profile"
 assert_contains "$workspace_bundle_status_output" "Optional Development Workspace: enabled (development Zellij layouts)" "Terrapod status reports enabled Optional Development Workspace"
 assert_not_contains "$workspace_bundle_status_output" "Warning: Optional AI Tool Stack is enabled but missing tools" "Terrapod status avoids duplicate optional tool warnings outside executable selection"
+
+status_macos_workspace_config="$tmp_dir/status-macos-workspace.toml"
+cat >"$status_macos_workspace_config" <<'TOML'
+[data]
+profile = "macos-terminal"
+enableEditorStack = false
+enableAiCliTools = false
+enableDevelopmentWorkspace = true
+TOML
+
+macos_workspace_status_path="$(status_doctor_path macos-workspace chezmoi git zsh mise brew nvim zellij)"
+
+macos_workspace_status_output="$(
+  TERRAPOD_PROFILE=macos-terminal TERRAPOD_CHEZMOI_CONFIG="$status_macos_workspace_config" PATH="$macos_workspace_status_path" \
+    /bin/sh "$terrapod" status
+)"
+
+assert_contains "$macos_workspace_status_output" "Optional Editor Stack         : enabled (rich Neovim configuration)" "macOS Terrapod status treats Optional Development Workspace as enabling Optional Editor Stack"
+assert_contains "$macos_workspace_status_output" "Optional AI Tool Stack        : enabled (missing tools: agy, claude, codex)" "macOS Terrapod status treats Optional Development Workspace as enabling Optional AI Tool Stack"
 
 status_unsupported_os_release="$tmp_dir/status-unsupported-os-release"
 write_os_release "$status_unsupported_os_release" debian 12 "Debian GNU/Linux 12"
@@ -2408,7 +2427,7 @@ assert_contains "$doctor_ok_output" "ok - Profile is supported: VPS Shell Profil
 assert_contains "$doctor_ok_output" "Canonical executable selection: ready" "Terrapod doctor validates canonical executable selection"
 assert_contains "$doctor_ok_output" "ok - apt is available" "Terrapod doctor validates Ubuntu Bootstrap Package Manager availability"
 assert_contains "$doctor_ok_output" "ok - Optional Editor Stack is disabled" "Terrapod doctor treats disabled Optional Editor Stack as valid"
-assert_contains "$doctor_ok_output" "ok - Optional AI Tool Stack is disabled" "Terrapod doctor treats disabled Optional AI Tool Stack as valid"
+assert_contains "$doctor_ok_output" "ok - Optional AI Tool Stack is not applicable for VPS Shell Profile" "Terrapod doctor reports the Optional AI Tool Stack as not applicable on the VPS Shell Profile"
 assert_contains "$doctor_ok_output" "ok - brew is available" "VPS Shell Profile doctor always requires Homebrew"
 assert_contains "$doctor_ok_output" "ok - Optional Development Workspace is disabled" "Terrapod doctor treats disabled Optional Development Workspace as valid"
 assert_contains "$doctor_ok_output" "Guidance: none" "Terrapod doctor prints no guidance when checks pass"

--- a/tests/terrapod_config_test.sh
+++ b/tests/terrapod_config_test.sh
@@ -508,7 +508,7 @@ fi
 pass "development Preset creates a chezmoi config file"
 
 assert_data_key_once_with_value "$development_config" "enableEditorStack" "true" "development Preset enables Optional Editor Stack in a new config"
-assert_data_key_once_with_value "$development_config" "enableAiCliTools" "true" "development Preset enables Optional AI Tool Stack in a new config"
+assert_data_key_once_with_value "$development_config" "enableAiCliTools" "false" "development Preset leaves Optional AI Tool Stack disabled on the VPS Shell Profile"
 assert_data_key_once_with_value "$development_config" "enableDevelopmentWorkspace" "true" "development Preset enables Optional Development Workspace in a new config"
 assert_data_key_once_with_value "$development_config" "profile" "\"vps-shell\"" "development Preset writes the detected profile in a new config"
 assert_data_key_once_with_value "$development_config" "enableMacosAppGroupTerminalApps" "false" "development Preset disables terminal-apps macOS App Group in a new config"
@@ -520,6 +520,22 @@ assert_data_key_once_with_value "$development_config" "enableMacosAppGroupMobile
 assert_not_contains "$development_config" "enableMacosDesktopApps" "development Preset does not write the legacy all-in desktop app toggle"
 assert_not_contains "$development_config" "terrapodPreset" "development Preset stores concrete values instead of a dynamic Preset"
 assert_backup_count "$development_config" 0 "development config creation does not create a backup"
+
+macos_development_home="$tmp_dir/macos-development-home"
+macos_development_xdg="$tmp_dir/macos-development-xdg"
+macos_development_config="$macos_development_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$macos_development_home"
+
+run_terrapod_configure development "" "$macos_development_home" "$macos_development_xdg" macos-terminal
+
+if [ ! -f "$macos_development_config" ]; then
+  fail "macOS development Preset creates a chezmoi config file"
+fi
+pass "macOS development Preset creates a chezmoi config file"
+
+assert_data_key_once_with_value "$macos_development_config" "enableEditorStack" "true" "macOS development Preset enables Optional Editor Stack in a new config"
+assert_data_key_once_with_value "$macos_development_config" "enableAiCliTools" "true" "macOS development Preset enables Optional AI Tool Stack in a new config"
+assert_data_key_once_with_value "$macos_development_config" "enableDevelopmentWorkspace" "true" "macOS development Preset enables Optional Development Workspace in a new config"
 
 workstation_home="$tmp_dir/workstation-home"
 workstation_xdg="$tmp_dir/workstation-xdg"
@@ -578,6 +594,7 @@ fi
 pass "no-gum development Preset creates a chezmoi config file"
 
 assert_data_key_once_with_value "$nogum_development_config" "enableEditorStack" "true" "no-gum development writes concrete Editor Stack setting"
+assert_data_key_once_with_value "$nogum_development_config" "enableAiCliTools" "false" "no-gum development leaves Optional AI Tool Stack disabled on the VPS Shell Profile"
 assert_data_key_once_with_value "$nogum_development_config" "enableDevelopmentWorkspace" "true" "no-gum development writes concrete Development Workspace setting"
 assert_data_key_once_with_value "$nogum_development_config" "enableMacosAppGroupTerminalApps" "false" "no-gum development writes concrete macOS App Group setting"
 assert_data_key_once_with_value "$nogum_development_config" "enableMacosAppGroupDevelopmentApps" "false" "no-gum development writes concrete development-apps App Group setting"
@@ -822,7 +839,6 @@ mkdir -p "$gum_vps_home"
 if ! run_terrapod_setup vps-shell 'minimal
 n
 y
-n
 y
 ' "$gum_vps_home" "$gum_vps_xdg" >"$tmp_dir/gum-vps.out" 2>"$tmp_dir/gum-vps.err"; then
   printf '%s\n' "gum VPS stdout:" >&2
@@ -838,6 +854,11 @@ if printf '%s\n' "$gum_vps_combined" | grep -F "terminal-apps macOS App Group" >
   fail "gum VPS setup does not show macOS App Group items"
 fi
 pass "gum VPS setup does not show macOS App Group items"
+
+if printf '%s\n' "$gum_vps_combined" | grep -F "Enable Optional AI Tool Stack?" >/dev/null; then
+  fail "gum VPS setup does not prompt for the Optional AI Tool Stack"
+fi
+pass "gum VPS setup does not prompt for the Optional AI Tool Stack"
 
 assert_data_key_once_with_value "$gum_vps_config" "enableEditorStack" "true" "gum VPS setup writes customized Optional Editor Stack"
 assert_data_key_once_with_value "$gum_vps_config" "enableAiCliTools" "false" "gum VPS setup writes customized Optional AI Tool Stack"
@@ -903,7 +924,6 @@ mkdir -p "$setup_vps_custom_home"
 if ! run_terrapod_setup vps-shell 'minimal
 n
 y
-n
 y
 ' "$setup_vps_custom_home" "$setup_vps_custom_xdg" >"$tmp_dir/setup-vps-custom.out" 2>"$tmp_dir/setup-vps-custom.err"; then
   printf '%s\n' "setup stdout:" >&2
@@ -920,6 +940,12 @@ if printf '%s\n' "$setup_vps_custom_output" | grep -F "terminal-apps macOS App G
 fi
 pass "VPS setup does not prompt for terminal-apps macOS App Group"
 
+if printf '%s\n' "$setup_vps_custom_output" | grep -F "Enable Optional AI Tool Stack?" >/dev/null; then
+  fail "VPS setup does not prompt for the Optional AI Tool Stack"
+fi
+pass "VPS setup does not prompt for the Optional AI Tool Stack"
+
+assert_contains "$tmp_dir/setup-vps-custom.out" "Optional AI Tool Stack: not applicable for VPS Shell Profile" "VPS setup explains the Optional AI Tool Stack is not applicable"
 assert_contains "$tmp_dir/setup-vps-custom.out" "macOS App Groups: not applicable for VPS Shell Profile" "VPS setup explains macOS App Groups are not applicable"
 assert_contains "$tmp_dir/setup-vps-custom.out" "enableEditorStack = true" "VPS setup summary reflects customized Optional Editor Stack"
 assert_contains "$tmp_dir/setup-vps-custom.out" "enableAiCliTools = false" "VPS setup summary reflects customized Optional AI Tool Stack"
@@ -1099,7 +1125,7 @@ assert_contains "$existing_config" "email = \"minu@example.com\"" "existing upda
 assert_contains "$existing_config" "command = \"nvim\"" "existing update preserves unrelated later sections"
 assert_data_key_once_with_value "$existing_config" "profile" "\"vps-shell\"" "existing update writes the detected profile exactly once in data"
 assert_data_key_once_with_value "$existing_config" "enableEditorStack" "true" "development Preset enables Optional Editor Stack exactly once in data"
-assert_data_key_once_with_value "$existing_config" "enableAiCliTools" "true" "development Preset enables Optional AI Tool Stack exactly once in data"
+assert_data_key_once_with_value "$existing_config" "enableAiCliTools" "false" "development Preset leaves Optional AI Tool Stack disabled exactly once on the VPS Shell Profile"
 assert_data_key_once_with_value "$existing_config" "enableDevelopmentWorkspace" "true" "development Preset enables Optional Development Workspace exactly once in data"
 assert_data_key_once_with_value "$existing_config" "enableMacosAppGroupTerminalApps" "false" "development Preset disables terminal-apps macOS App Group exactly once in data"
 assert_data_key_once_with_value "$existing_config" "enableMacosAppGroupAutomation" "false" "development Preset disables automation macOS App Group exactly once in data"
@@ -1129,7 +1155,7 @@ terrapodPreset = "minimal"
 branch = "main"
 TOML
 
-run_terrapod_configure development "y" "$quoted_table_home" "$quoted_table_xdg"
+run_terrapod_configure development "y" "$quoted_table_home" "$quoted_table_xdg" macos-terminal
 
 assert_contains "$quoted_table_config" "[\"data\"]" "quoted data table header is preserved"
 assert_not_contains "$quoted_table_config" "[data]" "quoted data table update does not append a duplicate bare data table"
@@ -1161,7 +1187,7 @@ terrapodPreset = "minimal"
 branch = "main"
 TOML
 
-run_terrapod_configure development "y" "$spaced_table_home" "$spaced_table_xdg"
+run_terrapod_configure development "y" "$spaced_table_home" "$spaced_table_xdg" macos-terminal
 
 assert_contains "$spaced_table_config" "[ data ]" "spaced data table header is preserved"
 assert_not_contains "$spaced_table_config" "[data]" "spaced data table update does not append a duplicate bare data table"
@@ -1201,7 +1227,7 @@ assert_contains "$dotted_config" "data.email = \"minu@example.com\"" "dotted dat
 assert_contains "$dotted_config" "branch = \"main\"" "dotted data update preserves later sections"
 assert_contains "$dotted_config" "data.profile = \"vps-shell\"" "dotted data update writes profile as a dotted data key"
 assert_contains "$dotted_config" "data.enableEditorStack = true" "dotted data update writes Editor Stack as a dotted data key"
-assert_contains "$dotted_config" "data.enableAiCliTools = true" "dotted data update writes AI Tool Stack as a dotted data key"
+assert_contains "$dotted_config" "data.enableAiCliTools = false" "dotted data update writes the profile-gated AI Tool Stack as a dotted data key"
 assert_contains "$dotted_config" "data.enableDevelopmentWorkspace = true" "dotted data update writes Development Workspace as a dotted data key"
 assert_contains "$dotted_config" "data.enableMacosAppGroupTerminalApps = false" "dotted data update writes terminal-apps App Group as a dotted data key"
 assert_contains "$dotted_config" "data.enableMacosAppGroupAutomation = false" "dotted data update writes automation App Group as a dotted data key"
@@ -1232,7 +1258,7 @@ cat >"$quoted_config" <<'TOML'
 keepLiteral = "preserve"
 TOML
 
-run_terrapod_configure development "y" "$quoted_home" "$quoted_xdg"
+run_terrapod_configure development "y" "$quoted_home" "$quoted_xdg" macos-terminal
 
 assert_data_key_once_with_value "$quoted_config" "enableEditorStack" "true" "quoted managed key update writes one Editor Stack value in data"
 assert_data_key_once_with_value "$quoted_config" "enableAiCliTools" "true" "quoted managed key update writes one AI Tool Stack value in data"
@@ -1268,7 +1294,7 @@ enableEditorStack = "do-not-touch"
 TOML
 chmod 600 "$array_config"
 
-run_terrapod_configure development "y" "$array_home" "$array_xdg"
+run_terrapod_configure development "y" "$array_home" "$array_xdg" macos-terminal
 
 assert_contains "$array_config" "keepMe = \"yes\"" "array-table update preserves unrelated data values"
 assert_data_key_once_with_value "$array_config" "enableEditorStack" "true" "array-table update writes Editor Stack only in data"
@@ -1312,7 +1338,7 @@ enableAiCliTools = false
 branch = "main"
 TOML
 
-run_terrapod_configure development "y" "$custom_array_home" "$custom_array_xdg"
+run_terrapod_configure development "y" "$custom_array_home" "$custom_array_xdg" macos-terminal
 
 assert_contains "$custom_array_config" "customValues = [" "custom array update preserves array header"
 assert_contains "$custom_array_config" "preserve-me" "custom array update preserves array value"


### PR DESCRIPTION
Closes #149

## Problem

`Brewfile.ai-cli-tools.tmpl` declared only casks (`antigravity-cli`, `claude-code`, `codex`) while the installer guard allowed both `darwin` and `linux`. Homebrew on Linux does not install casks, and `brew info --formula` confirms none of the three has a formula counterpart — so there is no Linux Homebrew path to add.

The `development` preset is explicitly allowed on the VPS profile (only `workstation` is gated), so a VPS with the documented preset failed this bundle on every apply, permanently recorded an `optional-ai-cli-tools` install warning, and kept `tpod doctor` failing.

## Approach

Scope the stack to the macOS Terminal Profile and treat it as *not applicable* on the VPS Shell Profile, matching how macOS App Groups already behave on a profile mismatch. The `development` preset stays available on a VPS and keeps the Editor Stack and Development Workspace.

- **`Brewfile.ai-cli-tools.tmpl`** — gated on `.chezmoi.os == darwin`; renders empty elsewhere.
- **`run_before_60-install-ai-cli-tools.sh.tmpl`** — the line-1 guard stays `darwin`/`linux` on purpose. Narrowing it would stop the script from rendering on Linux, and marker pruning only removes *unrecognized* categories, so a stale `optional-ai-cli-tools` marker from an earlier apply would linger forever. Instead the enablement condition is gated, so Linux always takes the clear-marker-and-exit path.
- **`effective_ai_cli_tools_enabled`** is now profile-aware. This is the single choke point: it also stops `enableDevelopmentWorkspace` from implying the stack on a VPS.
- **Setup / configure** — `development` writes `enableAiCliTools = false` on a VPS; setup does not prompt for the stack there and prints `Optional AI Tool Stack: not applicable for VPS Shell Profile`; the workspace prompt's "Includes:" list drops the entry.
- **`tpod status` / `tpod doctor`** report `not applicable`, and executable selection no longer checks `agy`/`claude`/`codex` on a VPS.
- A machine-local `enableAiCliTools = true` on a VPS is ignored rather than rejected.

## Docs

New **ADR 0015** supersedes ADR 0008's claim that the stack installs "from the same Homebrew casks on the macOS Terminal Profile and VPS Shell Profile", and its consequence that Ubuntu bootstraps Homebrew only when the stack is enabled — ADR 0010 already made standard-prefix Homebrew mandatory on both profiles. Per repo convention ADR 0008 itself is left untouched. `CONTEXT.md`, `README.md`, and `README.ko.md` are corrected to match.

## Testing

Full suite passes (20 test files; `homebrew_ubuntu_smoke.sh` needs Docker and was not run).

- `homebrew_manifests_test.sh` — exactly three casks on darwin, empty render on linux.
- `chezmoiignore_test.sh` — the Linux render carries no bundle step and no casks; running it never invokes `brew` and does clear a seeded stale marker.
- `terrapod_config_test.sh` — VPS `development` writes the stack disabled, a new macOS `development` case covers the enabled side, and VPS setup no longer prompts for the stack.
- `terrapod_command_test.sh` — VPS status/doctor report `not applicable`; a new macOS workspace block preserves coverage of the `enabled (missing tools: ...)` rendering.
- `readme_optional_stack_profiles_test.sh` — the Ubuntu section must not promise AI casks and must explain the macOS-only scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRKPksvRpAUHPVDhUsWZEt