### PR TITLE
Split Homebrew candidate paths on one separator

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -135,6 +135,21 @@ expected_homebrew_path() {
   esac
 }
 
+# TERRAPOD_HOMEBREW_CANDIDATE_PATHS overrides the Homebrew search list. Entries
+# are colon-separated like PATH; an empty value means there are no candidates.
+first_executable_homebrew_candidate() {
+  candidate_paths="${TERRAPOD_HOMEBREW_CANDIDATE_PATHS-/opt/homebrew/bin/brew:/usr/local/bin/brew}"
+  old_ifs="$IFS"
+  IFS=:
+  for candidate in $candidate_paths; do
+    if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+      printf '%s\n' "$candidate"
+      break
+    fi
+  done
+  IFS="$old_ifs"
+}
+
 reject_nonstandard_homebrew() {
   expected_brew="$1"
   discovered_brew=""
@@ -148,15 +163,7 @@ reject_nonstandard_homebrew() {
   if command -v brew >/dev/null 2>&1; then
     discovered_brew="$(command -v brew)"
   elif [ -n "${TERRAPOD_HOMEBREW_CANDIDATE_PATHS:-}" ]; then
-    old_ifs="$IFS"
-    IFS=:
-    for candidate in $TERRAPOD_HOMEBREW_CANDIDATE_PATHS; do
-      if [ -x "$candidate" ]; then
-        discovered_brew="$candidate"
-        break
-      fi
-    done
-    IFS="$old_ifs"
+    discovered_brew="$(first_executable_homebrew_candidate)"
   fi
 
   if [ -n "$discovered_brew" ] && [ "$discovered_brew" != "$expected_brew" ]; then
@@ -967,20 +974,9 @@ find_homebrew() {
     return 0
   fi
 
-  if [ "${TERRAPOD_HOMEBREW_CANDIDATE_PATHS+x}" ]; then
-    homebrew_candidate_paths="$TERRAPOD_HOMEBREW_CANDIDATE_PATHS"
-  else
-    homebrew_candidate_paths="/opt/homebrew/bin/brew /usr/local/bin/brew"
-  fi
-
-  for brew_path in $homebrew_candidate_paths; do
-    if [ -x "$brew_path" ]; then
-      printf '%s\n' "$brew_path"
-      return 0
-    fi
-  done
-
-  return 1
+  brew_path="$(first_executable_homebrew_candidate)"
+  [ -n "$brew_path" ] || return 1
+  printf '%s\n' "$brew_path"
 }
 
 mark_install_warning_from_source() {

--- a/tests/terrapod_installer_test.sh
+++ b/tests/terrapod_installer_test.sh
@@ -1480,6 +1480,47 @@ unset TERRAPOD_HOMEBREW_CANDIDATE_PATHS TERRAPOD_EXPECTED_HOMEBREW_PATH TERRAPOD
 assert_failure "$installer_status" "nonstandard Homebrew prefix is rejected"
 assert_contains "$(cat "$nonstandard_prefix_case/stderr")" "Homebrew exists outside the supported prefix" "nonstandard prefix guidance is explicit"
 
+candidate_paths_case="$(make_case_dir homebrew-candidate-paths)"
+candidate_installer_functions="$candidate_paths_case/install-functions.sh"
+sed '$d' "$repo_root/install.sh" >"$candidate_installer_functions"
+candidate_missing_brew="$candidate_paths_case/opt/missing/bin/brew"
+candidate_present_brew="$candidate_paths_case/opt/custom/bin/brew"
+mkdir -p "${candidate_present_brew%/brew}"
+write_stub "$candidate_present_brew" '#!/bin/sh' 'exit 0'
+
+candidate_found_brew="$(
+  PATH="$safe_path_dir:/usr/bin:/bin" \
+    TERRAPOD_HOMEBREW_CANDIDATE_PATHS="$candidate_missing_brew:$candidate_present_brew" \
+    sh -c '. "$1"; find_homebrew || true' sh "$candidate_installer_functions"
+)"
+if [ "$candidate_found_brew" != "$candidate_present_brew" ]; then
+  fail "find_homebrew splits candidate paths on colons"
+fi
+pass "find_homebrew splits candidate paths on colons"
+
+default_candidate_brew="$(
+  PATH="$safe_path_dir:/usr/bin:/bin" sh -c '. "$1"; find_homebrew || true' sh "$candidate_installer_functions"
+)"
+case "$default_candidate_brew" in
+  ''|/opt/homebrew/bin/brew|/usr/local/bin/brew)
+    pass "find_homebrew keeps its default candidate list separable"
+    ;;
+  *)
+    fail "find_homebrew keeps its default candidate list separable"
+    ;;
+esac
+
+candidate_reject_stderr="$candidate_paths_case/reject-stderr"
+if PATH="$safe_path_dir:/usr/bin:/bin" \
+  TERRAPOD_HOMEBREW_CANDIDATE_PATHS="$candidate_missing_brew:$candidate_present_brew" \
+  sh -c '. "$1"; reject_nonstandard_homebrew "$2"' sh \
+    "$candidate_installer_functions" "$candidate_paths_case/opt/homebrew/bin/brew" \
+    2>"$candidate_reject_stderr"; then
+  fail "reject_nonstandard_homebrew splits candidate paths on colons"
+fi
+pass "reject_nonstandard_homebrew splits candidate paths on colons"
+assert_contains "$(cat "$candidate_reject_stderr")" "Homebrew exists outside the supported prefix" "colon-separated candidate rejection explains the unsupported prefix"
+
 low_disk_case="$(make_case_dir low-linuxbrew-disk)"
 write_uname_stub "$low_disk_case" "Linux"
 low_disk_os_release="$(write_os_release "$low_disk_case" "ID=ubuntu" 'VERSION_ID="24.04"')"


