### PR TITLE
Resolve every Terrapod helper path through one fallback

### DIFF
--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -15,13 +15,29 @@ command_dir="${command_path%/*}"
 command_dir="$(CDPATH= cd -- "$command_dir" 2>/dev/null && pwd || printf '%s\n' ".")"
 install_warnings_lib="${TERRAPOD_INSTALL_WARNINGS_LIB:-$command_dir/../lib/terrapod/install-warnings.sh}"
 homebrew_prefix_lib="${TERRAPOD_HOMEBREW_PREFIX_LIB:-$command_dir/../lib/terrapod/homebrew-prefix.sh}"
-executable_selection_helper="${TERRAPOD_EXECUTABLE_SELECTION_HELPER:-$command_dir/../lib/terrapod/executable-selection}"
-if [ ! -e "$executable_selection_helper" ] &&
-  [ -e "$command_dir/../lib/terrapod/executable_executable-selection" ]; then
-  executable_selection_helper="$command_dir/../lib/terrapod/executable_executable-selection"
-fi
-jetendard_font_helper="${TERRAPOD_JETENDARD_FONT_HELPER:-$command_dir/../lib/terrapod/jetendard-font}"
-jetendard_settings_helper="${TERRAPOD_JETENDARD_SETTINGS_HELPER:-$command_dir/../lib/terrapod/jetendard-settings}"
+# Helpers ship as 'lib/terrapod/<name>' but are tracked under the chezmoi
+# source name 'executable_<name>', so a command run straight from the checkout
+# resolves the source name. An explicit override is used as given.
+resolve_helper() {
+  override="$1"
+  name="$2"
+
+  if [ -n "$override" ]; then
+    printf '%s\n' "$override"
+    return 0
+  fi
+
+  helper_path="$command_dir/../lib/terrapod/$name"
+  if [ ! -e "$helper_path" ] &&
+    [ -e "$command_dir/../lib/terrapod/executable_$name" ]; then
+    helper_path="$command_dir/../lib/terrapod/executable_$name"
+  fi
+  printf '%s\n' "$helper_path"
+}
+
+executable_selection_helper="$(resolve_helper "${TERRAPOD_EXECUTABLE_SELECTION_HELPER:-}" executable-selection)"
+jetendard_font_helper="$(resolve_helper "${TERRAPOD_JETENDARD_FONT_HELPER:-}" jetendard-font)"
+jetendard_settings_helper="$(resolve_helper "${TERRAPOD_JETENDARD_SETTINGS_HELPER:-}" jetendard-settings)"
 TERRAPOD_INSTALL_WARNINGS_LOADED=
 if [ -f "$install_warnings_lib" ]; then
   . "$install_warnings_lib"

--- a/tests/executable_selection_test.sh
+++ b/tests/executable_selection_test.sh
@@ -361,21 +361,11 @@ run_integration_command() {
 }
 
 run_absent_helper_command() {
-  run_integration_terrapod "$absent_helper" "$absent_root/bin/terrapod" "$@"
+  run_integration_command "$absent_helper" "$@"
 }
 
 failing_helper="$integration_bin/executable-selection-failing"
 absent_helper="$integration_bin/executable-selection-absent"
-
-# The installed command falls back to the chezmoi-named helper next to itself
-# when the configured path does not exist, so an absent helper only stays
-# absent under a command root that carries no helper of its own.
-absent_root="$tmp_dir/absent-root"
-mkdir -p "$absent_root/bin" "$absent_root/lib/terrapod"
-cp "$repo_root/dot_local/bin/executable_terrapod" "$absent_root/bin/terrapod"
-for lib in install-warnings.sh homebrew-prefix.sh; do
-  cp "$repo_root/dot_local/lib/terrapod/$lib" "$absent_root/lib/terrapod/$lib"
-done
 
 set +e
 failing_apply_output="$(run_integration_command "$failing_helper" apply)"

