### PR TITLE
Share one Homebrew prefix mapping across Terrapod commands

### DIFF
--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -14,6 +14,7 @@ esac
 command_dir="${command_path%/*}"
 command_dir="$(CDPATH= cd -- "$command_dir" 2>/dev/null && pwd || printf '%s\n' ".")"
 install_warnings_lib="${TERRAPOD_INSTALL_WARNINGS_LIB:-$command_dir/../lib/terrapod/install-warnings.sh}"
+homebrew_prefix_lib="${TERRAPOD_HOMEBREW_PREFIX_LIB:-$command_dir/../lib/terrapod/homebrew-prefix.sh}"
 executable_selection_helper="${TERRAPOD_EXECUTABLE_SELECTION_HELPER:-$command_dir/../lib/terrapod/executable-selection}"
 if [ ! -e "$executable_selection_helper" ] &&
   [ -e "$command_dir/../lib/terrapod/executable_executable-selection" ]; then
@@ -24,6 +25,11 @@ jetendard_settings_helper="${TERRAPOD_JETENDARD_SETTINGS_HELPER:-$command_dir/..
 TERRAPOD_INSTALL_WARNINGS_LOADED=
 if [ -f "$install_warnings_lib" ]; then
   . "$install_warnings_lib"
+fi
+
+TERRAPOD_HOMEBREW_PREFIX_LOADED=
+if [ -f "$homebrew_prefix_lib" ]; then
+  . "$homebrew_prefix_lib"
 fi
 
 run_jetendard_check() {
@@ -1028,26 +1034,12 @@ if [ "${TERRAPOD_PRINT_HOMEBREW_CLI_RECORDS:-}" = "1" ]; then
   exit 0
 fi
 
+# TERRAPOD_STANDARD_HOMEBREW_PREFIX is deliberately not consulted here: it is
+# how this command hands its own answer down to the executable-selection
+# helper, not a way to override the mapping for this command.
 standard_homebrew_prefix() {
-  profile="$1"
-  case "$profile" in
-    macos-terminal) os=darwin ;;
-    vps-shell) os=linux ;;
-    *) return 1 ;;
-  esac
-
-  arch="${TERRAPOD_MACHINE_ARCH:-$(uname -m 2>/dev/null || true)}"
-  if [ "$os" = darwin ] && [ "$arch" = x86_64 ] &&
-    [ "$(sysctl -in sysctl.proc_translated 2>/dev/null || true)" = 1 ]; then
-    arch=arm64
-  fi
-
-  case "$os:$arch" in
-    darwin:arm64|darwin:aarch64) printf '%s\n' /opt/homebrew ;;
-    darwin:x86_64) printf '%s\n' /usr/local ;;
-    linux:x86_64|linux:aarch64) printf '%s\n' /home/linuxbrew/.linuxbrew ;;
-    *) return 1 ;;
-  esac
+  [ "${TERRAPOD_HOMEBREW_PREFIX_LOADED:-}" = 1 ] || return 1
+  terrapod_standard_homebrew_prefix_for_profile "$1"
 }
 
 if [ "${TERRAPOD_PRINT_STANDARD_HOMEBREW_PREFIX:-}" = "1" ]; then

--- a/dot_local/lib/terrapod/executable_executable-selection
+++ b/dot_local/lib/terrapod/executable_executable-selection
@@ -14,18 +14,26 @@ case "$mode" in
     ;;
 esac
 
