### PR TITLE
Keep a failed recovery cleanup from changing the install outcome

### DIFF
--- a/dot_local/lib/terrapod/executable_jetendard-font
+++ b/dot_local/lib/terrapod/executable_jetendard-font
@@ -110,7 +110,7 @@ def atomic_json(path: Path, data: dict) -> None:
         os.chmod(temporary, 0o600)
         os.replace(temporary, path)
     finally:
-        if os.path.exists(temporary):
+        if os.path.lexists(temporary):
             os.unlink(temporary)
 
 
@@ -177,7 +177,10 @@ def create_transaction(recovery_root: Path) -> Path:
 
 
 def cleanup_transaction(transaction: Path, recovery_root: Path) -> None:
-    shutil.rmtree(transaction)
+    try:
+        shutil.rmtree(transaction)
+    except OSError:
+        pass
     try:
         recovery_root.rmdir()
     except OSError:

--- a/tests/jetendard_font_test.sh
+++ b/tests/jetendard_font_test.sh
@@ -558,5 +558,47 @@ metadata = json.loads((recovery / "transaction.json").read_text())
 assert metadata["status"] == "rollback_failed"
 assert "manifest.json" in metadata["rollback_errors"][0]
 assert (fonts / "Jetendard-Manual.ttf").read_text() == "manual\n"
+
+home, state = scenario("cleanup-success")
+real_rmtree = module.shutil.rmtree
+cleanup_targets = []
+def fail_transaction_cleanup(path, *args, **kwargs):
+    target = Path(path)
+    if target.name.startswith("rollback-"):
+        cleanup_targets.append(target)
+        raise OSError("injected transaction cleanup failure")
+    return real_rmtree(path, *args, **kwargs)
+module.shutil.rmtree = fail_transaction_cleanup
+try:
+    result, stdout, stderr = cli_install(home)
+finally:
+    module.shutil.rmtree = real_rmtree
+assert cleanup_targets, "transaction cleanup failure was not injected"
+assert result == 0, stderr
+assert not stderr
+assert "Installed Jetendard" in stdout
+assert (home / "Library" / "Fonts" / "Jetendard-Regular.ttf").read_text() == "replacement:Regular\n"
+module.check(home, str(state))
+assert cleanup_targets[0].exists()
+
+home, state = scenario("cleanup-after-rollback")
+before = snapshot(home, state)
+replacement_count = 0
+failed = False
+cleanup_targets = []
+module.os.replace = fail_late_replace
+module.shutil.rmtree = fail_transaction_cleanup
+try:
+    result, stdout, stderr = cli_install(home)
+finally:
+    module.os.replace = real_replace
+    module.shutil.rmtree = real_rmtree
+assert cleanup_targets, "transaction cleanup failure was not injected"
+assert result == 1 and not stdout
+assert stderr.count("\n") == 1
+assert "injected late font replacement failure" in stderr, stderr
+assert "injected transaction cleanup failure" not in stderr, stderr
+assert_snapshot(home, state, before)
 PY
 pass "installer rolls back failures and preserves backups when restore fails"
+pass "recovery cleanup failures never change the reported install outcome"


### PR DESCRIPTION
Closes #158

## Problem

`cleanup_transaction` removed the recovery transaction with an unguarded
`shutil.rmtree`, and it runs on three paths. On the success path the
fonts and the manifest are already committed, so an `rmtree` failure
turned a completed install into a nonzero `main()` and made the calling
script write a `jetendard-font` warning marker the contract reserves for
a failed rerun. On the two `except BaseException:` paths the same
failure replaced the error that caused the rollback, hiding what
actually went wrong.

## Approach

`shutil.rmtree` now sits in `try/except OSError: pass`, matching the
`recovery_root.rmdir()` call directly below it. `cleanup_transaction`
raises on no path, so the success path stays a success and the two
failure paths report their original error.

`ignore_errors=True` would have worked too, but it would leave one
function handling cleanup failures two different ways.

A transaction that cannot be removed stays in the state directory. That
costs a few KB of font backups and does not block later installs:
`create_transaction` allocates a fresh random name and the recovery root
keeps its mode-0700 check.

`atomic_json` now spells its temp-file check `os.path.lexists`, matching
`restore_path`. Behavior is unchanged — `mkstemp` never leaves a symlink
there — so this one ships without a test of its own.

## Tests

Two scenarios in `tests/jetendard_font_test.sh`, both injecting an
`OSError` from `shutil.rmtree` only for paths named `rollback-*` so the
`TemporaryDirectory` cleanup keeps working:

- `cleanup-success`: a completed install still exits 0 with no stderr,
  the new fonts and manifest are in place, `check` passes, and the
  undeleted transaction is still on disk
- `cleanup-after-rollback`: a late `os.replace` failure that rolls back
  cleanly still reports the replacement error, not the cleanup error

Verified red before the fix: the first failed with `Jetendard font:
injected transaction cleanup failure` instead of exiting 0, and the
second reported the cleanup error in place of the replacement error. All
20 test suites pass after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFV9MwqcnkNrfNP5dgr8i1

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
