### PR TITLE
Distinguish a failing executable selection helper from a missing one

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -248,6 +248,7 @@ _Avoid_: separate Korean introduction, independent README, self-labeled translat
 - `tpod status` summarizes whether Terrapod install warnings are present and points to `tpod doctor`; `tpod doctor` prints category-level warning summary and guidance.
 - `tpod apply` should surface remaining Terrapod install warnings after apply, while `tpod help` stays free of install warning state.
 - `tpod apply` exit status reflects whether the declared-state apply command itself succeeded; unresolved install warning markers after apply are surfaced in output but do not make apply fail.
+- `tpod apply` treats a missing or failing executable selection helper as a broken Terrapod command surface and exits non-zero, while executable selection advisories from a successful helper run do not change exit status.
 - `tpod doctor` recovery guidance points to `tpod apply` as the general retry path; category-specific retry commands are outside the current command surface.
 - `mise-tools` install warning guidance covers failures while the **Development Runtime Manager** installs the declared runtime versions.
 - First-run initial apply runs a forced recovery-core apply for managed shell startup files and the **Terrapod** command surface before the full declared-state apply.

--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -957,14 +957,14 @@ effective_ai_cli_tools_enabled() {
   fi
 }
 
+executable_selection_helper_available() {
+  [ -x "$executable_selection_helper" ]
+}
+
 run_executable_selection() {
   mode="$1"
   config_file="$2"
   profile="$3"
-
-  if [ ! -x "$executable_selection_helper" ]; then
-    return 1
-  fi
 
   canonical_homebrew_prefix="$(standard_homebrew_prefix "$profile" 2>/dev/null || true)"
   TERRAPOD_STANDARD_HOMEBREW_PREFIX="$canonical_homebrew_prefix" \
@@ -1278,8 +1278,10 @@ run_status() {
   print_section_value "Profile:" "$(profile_context_label)"
   show_config_context "$config_file"
   printf '%s\n' "Core Shell Stack source: Homebrew"
-  if ! run_executable_selection status "$config_file" "$profile"; then
+  if ! executable_selection_helper_available; then
     print_warning_line "executable selection helper is missing"
+  elif ! run_executable_selection status "$config_file" "$profile"; then
+    print_warning_line "executable selection helper failed"
   fi
   print_section "Optional stacks:"
   print_optional_setting_status "Optional Editor Stack" "$(effective_editor_stack_enabled "$config_file")" "rich Neovim configuration"
@@ -1550,14 +1552,24 @@ run_apply() {
     return 1
   fi
 
-  if ! run_executable_selection apply "$config_file" "$(current_profile)"; then
+  executable_selection_status=0
+  if ! executable_selection_helper_available; then
     print_warning_line "executable selection helper is missing"
+    executable_selection_status=1
+  elif ! run_executable_selection apply "$config_file" "$(current_profile)"; then
+    print_warning_line "executable selection helper failed"
+    executable_selection_status=1
   fi
 
   validation_status=0
   run_post_apply_validation || validation_status="$?"
   print_remaining_install_warnings
-  return "$validation_status"
+
+  if [ "$validation_status" -ne 0 ]; then
+    return "$validation_status"
+  fi
+
+  return "$executable_selection_status"
 }
 
 doctor_failed=0
@@ -1775,7 +1787,7 @@ run_doctor() {
 
   doctor_check_install_warnings
 
-  if [ -x "$executable_selection_helper" ]; then
+  if executable_selection_helper_available; then
     executable_selection_status=0
     executable_selection_output="$(
       run_executable_selection doctor "$config_file" "$profile"

--- a/tests/executable_selection_test.sh
+++ b/tests/executable_selection_test.sh
@@ -316,9 +316,16 @@ cat >"$integration_bin/executable-selection" <<'EOF'
 #!/bin/sh
 printf '%s\n' "$*" >>"$TERRAPOD_EXECUTABLE_SELECTION_LOG"
 printf '%s\n' "  advisory - bat resolves to /legacy/bin/bat"
-exit 1
+exit 0
 EOF
 chmod +x "$integration_bin/executable-selection"
+
+cat >"$integration_bin/executable-selection-failing" <<'EOF'
+#!/bin/sh
+printf '%s\n' "  failure - Homebrew prefix library is unavailable" >&2
+exit 1
+EOF
+chmod +x "$integration_bin/executable-selection-failing"
 
 integration_output="$(
   HOME="$tmp_dir/integration-home" \
@@ -333,3 +340,91 @@ assert_contains "$integration_output" "advisory - bat resolves to /legacy/bin/ba
   "tpod apply prints executable selection advisories after installation"
 assert_contains "$(cat "$selection_log")" "apply macos-terminal false false" \
   "tpod apply invokes executable selection with effective stack state"
+
+run_integration_terrapod() {
+  helper="$1"
+  command_path="$2"
+  shift 2
+  HOME="$tmp_dir/integration-home" \
+    TERRAPOD_PROFILE=macos-terminal \
+    TERRAPOD_CHEZMOI_CONFIG="$integration_config" \
+    TERRAPOD_EXECUTABLE_SELECTION_HELPER="$helper" \
+    TERRAPOD_EXECUTABLE_SELECTION_LOG="$selection_log" \
+    PATH="$integration_bin:/usr/bin:/bin" \
+    "$command_path" "$@" 2>&1
+}
+
+run_integration_command() {
+  helper="$1"
+  shift
+  run_integration_terrapod "$helper" "$repo_root/dot_local/bin/executable_terrapod" "$@"
+}
+
+run_absent_helper_command() {
+  run_integration_terrapod "$absent_helper" "$absent_root/bin/terrapod" "$@"
+}
+
+failing_helper="$integration_bin/executable-selection-failing"
+absent_helper="$integration_bin/executable-selection-absent"
+
+# The installed command falls back to the chezmoi-named helper next to itself
+# when the configured path does not exist, so an absent helper only stays
+# absent under a command root that carries no helper of its own.
+absent_root="$tmp_dir/absent-root"
+mkdir -p "$absent_root/bin" "$absent_root/lib/terrapod"
+cp "$repo_root/dot_local/bin/executable_terrapod" "$absent_root/bin/terrapod"
+for lib in install-warnings.sh homebrew-prefix.sh; do
+  cp "$repo_root/dot_local/lib/terrapod/$lib" "$absent_root/lib/terrapod/$lib"
+done
+
+set +e
+failing_apply_output="$(run_integration_command "$failing_helper" apply)"
+failing_apply_status="$?"
+set -e
+assert_contains "$failing_apply_output" "Warning: executable selection helper failed" \
+  "tpod apply distinguishes a helper that ran and failed"
+assert_not_contains "$failing_apply_output" "executable selection helper is missing" \
+  "tpod apply does not report a failing helper as missing"
+[ "$failing_apply_status" -ne 0 ] ||
+  fail "tpod apply exits non-zero when the executable selection helper fails"
+pass "tpod apply exits non-zero when the executable selection helper fails"
+
+set +e
+absent_apply_output="$(run_absent_helper_command apply)"
+absent_apply_status="$?"
+set -e
+assert_contains "$absent_apply_output" "Warning: executable selection helper is missing" \
+  "tpod apply reports an absent helper as missing"
+[ "$absent_apply_status" -ne 0 ] ||
+  fail "tpod apply exits non-zero when the executable selection helper is missing"
+pass "tpod apply exits non-zero when the executable selection helper is missing"
+
+set +e
+ready_apply_output="$(run_integration_command "$integration_bin/executable-selection" apply)"
+ready_apply_status="$?"
+set -e
+assert_not_contains "$ready_apply_output" "executable selection helper" \
+  "tpod apply stays quiet when the executable selection helper succeeds"
+[ "$ready_apply_status" -eq 0 ] ||
+  fail "tpod apply succeeds when the executable selection helper succeeds"
+pass "tpod apply succeeds when the executable selection helper succeeds"
+
+set +e
+failing_status_output="$(run_integration_command "$failing_helper" status)"
+failing_status_status="$?"
+set -e
+assert_contains "$failing_status_output" "Warning: executable selection helper failed" \
+  "tpod status distinguishes a helper that ran and failed"
+[ "$failing_status_status" -eq 0 ] ||
+  fail "tpod status stays informational when the executable selection helper fails"
+pass "tpod status stays informational when the executable selection helper fails"
+
+set +e
+absent_status_output="$(run_absent_helper_command status)"
+absent_status_status="$?"
+set -e
+assert_contains "$absent_status_output" "Warning: executable selection helper is missing" \
+  "tpod status reports an absent helper as missing"
+[ "$absent_status_status" -eq 0 ] ||
+  fail "tpod status stays informational when the executable selection helper is missing"
+pass "tpod status stays informational when the executable selection helper is missing"


### PR DESCRIPTION
Closes #155

## Problem

`run_executable_selection` (`dot_local/bin/executable_terrapod:960`) returned 1 for two unrelated conditions:

```sh
if [ ! -x "$executable_selection_helper" ]; then
  return 1
fi
```

So `status` and `apply` printed `Warning: executable selection helper is missing` for a helper that ran and failed, and `apply` discarded the real exit status. `run_doctor:1777` already tested `-x` first and handled the two cases separately.

The failure case is reachable: the helper exits 1 when `homebrew-prefix.sh` is unavailable (added in #186) and 2 on a bad mode. In `apply` and `status` modes it otherwise exits 0 regardless of findings, so a non-zero exit there means the helper itself is broken — not that a package is missing.

## Approach

- `executable_selection_helper_available()` owns the `-x` test; `run_executable_selection` returns only the helper's exit status. `run_doctor`'s inline `[ -x ... ]` uses the new predicate, unchanged in behavior.
- `run_status` and `run_apply` branch on the predicate first: absent → `helper is missing`, non-zero exit → `helper failed`.
- `run_apply` records either condition in `executable_selection_status` and returns it. Post-apply validation and install warning output still run first, and a validation failure still wins the exit status.

`tpod status` stays informational (exit 0 either way), per `CONTEXT.md:249`.

### Why a broken helper fails `apply`

Both conditions fail apply, not just the failure case. chezmoi manages the helper, so an absent helper after apply means apply did not reach its declared state — the same class of problem `run_post_apply_validation` already fails on.

This propagates: `install.sh:1260` treats a non-zero `tpod apply` as `fatal`, so a broken helper now hard-fails first-run installation. That matches what a post-apply validation failure already does there.

### ADR 0012 is not affected

ADR 0012 keeps selection *findings* out of `apply`/`update`/`status` exit semantics. This change is about the helper *malfunctioning*. The helper's `apply` mode exits 0 regardless of findings, so the boundary holds. `CONTEXT.md` states it explicitly:

> `tpod apply` treats a missing or failing executable selection helper as a broken Terrapod command surface and exits non-zero, while executable selection advisories from a successful helper run do not change exit status.

## Tests

Written test-first; the failing-helper case was red before the change (it produced `helper is missing`).

`tests/executable_selection_test.sh` adds six assertions across `apply` and `status` for three helper states — failing, absent, succeeding — checking both the message and the exit status.

Two fixture notes:

- The existing integration stub exited 1 while asserting only on advisory output, so it was silently exercising the "missing" warning. It now exits 0, matching the real helper's apply mode, and a new assertion checks that a succeeding helper produces no warning at all.
- `executable_terrapod:19-22` falls back to the chezmoi-named helper beside itself when the configured path does not exist, so pointing `TERRAPOD_EXECUTABLE_SELECTION_HELPER` at a nonexistent file is not enough. The absent-helper cases run a copy of the command under a root whose `lib/terrapod/` carries `install-warnings.sh` and `homebrew-prefix.sh` but no helper.

Full suite green: 18 `.sh` suites (1,946 assertions) + 2 `.zsh` suites. `homebrew_ubuntu_smoke.sh` needs Docker and was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CdAw1bKKPMx4AgsLPzzNSv