--- a/tests/helper_resolution_test.sh
+++ b/tests/helper_resolution_test.sh
@@ -1,0 +1,119 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+terrapod="$repo_root/dot_local/bin/executable_terrapod"
+tmp_dir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT INT TERM
+
+fail() {
+  printf '%s\n' "not ok - $1" >&2
+  exit 1
+}
+
+pass() {
+  printf '%s\n' "ok - $1"
+}
+
+assert_contains() {
+  text="$1"
+  expected="$2"
+  label="$3"
+  case "$text" in
+    *"$expected"*) pass "$label" ;;
+    *)
+      printf '%s\n' "$text" >&2
+      fail "$label (missing: $expected)"
+      ;;
+  esac
+}
+
+assert_not_contains() {
+  text="$1"
+  unexpected="$2"
+  label="$3"
+  case "$text" in
+    *"$unexpected"*)
+      printf '%s\n' "$text" >&2
+      fail "$label (unexpected: $unexpected)"
+      ;;
+    *) pass "$label" ;;
+  esac
+}
+
+stub_bin="$tmp_dir/bin"
+config_file="$tmp_dir/config/chezmoi.toml"
+home_dir="$tmp_dir/home"
+mkdir -p \
+  "$stub_bin" \
+  "${config_file%/*}" \
+  "$home_dir/.local/state/terrapod/jetendard" \
+  "$home_dir/Library/Fonts"
+
+cat >"$home_dir/.local/state/terrapod/jetendard/manifest.json" <<'JSON'
+{
+  "tag": "v1.0.0",
+  "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "files": ["Jetendard-Regular.ttf"]
+}
+JSON
+printf '%s\n' "test font" >"$home_dir/Library/Fonts/Jetendard-Regular.ttf"
+
+cat >"$config_file" <<'EOF'
+[data]
+profile = "macos-terminal"
+enableEditorStack = false
+enableAiCliTools = false
+enableDevelopmentWorkspace = false
+enableMacosAppGroupTerminalApps = false
+enableMacosAppGroupAutomation = false
+enableMacosAppGroupLauncher = false
+enableMacosAppGroupMonitoring = false
+enableMacosAppGroupDevelopmentApps = false
+enableMacosAppGroupMobileDev = false
+EOF
+
+cat >"$stub_bin/chezmoi" <<'EOF'
+#!/bin/sh
+case " $* " in
+  *" managed "*)
+    printf '%s\n' ".local/bin/terrapod" ".local/bin/tpod"
+    ;;
+esac
+EOF
+chmod +x "$stub_bin/chezmoi"
+
+python3_path="$(command -v python3 2>/dev/null || true)"
+[ -n "$python3_path" ] || fail "helper resolution tests require python3"
+ln -s "$python3_path" "$stub_bin/python3"
+
+# The source checkout carries chezmoi source names, so running the command from
+# the checkout must still resolve every helper next to it. install.sh points
+# users at this path for setup recovery.
+run_from_checkout() {
+  HOME="$home_dir" \
+    TERRAPOD_PROFILE=macos-terminal \
+    TERRAPOD_CHEZMOI_CONFIG="$config_file" \
+    PATH="$stub_bin:/usr/bin:/bin" \
+    /bin/sh "$terrapod" "$@" 2>&1
+}
+
+set +e
+checkout_status_output="$(run_from_checkout status)"
+checkout_doctor_output="$(run_from_checkout doctor)"
+set -e
+
+assert_contains "$checkout_status_output" "Jetendard font                : installed" \
+  "tpod status resolves the Jetendard font helper from the source checkout"
+assert_not_contains "$checkout_status_output" "executable selection helper is missing" \
+  "tpod status resolves the executable selection helper from the source checkout"
+assert_not_contains "$checkout_doctor_output" "Jetendard checker is unavailable" \
+  "tpod doctor resolves the Jetendard font and settings helpers from the source checkout"
+assert_not_contains "$checkout_doctor_output" "executable selection helper is missing" \
+  "tpod doctor resolves the executable selection helper from the source checkout"
+
+printf '%s\n' "all helper resolution tests passed"


### PR DESCRIPTION
Closes #156

## Problem

`dot_local/bin/executable_terrapod` resolved three helpers next to itself. Only one of them handled the chezmoi source name:

```sh
executable_selection_helper="${TERRAPOD_EXECUTABLE_SELECTION_HELPER:-$command_dir/../lib/terrapod/executable-selection}"
if [ ! -e "$executable_selection_helper" ] && ...
jetendard_font_helper="${TERRAPOD_JETENDARD_FONT_HELPER:-$command_dir/../lib/terrapod/jetendard-font}"
jetendard_settings_helper="${TERRAPOD_JETENDARD_SETTINGS_HELPER:-$command_dir/../lib/terrapod/jetendard-settings}"
```

The tracked files are `executable_jetendard-font` and `executable_jetendard-settings`, so both Jetendard paths miss in a checkout. `install.sh:963-967` points users at `./dot_local/bin/executable_terrapod setup` for setup recovery, so this is a path users are told to take: `tpod status` reported `Jetendard font: missing` and `tpod doctor` reported `Jetendard checker is unavailable` for all four components on a healthy machine.

## Approach

One `resolve_helper <override> <name>` applies the `executable_` fallback for all three helpers.

An explicit `TERRAPOD_*_HELPER` override is now used as given. Before, the `-e` test ran after the default expansion, so an override pointing at a missing file was silently replaced by the source-tree helper — that hid a misconfigured override behind a different file.

## Tests

`tests/helper_resolution_test.sh` runs `status` and `doctor` from the checkout with no helper overrides set, against a HOME seeded with a Jetendard manifest and font. It asserts `Jetendard font: installed` — the font state is a fixture, so the assertion fails when the helper path does not resolve. It failed before this change.

`tests/executable_selection_test.sh` built an `absent_root` copy of the command tree so an absent helper would not hit the fallback. With overrides respected, that scaffolding and its comment are gone. Mutating `resolve_helper` to apply the fallback to overrides makes that suite fail on `tpod apply reports an absent helper as missing`, so the override precedence is covered.

Full suite green, except `tests/homebrew_ubuntu_smoke.sh` which needs Docker/Ubuntu and was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuQnUqqBDH7GAhJ4oqZdS7