### PR DESCRIPTION
Closes #154

## Problem

`TERRAPOD_HOMEBREW_CANDIDATE_PATHS` was parsed two different ways. `reject_nonstandard_homebrew` split it with `IFS=:`, while `find_homebrew` iterated it under the default IFS and defaulted to the space-separated list `"/opt/homebrew/bin/brew /usr/local/bin/brew"`. A colon-separated value became one bogus path in `find_homebrew`; a space-separated one became one bogus path in `reject_nonstandard_homebrew`. Only single-element values were exercised, so neither reading ever failed a test.

## Approach

`first_executable_homebrew_candidate` now owns both the separator and the default list. Entries are colon-separated like `PATH`, which also keeps paths containing spaces intact; an empty value still means "no candidates" in both callers, as `${VAR+x}` and `-n` did before.

The issue suggested a `homebrew_candidate_paths()` list emitter, but emitting only the list leaves both callers repeating the first-executable loop. Folding the split and the selection into one function reduces each call site to a single line.

`reject_nonstandard_homebrew` keeps its `[ -n "${TERRAPOD_HOMEBREW_CANDIDATE_PATHS:-}" ]` guard, so the default list stays out of that path and user-facing behavior is unchanged. An Apple Silicon machine with a leftover Intel Homebrew off PATH is still not rejected; widening that guardrail is a separate decision.

## Tests

`tests/terrapod_installer_test.sh` only ever passed a single path. Four cases now cover multi-element values:

- `find_homebrew` resolves the second entry of `"$missing:$present"`
- the unset default stays separable rather than collapsing into one path
- `reject_nonstandard_homebrew` rejects a nonstandard brew that sits in the second entry, and explains the unsupported prefix

The default-list case can only assert that the result is empty or one of the two absolute defaults, since neither path can be faked in the test sandbox. It is weaker than the other three.

Verified red before the fix: `find_homebrew splits candidate paths on colons` failed. All 20 test suites pass after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2sVuFTvkJPTweQ1gnNEUq