### PR TITLE
Read per-item brew bundle records from a dedicated descriptor

### DIFF
--- a/.chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl
+++ b/.chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl
@@ -153,7 +153,9 @@ run_desktop_app_bundle() {
   fi
 
   tab="$(printf '\t')"
-  while IFS="$tab" read -r app_group token declaration; do
+  # Keep the record list on fd 3 so a cask post-install step that reads stdin
+  # cannot consume the remaining packages and silently skip them.
+  while IFS="$tab" read -r app_group token declaration <&3; do
     single_package_brewfile="$(mktemp "${TMPDIR:-/tmp}/terrapod-macos-desktop-package.XXXXXX")" || {
       cleanup_desktop_app_bundle_temps
       return 1
@@ -178,7 +180,7 @@ run_desktop_app_bundle() {
 
     rm -f "$single_package_brewfile"
     single_package_brewfile=
-  done <"$records_file"
+  done 3<"$records_file"
 
   if [ -s "$failed_casks_file" ]; then
     if ! failed_casks="$(join_lines_with_commas "$failed_casks_file")"; then

--- a/dot_local/lib/terrapod/homebrew-core-bundle.sh
+++ b/dot_local/lib/terrapod/homebrew-core-bundle.sh
@@ -131,7 +131,9 @@ terrapod_homebrew_core_run_bundle() {
   fi
 
   tab="$(printf '\t')"
-  while IFS="$tab" read -r item_kind item_name; do
+  # Keep the record list on fd 3 so a brew bundle run that reads stdin cannot
+  # consume the remaining items and silently skip them.
+  while IFS="$tab" read -r item_kind item_name <&3; do
     single_core_brewfile="$(mktemp "${TMPDIR:-/tmp}/terrapod-homebrew-core-item.XXXXXX")" || {
       terrapod_homebrew_core_cleanup_temps
       return 1
@@ -166,7 +168,7 @@ terrapod_homebrew_core_run_bundle() {
 
     rm -f "$single_core_brewfile"
     single_core_brewfile=
-  done <"$core_records_file"
+  done 3<"$core_records_file"
 
   terrapod_homebrew_core_failure_guidance_from_files || {
     terrapod_homebrew_core_cleanup_temps

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -489,6 +489,9 @@ write_brew_bundle_stub() {
     '    ;;' \
     '  analytics) exit 0 ;;' \
     '  bundle)' \
+    '    if [ "${MACOS_BREW_DRAIN_STDIN:-}" = "1" ]; then' \
+    '      cat >/dev/null' \
+    '    fi' \
     '    if [ "${MACOS_BREW_ECHO_OUTPUT:-}" = "1" ]; then' \
     '      printf "%s\n" "visible brew bundle output: $*"' \
     '    fi' \
@@ -932,6 +935,23 @@ assert_not_contains_text "$core_retry_failure_marker_text" "old core retry warni
 
 assert_contains_text "$core_retry_failure_marker_text" "updated_at='" "failed core reconciliation replacement marker keeps updated_at"
 
+# A cask post-install step that reads stdin must not consume the per-item record
+# list, which would silently skip every package after the first.
+core_stdin_bin="$tmp_dir/core-stdin-bin"
+core_stdin_state="$tmp_dir/core-stdin-state"
+core_stdin_home="$tmp_dir/core-stdin-home"
+core_stdin_log="$tmp_dir/core-stdin-brew.log"
+mkdir -p "$core_stdin_bin" "$core_stdin_home"
+write_brew_bundle_stub "$core_stdin_bin/brew"
+
+if ! HOME="$core_stdin_home" XDG_STATE_HOME="$core_stdin_state" MACOS_BREW_LOG="$core_stdin_log" MACOS_BREW_FAIL_CORE_BULK=1 MACOS_BREW_FAIL_FORMULAE="bat zoxide" MACOS_BREW_DRAIN_STDIN=1 PATH="$core_stdin_bin:/usr/bin:/bin" \
+  sh "$macos_bootstrap_script" >"$tmp_dir/core-stdin.out" 2>"$tmp_dir/core-stdin.err" </dev/null; then
+  fail "core reconciliation survives a brew bundle that reads stdin"
+fi
+
+core_stdin_marker_text="$(cat "$core_stdin_state/terrapod/install-warnings/homebrew-core")"
+assert_contains_text "$core_stdin_marker_text" "failed formulae: bat, zoxide" "core retry keeps reading records when brew bundle consumes stdin"
+
 mise_missing_without_core_home="$tmp_dir/mise-missing-without-core-home"
 mise_missing_without_core_state="$tmp_dir/mise-missing-without-core-state"
 mkdir -p "$mise_missing_without_core_home"
@@ -1227,6 +1247,23 @@ assert_contains_text "$terminal_launcher_marker_text" "summary='Homebrew desktop
 assert_contains_text "$terminal_launcher_marker_text" "failed casks: ghostty, raycast" "desktop app marker guidance includes only casks whose single-cask bundle failed"
 assert_contains_text "$terminal_launcher_marker_text" "App Groups: terminal-apps, launcher" "desktop app marker guidance includes enabled App Groups"
 assert_not_contains_text "$terminal_launcher_marker_text" "1password-cli" "desktop app marker excludes casks whose single-cask bundle succeeded"
+
+# Same stdin hazard as the core retry loop: ghostty is the first record, so a
+# stdin-reading brew would hide the later raycast failure entirely.
+desktop_stdin_bin="$tmp_dir/desktop-stdin-bin"
+desktop_stdin_state="$tmp_dir/desktop-stdin-state"
+desktop_stdin_home="$tmp_dir/desktop-stdin-home"
+desktop_stdin_log="$tmp_dir/desktop-stdin-brew.log"
+mkdir -p "$desktop_stdin_bin" "$desktop_stdin_home"
+write_brew_bundle_stub "$desktop_stdin_bin/brew"
+
+if ! HOME="$desktop_stdin_home" XDG_STATE_HOME="$desktop_stdin_state" MACOS_BREW_LOG="$desktop_stdin_log" MACOS_BREW_FAIL_DESKTOP_BULK=1 MACOS_BREW_FAIL_CASKS="ghostty raycast" MACOS_BREW_DRAIN_STDIN=1 PATH="$desktop_stdin_bin:/usr/bin:/bin" \
+  sh "$terminal_launcher_bootstrap_script" >"$tmp_dir/desktop-stdin.out" 2>"$tmp_dir/desktop-stdin.err" </dev/null; then
+  fail "desktop app reconciliation survives a brew bundle that reads stdin"
+fi
+
+desktop_stdin_marker_text="$(cat "$desktop_stdin_state/terrapod/install-warnings/homebrew-desktop-apps")"
+assert_contains_text "$desktop_stdin_marker_text" "failed casks: ghostty, raycast" "desktop app retry keeps reading records when brew bundle consumes stdin"
 
 core_then_desktop_bin="$tmp_dir/core-then-desktop-bin"
 core_then_desktop_state="$tmp_dir/core-then-desktop-state"


### PR DESCRIPTION
Closes #159

## Problem

Both per-item retry loops fed their record file to the loop on stdin:

```sh
while IFS="$tab" read -r item_kind item_name; do
  ... brew bundle --file="$single_core_brewfile" ...
done <"$core_records_file"
```

`brew bundle` runs in the loop body with the record file still on fd 0, so anything brew or a cask's post-install step reads consumes the remaining records. The loop then ends early: every package after that point is never attempted, and its failure never reaches the warning marker.

That under-reports rather than over-reports, which is the direction `CONTEXT.md` rules out — marker detail should reflect reliable observations only.

Reproduced with a stub that drains stdin. The core loop stopped after two `brew bundle` calls (the bulk run plus the first record, `bat`), and the desktop loop recorded `failed casks: ghostty` while `raycast` was never attempted at all.

## Approach

Move the record list to fd 3 in both loops:

```sh
while IFS="$tab" read -r item_kind item_name <&3; do
  ...
done 3<"$core_records_file"
```

The alternative was `</dev/null` on each `brew bundle`. fd 3 wins on three counts: it is two lines per loop instead of one per call site, it protects any command later added to the loop body rather than only the ones flagged today, and it leaves brew holding the script's real stdin, so an interactive `chezmoi apply` behaves exactly as before.

The repo's other `read` loops — `install.sh:55`, `executable-selection`, `executable_terrapod`, and the Ubuntu smoke fixture — run only `printf`, `case`, and `command -v` in their bodies and are left alone.

## Tests

Written test-first; both cases were red before the change.

`write_brew_bundle_stub` in `tests/chezmoiignore_test.sh` gains a `MACOS_BREW_DRAIN_STDIN=1` branch that runs `cat >/dev/null` at the top of the `bundle` case, standing in for a post-install step that reads stdin. Two scenarios use it:

- core: `MACOS_BREW_FAIL_CORE_BULK=1 MACOS_BREW_FAIL_FORMULAE="bat zoxide"`. `bat` is the first record in `Brewfile` and `zoxide` the last, so the marker has to name both.
- desktop: `MACOS_BREW_FAIL_DESKTOP_BULK=1 MACOS_BREW_FAIL_CASKS="ghostty raycast"`, where `ghostty` is the first record.

Both invocations redirect stdin from `/dev/null`, because the bulk `brew bundle` that runs before the loop would otherwise drain the test script's own stdin.

Full suite green: 18 `.sh` suites (1,984 assertions) + 2 `.zsh` suites. `homebrew_ubuntu_smoke.sh` needs Docker and was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Zmn9uxENv5xftt4raE7zq