+case "$0" in
+  */*) script_path="$0" ;;
+  *) script_path="$(command -v -- "$0" 2>/dev/null || printf '%s\n' "$0")" ;;
+esac
+script_dir="${script_path%/*}"
+script_dir="$(CDPATH= cd -- "$script_dir" 2>/dev/null && pwd || printf '%s\n' ".")"
+homebrew_prefix_lib="${TERRAPOD_HOMEBREW_PREFIX_LIB:-$script_dir/homebrew-prefix.sh}"
+if [ ! -f "$homebrew_prefix_lib" ]; then
+  printf '%s\n' "  failure - Homebrew prefix library is unavailable: $homebrew_prefix_lib" >&2
+  exit 1
+fi
+. "$homebrew_prefix_lib"
+
 standard_homebrew_prefix() {
   if [ -n "${TERRAPOD_STANDARD_HOMEBREW_PREFIX:-}" ]; then
     printf '%s\n' "$TERRAPOD_STANDARD_HOMEBREW_PREFIX"
     return
   fi
 
-  case "$profile:$(uname -m 2>/dev/null || true)" in
-    macos-terminal:arm64|macos-terminal:aarch64) printf '%s\n' /opt/homebrew ;;
-    macos-terminal:x86_64) printf '%s\n' /usr/local ;;
-    vps-shell:x86_64|vps-shell:aarch64) printf '%s\n' /home/linuxbrew/.linuxbrew ;;
-    *) return 1 ;;
-  esac
+  terrapod_standard_homebrew_prefix_for_profile "$profile"
 }
 
 core_records() {

--- a/dot_local/lib/terrapod/homebrew-prefix.sh
+++ b/dot_local/lib/terrapod/homebrew-prefix.sh
@@ -42,6 +42,19 @@ terrapod_standard_homebrew_prefix_for_os() {
   esac
 }
 
+terrapod_standard_homebrew_os_for_profile() {
+  case "$1" in
+    macos-terminal) printf '%s\n' darwin ;;
+    vps-shell) printf '%s\n' linux ;;
+    *) return 1 ;;
+  esac
+}
+
+terrapod_standard_homebrew_prefix_for_profile() {
+  os="$(terrapod_standard_homebrew_os_for_profile "$1")" || return 1
+  terrapod_standard_homebrew_prefix_for_os "$os"
+}
+
 terrapod_standard_homebrew_brew_path() {
   os="$1"
   hardware_arch="$(terrapod_homebrew_hardware_arch "$os")" || return 1

--- a/tests/executable_selection_test.sh
+++ b/tests/executable_selection_test.sh
@@ -230,6 +230,62 @@ status_output="$(run_selection status)"
 assert_contains "$status_output" "Executable selection:" \
   "status exposes executable selection state"
 
+# The canonical path appears in whichever concern the record raises, so these
+# assertions observe the resolved prefix without depending on what the host
+# machine has actually installed.
+assert_canonical_prefix() {
+  profile="$1"
+  arch="$2"
+  translated="$3"
+  expected_prefix="$4"
+  rejected_prefix="$5"
+  label="$6"
+
+  set +e
+  prefix_output="$(
+    HOME="$tmp_dir/home" \
+      TERRAPOD_EXECUTABLE_SELECTION_INVENTORY_DIR="$inventory" \
+      TERRAPOD_MISE_SHIMS_DIR="$mise_shims" \
+      TERRAPOD_MACHINE_ARCH="$arch" \
+      TERRAPOD_DARWIN_TRANSLATED="$translated" \
+      PATH="$path_dir:/usr/bin:/bin" \
+      "$selection" doctor "$profile" false false 2>&1
+  )"
+  set -e
+
+  assert_contains "$prefix_output" "$expected_prefix/bin/bat" "$label"
+  assert_not_contains "$prefix_output" "$rejected_prefix/bin/bat" "$label rejects the other prefix"
+}
+
+assert_canonical_prefix macos-terminal x86_64 1 /opt/homebrew /usr/local \
+  "Rosetta on Apple Silicon resolves canonical executables under /opt/homebrew"
+assert_canonical_prefix macos-terminal x86_64 0 /usr/local /opt/homebrew \
+  "native Intel macOS resolves canonical executables under /usr/local"
+assert_canonical_prefix macos-terminal arm64 0 /opt/homebrew /usr/local \
+  "native Apple Silicon resolves canonical executables under /opt/homebrew"
+assert_canonical_prefix vps-shell x86_64 0 /home/linuxbrew/.linuxbrew /opt/homebrew \
+  "VPS Shell resolves canonical executables under the Linuxbrew prefix"
+
+set +e
+missing_lib_output="$(
+  HOME="$tmp_dir/home" \
+    TERRAPOD_EXECUTABLE_SELECTION_INVENTORY_DIR="$inventory" \
+    TERRAPOD_STANDARD_HOMEBREW_PREFIX="$prefix" \
+    TERRAPOD_MISE_SHIMS_DIR="$mise_shims" \
+    TERRAPOD_HOMEBREW_PREFIX_LIB="$tmp_dir/absent-homebrew-prefix.sh" \
+    PATH="$path_dir:/usr/bin:/bin" \
+    "$selection" doctor macos-terminal false false 2>&1
+)"
+missing_lib_status="$?"
+set -e
+[ "$missing_lib_status" -ne 0 ] ||
+  fail "a missing Homebrew prefix library fails instead of reporting absent executables"
+pass "a missing Homebrew prefix library fails instead of reporting absent executables"
+assert_contains "$missing_lib_output" "Homebrew prefix library is unavailable" \
+  "a missing Homebrew prefix library is diagnosed distinctly"
+assert_not_contains "$missing_lib_output" "canonical executable is missing" \
+  "a missing Homebrew prefix library is not reported as missing executables"
+
 integration_bin="$tmp_dir/integration-bin"
 integration_config="$tmp_dir/integration-config/chezmoi.toml"
 selection_log="$tmp_dir/selection.log"

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -662,13 +662,21 @@ homebrew_owned_status_doctor_path() {
   printf '%s\n' "$owned_path"
 }
 
+# The rendered command reads its Homebrew prefix mapping from a sibling
+# library, so the fixture reproduces the deployed bin/ and lib/ layout and
+# rewrites the prefix in both files.
 render_terrapod_with_homebrew_prefix() {
   name="$1"
   production_prefix="$2"
   fixture_prefix="$3"
-  rendered_terrapod="$tmp_dir/terrapod-$name"
+  rendered_root="$tmp_dir/terrapod-$name"
+  rendered_terrapod="$rendered_root/bin/terrapod"
+  rendered_prefix_lib="$rendered_root/lib/terrapod/homebrew-prefix.sh"
 
+  mkdir -p "$rendered_root/bin" "$rendered_root/lib/terrapod"
   sed "s|$production_prefix|$fixture_prefix|g" "$terrapod" >"$rendered_terrapod"
+  sed "s|$production_prefix|$fixture_prefix|g" \
+    "$repo_root/dot_local/lib/terrapod/homebrew-prefix.sh" >"$rendered_prefix_lib"
   chmod +x "$rendered_terrapod"
   printf '%s\n' "$rendered_terrapod"
 }
@@ -770,6 +778,38 @@ if [ "$rosetta_prefix_output" != /opt/homebrew ]; then
   fail "Rosetta doctor prefix mapping selects Apple Silicon Homebrew"
 fi
 pass "Rosetta doctor prefix mapping selects Apple Silicon Homebrew"
+
+write_stub "$standard_prefix_mapping_path/sysctl" 'exit 1'
+set +e
+translated_hook_output="$(
+  TERRAPOD_PRINT_STANDARD_HOMEBREW_PREFIX=1 TERRAPOD_PROFILE=macos-terminal \
+    TERRAPOD_MACHINE_ARCH=x86_64 TERRAPOD_DARWIN_TRANSLATED=1 \
+    PATH="$standard_prefix_mapping_path" /bin/sh "$terrapod"
+)"
+translated_hook_status=$?
+set -e
+assert_status "$translated_hook_status" 0 "TERRAPOD_DARWIN_TRANSLATED=1 prefix mapping succeeds"
+if [ "$translated_hook_output" != /opt/homebrew ]; then
+  fail "TERRAPOD_DARWIN_TRANSLATED=1 selects Apple Silicon Homebrew without sysctl"
+fi
+pass "TERRAPOD_DARWIN_TRANSLATED=1 selects Apple Silicon Homebrew without sysctl"
+
+write_stub "$standard_prefix_mapping_path/sysctl" \
+  'if [ "$*" = "-in sysctl.proc_translated" ]; then printf "%s\n" "1"; exit 0; fi' \
+  'exit 1'
+set +e
+untranslated_hook_output="$(
+  TERRAPOD_PRINT_STANDARD_HOMEBREW_PREFIX=1 TERRAPOD_PROFILE=macos-terminal \
+    TERRAPOD_MACHINE_ARCH=x86_64 TERRAPOD_DARWIN_TRANSLATED=0 \
+    PATH="$standard_prefix_mapping_path" /bin/sh "$terrapod"
+)"
+untranslated_hook_status=$?
+set -e
+assert_status "$untranslated_hook_status" 0 "TERRAPOD_DARWIN_TRANSLATED=0 prefix mapping succeeds"
+if [ "$untranslated_hook_output" != /usr/local ]; then
+  fail "TERRAPOD_DARWIN_TRANSLATED=0 overrides the sysctl translation report"
+fi
+pass "TERRAPOD_DARWIN_TRANSLATED=0 overrides the sysctl translation report"
 
 write_stub "$standard_prefix_mapping_path/uname" 'printf "%s\n" "mystery-arch"'
 set +e


### PR DESCRIPTION
Closes #151

## Problem

The Homebrew prefix mapping existed in **three** places:

| Location | Rosetta handling | Test hooks |
|---|---|---|
| `dot_local/lib/terrapod/homebrew-prefix.sh` (canonical) | yes | `TERRAPOD_MACHINE_ARCH`, `TERRAPOD_DARWIN_TRANSLATED` |
| `dot_local/bin/executable_terrapod:1031` | yes | `TERRAPOD_MACHINE_ARCH` only |
| `dot_local/lib/terrapod/executable_executable-selection:17-29` | **no** | none |

The canonical library had only ever been consumed by `chezmoi` templates via `include`, so both runtime scripts carried their own copy.

The helper's copy resolved `macos-terminal:x86_64` to `/usr/local`. Under Rosetta on Apple Silicon `uname -m` reports `x86_64`, so a shell running the helper without `TERRAPOD_STANDARD_HOMEBREW_PREFIX` reported every core formula as a missing canonical executable.

## Correction to the issue's impact claim

`tpod doctor` did **not** fail wholesale. `executable_terrapod:963` always computes the prefix with the Rosetta-aware copy and passes it down as `TERRAPOD_STANDARD_HOMEBREW_PREFIX`, so the helper's `case` was a near-unreachable fallback and the defect only surfaced when the helper ran standalone. The triplicated mapping is the real problem, and that is what this PR removes.

## Approach

- **`homebrew-prefix.sh`** — adds `terrapod_standard_homebrew_os_for_profile` (profile → OS) and `terrapod_standard_homebrew_prefix_for_profile`, which delegates to the existing `terrapod_standard_homebrew_prefix_for_os`. The Rosetta check and both test hooks are reused, not rewritten.
- **`executable_terrapod`** — sources the library through `TERRAPOD_HOMEBREW_PREFIX_LIB` with the same `[ -f ]` guard `install-warnings.sh` already uses, and `standard_homebrew_prefix` shrinks from 21 lines to a delegation. Its three call sites are untouched. `TERRAPOD_DARWIN_TRANSLATED` now works here too.
- **`executable-selection`** — sources the library from its own directory and delegates. When the library is absent it now fails with a distinct diagnostic instead of flowing into `canonical executable is missing`, so a broken deployment no longer masquerades as missing executables.

`TERRAPOD_STANDARD_HOMEBREW_PREFIX` stays a helper-only override. It is deliberately **not** moved into the library: `tests/terrapod_command_test.sh:777-786` asserts that `terrapod`'s own mapping cannot be bypassed by it, because the variable is how `terrapod` hands its answer down to the helper — not a way to override its own mapping. A comment on the function records this.

## Test fixture change

`render_terrapod_with_homebrew_prefix` (`tests/terrapod_command_test.sh:665`) copied `terrapod` into `$tmp_dir` and `sed`-rewrote the `/opt/homebrew` literal inside it. Moving the mapping into the library broke both halves of that: the copy had no sibling library, and the literal was gone. The fixture now reproduces the deployed `bin/` and `lib/` layout and rewrites the prefix in both files.

## Testing

Written test-first; the `native Intel macOS` case was red before the change (the helper ignored `TERRAPOD_MACHINE_ARCH`).

- **`tests/executable_selection_test.sh`** — four prefix cases (Rosetta `x86_64` + translated → `/opt/homebrew`, native Intel → `/usr/local`, native Apple Silicon, VPS Shell → Linuxbrew), each asserting the resolved prefix appears *and* the other one does not, so the assertions do not depend on what the host machine has installed. Plus the missing-library diagnostic.
- **`tests/terrapod_command_test.sh`** — `TERRAPOD_DARWIN_TRANSLATED=1` selects Apple Silicon without consulting `sysctl`, and `=0` overrides a `sysctl` that reports translation.

Full suite passes: 18 `.sh` suites + 2 `.zsh` suites. `homebrew_ubuntu_smoke.sh` needs Docker and was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8NEP9Br6qNemEVQKTdTQt
