### PR TITLE
Load install warnings by a chosen rule per entry point

### DIFF
--- a/.chezmoiscripts/run_after_20-install-mise-tools.sh.tmpl
+++ b/.chezmoiscripts/run_after_20-install-mise-tools.sh.tmpl
@@ -5,41 +5,9 @@ set -eu
 
 {{ include "dot_local/lib/terrapod/homebrew-prefix.sh" }}
 
-install_warnings_lib="{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/install-warnings.sh"
-TERRAPOD_INSTALL_WARNINGS_LOADED=
-if [ -f "$install_warnings_lib" ]; then
-  . "$install_warnings_lib"
-fi
+{{ include "dot_local/lib/terrapod/install-warnings.sh" }}
 
-INSTALL_WARNING_RECORDED=0
-
-mark_install_warning() {
-  category="$1"
-  summary="$2"
-  guidance="$3"
-  INSTALL_WARNING_RECORDED=0
-
-  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ] &&
-    terrapod_install_warning_write "$category" "$summary" "$guidance"; then
-    INSTALL_WARNING_RECORDED=1
-  fi
-}
-
-exit_after_install_warning() {
-  if [ "$INSTALL_WARNING_RECORDED" -eq 1 ]; then
-    exit 0
-  fi
-
-  exit 1
-}
-
-clear_install_warning() {
-  category="$1"
-
-  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ]; then
-    terrapod_install_warning_clear "$category" || true
-  fi
-}
+{{ include "dot_local/lib/terrapod/install-warning-script.sh" }}
 
 failed_mise_steps=
 

--- a/.chezmoiscripts/run_after_70-apply-jetendard-settings.sh.tmpl
+++ b/.chezmoiscripts/run_after_70-apply-jetendard-settings.sh.tmpl
@@ -1,18 +1,18 @@
 {{ if eq .chezmoi.os "darwin" -}}
 #!/bin/sh
-set -u
+set -eu
 
-warnings_lib="{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/install-warnings.sh"
+{{ include "dot_local/lib/terrapod/install-warnings.sh" }}
+
 settings_helper="{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/executable_jetendard-settings"
-. "$warnings_lib"
 
 if ! command -v python3 >/dev/null 2>&1; then
   terrapod_install_warning_write jetendard-settings "Jetendard app settings need attention" "Restore Python, quit Orca, then rerun tpod apply." || exit 1
   exit 0
 fi
 
-python3 "$settings_helper" apply
-settings_status="$?"
+settings_status=0
+python3 "$settings_helper" apply || settings_status="$?"
 case "$settings_status" in
   0)
     terrapod_install_warning_clear jetendard-settings || exit 1

--- a/.chezmoiscripts/run_before_01-retry-ubuntu-bootstrap.sh.tmpl
+++ b/.chezmoiscripts/run_before_01-retry-ubuntu-bootstrap.sh.tmpl
@@ -2,11 +2,7 @@
 #!/bin/sh
 set -eu
 
-install_warnings_lib="{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/install-warnings.sh"
-if [ ! -f "$install_warnings_lib" ]; then
-  exit 0
-fi
-. "$install_warnings_lib"
+{{ include "dot_local/lib/terrapod/install-warnings.sh" }}
 
 if ! terrapod_install_warning_existing_path ubuntu-bootstrap >/dev/null 2>&1; then
   exit 0

--- a/.chezmoiscripts/run_before_02-retry-jetendard-font.sh.tmpl
+++ b/.chezmoiscripts/run_before_02-retry-jetendard-font.sh.tmpl
@@ -1,10 +1,10 @@
 {{ if eq .chezmoi.os "darwin" -}}
 #!/bin/sh
-set -u
+set -eu
 
-warnings_lib="{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/install-warnings.sh"
+{{ include "dot_local/lib/terrapod/install-warnings.sh" }}
+
 font_helper="{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/executable_jetendard-font"
-. "$warnings_lib"
 
 if ! terrapod_install_warning_existing_path jetendard-font >/dev/null 2>&1; then
   exit 0

--- a/.chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl
+++ b/.chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl
@@ -14,58 +14,11 @@ set -eu
 
 {{ include "dot_local/lib/terrapod/homebrew-prefix.sh" }}
 
-install_warnings_lib="{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/install-warnings.sh"
-TERRAPOD_INSTALL_WARNINGS_LOADED=
-if [ -f "$install_warnings_lib" ]; then
-  . "$install_warnings_lib"
-fi
+{{ include "dot_local/lib/terrapod/install-warnings.sh" }}
 
-homebrew_core_bundle_lib="{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/homebrew-core-bundle.sh"
-TERRAPOD_HOMEBREW_CORE_BUNDLE_LOADED=
-if [ -f "$homebrew_core_bundle_lib" ]; then
-  . "$homebrew_core_bundle_lib"
-fi
+{{ include "dot_local/lib/terrapod/install-warning-script.sh" }}
 
-INSTALL_WARNING_RECORDED=0
-
-mark_install_warning() {
-  category="$1"
-  summary="$2"
-  guidance="$3"
-  INSTALL_WARNING_RECORDED=0
-
-  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ] &&
-    terrapod_install_warning_write "$category" "$summary" "$guidance"; then
-    INSTALL_WARNING_RECORDED=1
-    return 0
-  fi
-
-  return 1
-}
-
-exit_after_install_warning() {
-  if [ "$INSTALL_WARNING_RECORDED" -eq 1 ]; then
-    exit 0
-  fi
-
-  exit 1
-}
-
-continue_after_core_install_warning() {
-  if [ "$INSTALL_WARNING_RECORDED" -ne 1 ]; then
-    exit 1
-  fi
-
-  return 0
-}
-
-clear_install_warning() {
-  category="$1"
-
-  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ]; then
-    terrapod_install_warning_clear "$category" || true
-  fi
-}
+{{ include "dot_local/lib/terrapod/homebrew-core-bundle.sh" }}
 
 join_lines_with_commas() {
   awk '
@@ -298,29 +251,17 @@ core_brewfile="{{ .chezmoi.sourceDir }}/Brewfile"
 
 # Core Brewfile checksum: {{ include "Brewfile" | sha256sum }}
 if [ -f "$core_brewfile" ]; then
-  if [ "${TERRAPOD_HOMEBREW_CORE_BUNDLE_LOADED:-}" = "1" ]; then
-    if terrapod_homebrew_core_run_bundle "$core_brewfile"; then
-      clear_install_warning homebrew-core
-    else
-      if [ -z "${TERRAPOD_HOMEBREW_CORE_FAILURE_GUIDANCE_TEXT:-}" ]; then
-        TERRAPOD_HOMEBREW_CORE_FAILURE_GUIDANCE_TEXT="Review Homebrew core bundle output, fix package access, then rerun tpod apply."
-      fi
-      mark_install_warning \
-        homebrew-core \
-        "Homebrew core install needs attention" \
-        "$TERRAPOD_HOMEBREW_CORE_FAILURE_GUIDANCE_TEXT"
-      continue_after_core_install_warning
-    fi
+  if terrapod_homebrew_core_run_bundle "$core_brewfile"; then
+    clear_install_warning homebrew-core
   else
-    if HOMEBREW_NO_AUTO_UPDATE=1 brew bundle --no-upgrade --file="$core_brewfile"; then
-      clear_install_warning homebrew-core
-    else
-      mark_install_warning \
-        homebrew-core \
-        "Homebrew core install needs attention" \
-        "Review Homebrew core bundle output, fix package access, then rerun tpod apply."
-      continue_after_core_install_warning
+    if [ -z "${TERRAPOD_HOMEBREW_CORE_FAILURE_GUIDANCE_TEXT:-}" ]; then
+      TERRAPOD_HOMEBREW_CORE_FAILURE_GUIDANCE_TEXT="Review Homebrew core bundle output, fix package access, then rerun tpod apply."
     fi
+    mark_install_warning \
+      homebrew-core \
+      "Homebrew core install needs attention" \
+      "$TERRAPOD_HOMEBREW_CORE_FAILURE_GUIDANCE_TEXT"
+    continue_after_core_install_warning
   fi
 fi
 
@@ -343,9 +284,8 @@ if [ -s "$desktop_brewfile" ]; then
     mark_install_warning \
       homebrew-desktop-apps \
       "Homebrew desktop app install needs attention" \
-      "$desktop_app_failure_guidance_text" ||
-      exit 1
-    exit 0
+      "$desktop_app_failure_guidance_text"
+    exit_after_install_warning
   fi
 fi
 {{ else -}}

--- a/.chezmoiscripts/run_before_30-install-shell-integrations.sh.tmpl
+++ b/.chezmoiscripts/run_before_30-install-shell-integrations.sh.tmpl
@@ -4,47 +4,11 @@ set -eu
 
 {{ include "dot_local/lib/terrapod/homebrew-prefix.sh" }}
 
-install_warnings_lib="{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/install-warnings.sh"
-TERRAPOD_INSTALL_WARNINGS_LOADED=
-if [ -f "$install_warnings_lib" ]; then
-  . "$install_warnings_lib"
-fi
+{{ include "dot_local/lib/terrapod/install-warnings.sh" }}
 
-INSTALL_WARNING_RECORDED=0
-
-mark_install_warning() {
-  category="$1"
-  summary="$2"
-  guidance="$3"
-  INSTALL_WARNING_RECORDED=0
-
-  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ] &&
-    terrapod_install_warning_write "$category" "$summary" "$guidance"; then
-    INSTALL_WARNING_RECORDED=1
-  fi
-}
-
-exit_after_install_warning() {
-  if [ "$INSTALL_WARNING_RECORDED" -eq 1 ]; then
-    exit 0
-  fi
-
-  exit 1
-}
-
-clear_install_warning() {
-  category="$1"
-
-  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ]; then
-    terrapod_install_warning_clear "$category" || true
-  fi
-}
+{{ include "dot_local/lib/terrapod/install-warning-script.sh" }}
 
 shell_integrations_warning_exists() {
-  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" != "1" ]; then
-    return 1
-  fi
-
   terrapod_install_warning_existing_path shell-integrations >/dev/null 2>&1
 }
 

--- a/.chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl
+++ b/.chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl
@@ -4,32 +4,11 @@ set -eu
 
 {{ include "dot_local/lib/terrapod/homebrew-prefix.sh" }}
 
+{{ include "dot_local/lib/terrapod/install-warnings.sh" }}
+
+{{ include "dot_local/lib/terrapod/install-warning-script.sh" }}
+
 AI_CLI_WARNING_CATEGORY=optional-ai-cli-tools
-install_warnings_lib="{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/install-warnings.sh"
-TERRAPOD_INSTALL_WARNINGS_LOADED=
-if [ -f "$install_warnings_lib" ]; then
-  . "$install_warnings_lib"
-fi
-
-mark_install_warning() {
-  category="$1"
-  summary="$2"
-  guidance="$3"
-
-  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" != "1" ]; then
-    return 1
-  fi
-
-  terrapod_install_warning_write "$category" "$summary" "$guidance"
-}
-
-clear_install_warning() {
-  category="$1"
-
-  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ]; then
-    terrapod_install_warning_clear "$category" || true
-  fi
-}
 
 {{ if not (and (eq .chezmoi.os "darwin") (or (default false (get . "enableAiCliTools")) (default false (get . "enableDevelopmentWorkspace")))) }}
 clear_install_warning "$AI_CLI_WARNING_CATEGORY"
@@ -45,10 +24,12 @@ trap cleanup_ai_cli_install EXIT HUP INT TERM
 
 finish_ai_cli_install() {
   if [ "$1" -ne 0 ]; then
-    if ! mark_install_warning \
+    mark_install_warning \
       "$AI_CLI_WARNING_CATEGORY" \
       "Optional AI CLI tool install needs attention" \
-      "Homebrew setup or the AI CLI bundle failed. Review Homebrew output and network access, then rerun tpod apply."; then
+      "Homebrew setup or the AI CLI bundle failed. Review Homebrew output and network access, then rerun tpod apply."
+
+    if ! install_warning_recorded; then
       echo "Failed to record Optional AI CLI tool install warning." >&2
       return 1
     fi

--- a/.chezmoiscripts/run_onchange_after_65-install-jetendard-font.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_65-install-jetendard-font.sh.tmpl
@@ -1,7 +1,9 @@
 {{ if eq .chezmoi.os "darwin" -}}
 #!/bin/sh
-set -u
+set -eu
 
+# Sourced by path rather than inlined: inlining would put this library into the
+# run_onchange_ content hash, re-downloading the font on every library edit.
 warnings_lib="{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/install-warnings.sh"
 font_helper="{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/executable_jetendard-font"
 # Jetendard font helper checksum: {{ include "dot_local/lib/terrapod/executable_jetendard-font" | sha256sum }}

--- a/.chezmoiscripts/run_onchange_before_00-bootstrap-ubuntu.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_before_00-bootstrap-ubuntu.sh.tmpl
@@ -2,45 +2,14 @@
 #!/bin/sh
 set -eu
 
-install_warnings_lib="{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/install-warnings.sh"
-TERRAPOD_INSTALL_WARNINGS_LOADED=
-if [ -f "$install_warnings_lib" ]; then
-  . "$install_warnings_lib"
-fi
+# Sourced by path rather than inlined: inlining would put this library into the
+# run_onchange_ content hash, re-running the apt bootstrap on every library edit.
+. "{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/install-warnings.sh"
+. "{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/install-warning-script.sh"
 
 # Ubuntu bootstrap helper checksum: {{ include "dot_local/lib/terrapod/ubuntu-bootstrap.sh" | sha256sum }}
 ubuntu_bootstrap_lib="{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/ubuntu-bootstrap.sh"
 . "$ubuntu_bootstrap_lib"
-
-INSTALL_WARNING_RECORDED=0
-
-mark_install_warning() {
-  category="$1"
-  summary="$2"
-  guidance="$3"
-  INSTALL_WARNING_RECORDED=0
-
-  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ] &&
-    terrapod_install_warning_write "$category" "$summary" "$guidance"; then
-    INSTALL_WARNING_RECORDED=1
-  fi
-}
-
-exit_after_install_warning() {
-  if [ "$INSTALL_WARNING_RECORDED" -eq 1 ]; then
-    exit 0
-  fi
-
-  exit 1
-}
-
-clear_install_warning() {
-  category="$1"
-
-  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ]; then
-    terrapod_install_warning_clear "$category" || true
-  fi
-}
 
 os_id="{{ get .chezmoi.osRelease "id" }}"
 version_id="{{ get .chezmoi.osRelease "versionID" }}"

--- a/docs/adr/0016-load-install-warnings-by-a-chosen-rule.md
+++ b/docs/adr/0016-load-install-warnings-by-a-chosen-rule.md
@@ -30,6 +30,14 @@ as fatal, since a checkout missing the library is a broken clone.
 `TERRAPOD_INSTALL_WARNINGS_LOADED` is a load memo for `tpod` and nothing else.
 It never again decides whether warnings work.
 
+A script records a warning through one of two call shapes, chosen by whether it
+needs the exit policy. A script that must record a warning, then exit 0 because
+the user was already told, inlines `install-warning-script.sh` and calls its
+`mark_install_warning` / `install_warning_recorded` / `exit_after_install_warning`
+trio. A script that only writes or clears a marker, with no exit decision to
+make, calls `terrapod_install_warning_write` or `terrapod_install_warning_clear`
+directly and does not inline the policy layer.
+
 ## Considered Options
 
 - Inline everywhere, including the two `run_onchange_` scripts: rejected on the

--- a/docs/adr/0016-load-install-warnings-by-a-chosen-rule.md
+++ b/docs/adr/0016-load-install-warnings-by-a-chosen-rule.md
@@ -1,0 +1,67 @@
+# Load install warnings by a chosen rule per entry point
+
+Every consumer of `install-warnings.sh` loads it by one of three rules, chosen
+for that entry point rather than by habit. No rule can degrade quietly: the
+library is either compiled in, or its absence stops the script.
+
+Always-run chezmoi scripts inline the library with `{{ include }}`. Compile-time
+inlining is the default because it is the only rule under which the library
+cannot be missing, so no guard is needed and none can be reintroduced.
+
+The two `run_onchange_` scripts are the exception. They source the library by
+path, unguarded, under `set -e`. Chezmoi triggers `run_onchange_` scripts on
+rendered-content change, so inlining would put the library's bytes into the
+hash and re-run the work on every library edit — and neither piece of work is
+cheap. `install()` in `executable_jetendard-font` has no installed-state
+short-circuit: it always calls the GitHub releases API and downloads the full
+archive. `ubuntu-bootstrap.sh` always runs `apt-get update` and escalates
+through `sudo` for a non-root user. Both need network; one can raise an
+unexpected password prompt. Any future `run_onchange_` script that records
+install warnings follows this rule.
+
+`tpod` resolves the library lazily at each call site. A decision made once at
+process start is always wrong during the first-run apply, because the library
+target is created by that very apply.
+
+`install.sh` cannot use `{{ include }}` — it is a `curl | sh` bootstrap, not a
+chezmoi template. It loads the library once from the checkout and treats absence
+as fatal, since a checkout missing the library is a broken clone.
+
+`TERRAPOD_INSTALL_WARNINGS_LOADED` is a load memo for `tpod` and nothing else.
+It never again decides whether warnings work.
+
+## Considered Options
+
+- Inline everywhere, including the two `run_onchange_` scripts: rejected on the
+  cost above. `install-warnings.sh` changed seven times between `4d3a9dd` and
+  `f314327`, and its most common edit — a new name in
+  `terrapod_install_warning_categories()` — happens whenever a new install step
+  gains a warning category. Paying an `apt` run and a font download on every
+  machine for that is a worse trade than one documented exception.
+- Move `prune_retired_install_warnings` after the apply delegation so the
+  first-run prune works: rejected because ADR 0014 fixes that ordering so the
+  directory stays consistent when apply fails, and reversing it on unrelated
+  grounds is not this change's business.
+- Give `tpod` a `chezmoi source-path` fallback: rejected as machinery for a
+  state no code path produces. `tpod` already resolves the library relative to
+  its own directory, which covers running from a checkout; the only remaining
+  gap needs markers written by an apply that never wrote the library.
+
+## Consequences
+
+- The first-run prune remains a no-op, because it runs before the apply that
+  installs the library. A fresh machine has no markers to prune, so this costs
+  nothing. It is not a bug.
+- `mark_install_warning` never returns non-zero. Callers run under `set -e`, so
+  a failing bare call would kill the script before its exit policy runs. Code
+  that needs the outcome calls `install_warning_recorded`.
+- Editing `install-warnings.sh` does not re-run any `run_onchange_` script. A
+  future author who inlines it into one silently reintroduces that cost; the
+  loading-rule assertions in `tests/chezmoiignore_test.sh` fail if they do.
+- `install-warning-script.sh` deploys to `~/.local/lib/terrapod/` even though
+  only chezmoi scripts use it, following `homebrew-core-bundle.sh`. Making it
+  source-tree-only would need an unconditional `.chezmoiignore` entry, a shape
+  this repo does not otherwise use.
+- `run_before_10` no longer has a fallback branch that runs a bare `brew bundle`
+  when `homebrew-core-bundle.sh` fails to load. That branch existed only for a
+  state inlining makes impossible.

--- a/docs/superpowers/plans/2026-09-01-install-warnings-loading.md
+++ b/docs/superpowers/plans/2026-09-01-install-warnings-loading.md
@@ -1,0 +1,1359 @@
+# Install Warnings Loading Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the four ad-hoc ways eleven entry points load `install-warnings.sh` with three deliberate rules, so a missing library can no longer silently disable warning recording, warning reporting, or the retry path.
+
+**Architecture:** Always-run chezmoi scripts inline the library at compile time via `{{ include }}`. The two `run_onchange_` scripts source it by path, unguarded, under `set -e` — inlining would put the library into their rendered-content hash and re-run an `apt` bootstrap and a GitHub font download on every library edit. `tpod` resolves the library lazily at each call site. `install.sh` loads it once from the checkout and treats absence as fatal. The `mark`/`clear`/`exit` wrapper trio, currently duplicated five times with drift, moves into one new library.
+
+**Tech Stack:** POSIX `sh`, chezmoi templates (Go text/template), shell test scripts under `tests/` run as `sh tests/<name>.sh`.
+
+**Spec:** `docs/superpowers/specs/2026-09-01-install-warnings-loading-design.md`
+
+## Global Constraints
+
+- Every shell file is POSIX `sh`. No bashisms, no `local`.
+- Every chezmoi script under `.chezmoiscripts/` runs `set -eu`.
+- Existing behavior is preserved except where a task states otherwise. Exit codes, printed strings, and marker contents do not change.
+- `mark_install_warning` must never return non-zero. Callers run under `set -e`, and a failing bare call would kill the script before its `exit_after_install_warning` line runs.
+- Marker category names are fixed by `terrapod_install_warning_categories()`; no task adds or removes one.
+- Run a test file with `sh tests/<name>.sh`. It prints `ok - …` per assertion and exits non-zero on the first `not ok`.
+- The full relevant suite for this plan is: `tests/terrapod_command_test.sh`, `tests/terrapod_installer_test.sh`, `tests/chezmoiignore_test.sh`, `tests/bootstrap_ubuntu_test.sh`, `tests/shell_integrations_test.sh`. `chezmoiignore_test.sh` takes about 11 seconds; the others are comparable.
+
+---
+
+## Spec Correction Applied In This Plan
+
+The spec's "Fixture source directories gain a file" section says all three synthetic source trees need `install-warning-script.sh`. That is too broad, and this plan narrows it.
+
+Only `copy_desktop_apply_source_fixture` (`tests/terrapod_command_test.sh:551-575`) materializes `.chezmoiscripts/` and runs a real `chezmoi apply` against it, so only it needs the new file. `tests/terrapod_installer_test.sh:640` and `:816` build fixtures for a **stub** chezmoi; they never render a template, and they copy `install-warnings.sh` only so `install.sh`'s own loader finds it.
+
+Task 5 makes the one fixture change. Task 3 confirms the installer fixtures already satisfy the stricter `install.sh` loader.
+
+---
+
+## File Structure
+
+**Created:**
+- `dot_local/lib/terrapod/install-warning-script.sh` — installer policy layer: the `INSTALL_WARNING_RECORDED` flag and the five functions over it. Sourced or inlined only by `.chezmoiscripts/`.
+- `docs/adr/0016-load-install-warnings-by-a-chosen-rule.md` — records the three loading rules and the accepted first-run prune no-op.
+
+**Modified:**
+- `dot_local/bin/executable_terrapod` — one-shot load decision becomes a lazy loader.
+- `install.sh` — three guarded loaders become one unconditional load; two dead functions deleted.
+- `.chezmoiscripts/run_before_01-retry-ubuntu-bootstrap.sh.tmpl`
+- `.chezmoiscripts/run_before_02-retry-jetendard-font.sh.tmpl`
+- `.chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl`
+- `.chezmoiscripts/run_before_30-install-shell-integrations.sh.tmpl`
+- `.chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl`
+- `.chezmoiscripts/run_after_20-install-mise-tools.sh.tmpl`
+- `.chezmoiscripts/run_after_70-apply-jetendard-settings.sh.tmpl`
+- `.chezmoiscripts/run_onchange_before_00-bootstrap-ubuntu.sh.tmpl`
+- `.chezmoiscripts/run_onchange_after_65-install-jetendard-font.sh.tmpl`
+- `tests/terrapod_command_test.sh`, `tests/chezmoiignore_test.sh`
+
+**Unchanged on purpose:** `dot_local/lib/terrapod/install-warnings.sh`. Its `TERRAPOD_INSTALL_WARNINGS_LOADED=1` assignment stays; only the guards that read it are deleted. `.chezmoiignore` gains nothing — both libraries deploy, following `homebrew-core-bundle.sh`.
+
+---
+
+### Task 1: Add the installer policy library
+
+Creates the shared trio so later tasks have something to inline. No consumer changes yet, so the suite must stay green.
+
+**Files:**
+- Create: `dot_local/lib/terrapod/install-warning-script.sh`
+- Modify: `tests/terrapod_command_test.sh` (near `:846-848` and `:916`)
+
+**Interfaces:**
+- Consumes: `terrapod_install_warning_write`, `terrapod_install_warning_clear` from `dot_local/lib/terrapod/install-warnings.sh`.
+- Produces: global `INSTALL_WARNING_RECORDED`; functions `mark_install_warning category summary guidance` (always returns 0), `install_warning_recorded` (0 when the last mark succeeded), `exit_after_install_warning` (exits 0 or 1), `continue_after_core_install_warning` (returns 0 or exits 1), `clear_install_warning category` (always returns 0).
+
+- [ ] **Step 1: Write the failing tests**
+
+Find the block in `tests/terrapod_command_test.sh` that begins `assert_line \` with `".local/lib/terrapod/install-warnings.sh" \` (around line 845). Add immediately after that block:
+
+```sh
+assert_line \
+  "$managed_targets" \
+  ".local/lib/terrapod/install-warning-script.sh" \
+  "chezmoi manages the shared install warning script helper library"
+```
+
+Then find `sh -n "$install_warnings_lib" || fail "shared install warning marker library is valid POSIX shell"` (around line 916) and add after it:
+
+```sh
+install_warning_script_lib="$repo_root/dot_local/lib/terrapod/install-warning-script.sh"
+
+if [ ! -f "$install_warning_script_lib" ]; then
+  fail "shared install warning script helper library exists"
+fi
+pass "shared install warning script helper library exists"
+
+sh -n "$install_warning_script_lib" || fail "shared install warning script helper library is valid POSIX shell"
+pass "shared install warning script helper library is valid POSIX shell"
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `sh tests/terrapod_command_test.sh`
+Expected: FAIL with `not ok - chezmoi manages the shared install warning script helper library`
+
+- [ ] **Step 3: Create the library**
+
+Create `dot_local/lib/terrapod/install-warning-script.sh`:
+
+```sh
+#!/bin/sh
+
+# Installer-side policy over the install warning markers. Chezmoi scripts inline
+# or source this beside install-warnings.sh; tpod does not use it.
+#
+# There is deliberately no TERRAPOD_..._LOADED sentinel here. Nothing may branch
+# on whether this file loaded — that branch is the defect this library removes.
+
+INSTALL_WARNING_RECORDED=0
+
+# Records a warning marker. Never fails: callers run under `set -e`, and a
+# non-zero return here would kill the script before it reaches its exit policy.
+mark_install_warning() {
+  category="$1"
+  summary="$2"
+  guidance="$3"
+  INSTALL_WARNING_RECORDED=0
+
+  if terrapod_install_warning_write "$category" "$summary" "$guidance"; then
+    INSTALL_WARNING_RECORDED=1
+  fi
+
+  return 0
+}
+
+install_warning_recorded() {
+  [ "$INSTALL_WARNING_RECORDED" -eq 1 ]
+}
+
+# The user was told what went wrong, so the apply continues. If we could not
+# even record the warning, fail loudly instead of failing silently.
+exit_after_install_warning() {
+  if install_warning_recorded; then
+    exit 0
+  fi
+
+  exit 1
+}
+
+continue_after_core_install_warning() {
+  if ! install_warning_recorded; then
+    exit 1
+  fi
+
+  return 0
+}
+
+clear_install_warning() {
+  terrapod_install_warning_clear "$1" || true
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `sh tests/terrapod_command_test.sh`
+Expected: PASS, including the three new `ok -` lines.
+
+- [ ] **Step 5: Confirm nothing else broke**
+
+Run: `sh tests/chezmoiignore_test.sh`
+Expected: PASS. The new file has no profile scope, so it must not appear in the `macos_only_entries` or `linux_only_entries` lists (`:238-276`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dot_local/lib/terrapod/install-warning-script.sh tests/terrapod_command_test.sh
+git commit -m "Add shared install warning script helper library"
+```
+
+---
+
+### Task 2: Make tpod resolve the library lazily
+
+Fixes symptom 1: during the first-run apply, `tpod` starts before `~/.local/lib/terrapod/install-warnings.sh` exists and disables warning reporting for the whole run.
+
+**Files:**
+- Modify: `dot_local/bin/executable_terrapod:25-27`, `:1244-1246`, `:1519-1521`, `:1660-1663`, `:1685-1687`
+- Test: `tests/terrapod_command_test.sh`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `ensure_install_warnings_loaded` (returns 0 when `terrapod_install_warning_*` are callable, 1 otherwise) in `executable_terrapod`. No other file uses it.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/terrapod_command_test.sh`, before its final `pass`/exit. This mirrors the first-run sequence: the library path is absent when `tpod` starts, and the delegated apply creates it.
+
+```sh
+lazy_home="$tmp_dir/lazy-lib-home"
+lazy_state="$lazy_home/.local/state"
+lazy_lib="$tmp_dir/lazy-lib/install-warnings.sh"
+lazy_bin="$tmp_dir/lazy-lib-bin"
+lazy_config="$tmp_dir/lazy-lib-chezmoi.toml"
+mkdir -p "$lazy_home" "$lazy_state" "$lazy_bin" "$tmp_dir/lazy-lib"
+: >"$lazy_config"
+
+if [ -e "$lazy_lib" ]; then
+  fail "lazy library fixture starts without the install warning library"
+fi
+
+# The stub apply creates the library mid-run, exactly as the first real apply does.
+write_stub "$lazy_bin/chezmoi" \
+  'if [ "${1-}" = "apply" ]; then' \
+  '  mkdir -p "$(dirname "$LAZY_LIB_TARGET")"' \
+  '  cp "$LAZY_LIB_SOURCE" "$LAZY_LIB_TARGET"' \
+  '  HOME="$LAZY_HOME" XDG_STATE_HOME="$LAZY_STATE" sh -c '"'"'. "$1"; terrapod_install_warning_write mise-tools "mise tool install needs attention" "Rerun tpod apply."'"'"' sh "$LAZY_LIB_TARGET"' \
+  '  printf "%s\n" "stub apply output"' \
+  'fi' \
+  'exit 0'
+
+lazy_output="$(
+  LAZY_LIB_TARGET="$lazy_lib" \
+  LAZY_LIB_SOURCE="$repo_root/dot_local/lib/terrapod/install-warnings.sh" \
+  LAZY_HOME="$lazy_home" \
+  LAZY_STATE="$lazy_state" \
+  HOME="$lazy_home" \
+  XDG_STATE_HOME="$lazy_state" \
+  TERRAPOD_INSTALL_WARNINGS_LIB="$lazy_lib" \
+  TERRAPOD_PROFILE=macos-terminal \
+  TERRAPOD_CHEZMOI_CONFIG="$lazy_config" \
+  PATH="$lazy_bin:$PATH" \
+    "$terrapod" apply 2>&1
+)" || true
+
+assert_contains \
+  "$lazy_output" \
+  "Remaining install warnings:" \
+  "Terrapod apply reports warnings written by an apply that also installed the marker library"
+
+assert_contains \
+  "$lazy_output" \
+  "mise-tools: mise tool install needs attention" \
+  "Terrapod apply reads the marker library that appeared during the delegated apply"
+```
+
+If `write_stub` or `assert_contains` is not defined at that point in the file, move the block above the first use of the helper it needs; both are defined near the top of the file.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `sh tests/terrapod_command_test.sh`
+Expected: FAIL with `not ok - Terrapod apply reports warnings written by an apply that also installed the marker library`. The library existed by the time `print_remaining_install_warnings` ran, but the start-of-script decision had already disabled it.
+
+- [ ] **Step 3: Replace the one-shot decision with a lazy loader**
+
+In `dot_local/bin/executable_terrapod`, delete lines 25-27:
+
+```sh
+TERRAPOD_INSTALL_WARNINGS_LOADED=
+if [ -f "$install_warnings_lib" ]; then
+  . "$install_warnings_lib"
+fi
+```
+
+Leave the `TERRAPOD_HOMEBREW_PREFIX_LOADED` block that follows it untouched. Add this function immediately after the `homebrew_prefix_lib` block, before `run_jetendard_check`:
+
+```sh
+# Resolved per call rather than once at startup: during the first-run apply the
+# library target does not exist yet when tpod starts, but does by the time the
+# post-apply readers run.
+ensure_install_warnings_loaded() {
+  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ]; then
+    return 0
+  fi
+  if [ ! -f "$install_warnings_lib" ]; then
+    return 1
+  fi
+
+  . "$install_warnings_lib"
+}
+```
+
+Do not collapse this to `[ … ] && return 0`. Under the `set -eu` at line 2, a failing left operand makes the whole AND-list fail and kills `tpod`.
+
+- [ ] **Step 4: Convert the four call sites**
+
+In `install_warning_categories_csv` (around `:1244`), replace:
+
+```sh
+  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" != "1" ]; then
+    return 0
+  fi
+```
+
+with:
+
+```sh
+  if ! ensure_install_warnings_loaded; then
+    return 0
+  fi
+```
+
+In `prune_retired_install_warnings` (around `:1519`), replace:
+
+```sh
+  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" != "1" ]; then
+    return
+  fi
+```
+
+with:
+
+```sh
+  if ! ensure_install_warnings_loaded; then
+    return
+  fi
+```
+
+In `doctor_check_install_warnings` (around `:1660`), replace:
+
+```sh
+  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" != "1" ]; then
+    doctor_ok "No install warning marker reader is installed"
+    return
+  fi
+```
+
+with:
+
+```sh
+  if ! ensure_install_warnings_loaded; then
+    doctor_ok "No install warning marker reader is installed"
+    return
+  fi
+```
+
+In `print_remaining_install_warnings` (around `:1685`), replace:
+
+```sh
+  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" != "1" ]; then
+    return
+  fi
+```
+
+with:
+
+```sh
+  if ! ensure_install_warnings_loaded; then
+    return
+  fi
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `sh tests/terrapod_command_test.sh`
+Expected: PASS, including the two new assertions.
+
+The existing cases that point `TERRAPOD_INSTALL_WARNINGS_LIB` at `$tmp_dir/missing-install-warnings-lib` (`:2037`, `:2669`) must still pass: the file is absent at call time too, so `ensure_install_warnings_loaded` returns 1 and the same early return runs.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dot_local/bin/executable_terrapod tests/terrapod_command_test.sh
+git commit -m "Resolve the install warning library lazily in tpod"
+```
+
+---
+
+### Task 3: Load the library once in install.sh
+
+Removes two never-called functions and the guard that let a broken checkout skip the snapshot deciding whether the first run reports warnings.
+
+**Files:**
+- Modify: `install.sh:986-1028`, `:1035`, `:1052`, after `:1353`
+- Test: `tests/terrapod_installer_test.sh`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `load_install_warnings_from_source source_dir` — sources the library from the checkout, returns non-zero if the file is missing. Callers in `install.sh` only.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/terrapod_installer_test.sh`, after the existing fixture helpers are defined. It asserts the installer refuses a checkout with no library instead of silently continuing.
+
+```sh
+missing_lib_source="$tmp_dir/missing-lib-source"
+mkdir -p "$missing_lib_source/dot_local/lib/terrapod"
+
+missing_lib_output="$(
+  sh -c '
+    . "$1"
+    load_install_warnings_from_source "$2"
+  ' sh "$repo_root/install.sh" "$missing_lib_source" 2>&1
+)" && fail "install.sh rejects a checkout with no install warning library"
+pass "install.sh rejects a checkout with no install warning library"
+```
+
+If sourcing `install.sh` runs `main` and makes that shape unworkable, assert on the code instead — both statements must hold:
+
+```sh
+if grep -n "mark_install_warning_from_source" "$repo_root/install.sh" >/dev/null; then
+  fail "install.sh no longer defines the never-called mark_install_warning_from_source"
+fi
+pass "install.sh no longer defines the never-called mark_install_warning_from_source"
+
+if grep -n "load_install_warnings_from_source .* || return 0" "$repo_root/install.sh" >/dev/null; then
+  fail "install.sh no longer skips the marker snapshot when the library is missing"
+fi
+pass "install.sh no longer skips the marker snapshot when the library is missing"
+```
+
+`install.sh` ends with `main "$@"`, so the second shape is the expected one. Use it.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `sh tests/terrapod_installer_test.sh`
+Expected: FAIL with `not ok - install.sh no longer defines the never-called mark_install_warning_from_source`
+
+- [ ] **Step 3: Delete the dead functions**
+
+In `install.sh`, delete `mark_install_warning_from_source` (`:986-1001`) and `clear_install_warning_from_source` (`:1003-1016`) in full. Confirm first that nothing calls them:
+
+```bash
+grep -n "mark_install_warning_from_source\|clear_install_warning_from_source" install.sh
+```
+
+Only the two definition lines should appear.
+
+- [ ] **Step 4: Make the remaining loader unconditional**
+
+Replace `load_install_warnings_from_source` (`:1018-1028`) with:
+
+```sh
+load_install_warnings_from_source() {
+  source_dir="$1"
+  install_warnings_lib="$source_dir/dot_local/lib/terrapod/install-warnings.sh"
+
+  [ -f "$install_warnings_lib" ] || return 1
+
+  . "$install_warnings_lib"
+}
+```
+
+In `snapshot_install_warnings_from_source`, delete the line:
+
+```sh
+  load_install_warnings_from_source "$source_dir" || return 0
+```
+
+In `install_warning_markers_changed_since_snapshot`, delete the line:
+
+```sh
+  load_install_warnings_from_source "$source_dir" || return 1
+```
+
+- [ ] **Step 5: Load once from main**
+
+In `main`, immediately after the `ensure_first_run_setup "$profile" "$source_dir" "$chezmoi_bin"` line (`:1353`), insert:
+
+```sh
+  load_install_warnings_from_source "$source_dir" ||
+    fatal "failed to load the install warning library from $source_dir"
+```
+
+This runs after the checkout is guaranteed and before `apply_recovery_core_command_surface`, so both snapshot helpers called from `run_initial_apply` find the functions defined.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `sh tests/terrapod_installer_test.sh`
+Expected: PASS. The existing fixtures at `:640` and `:816` already copy `install-warnings.sh` into their source directories, which is what the stricter loader now requires.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add install.sh tests/terrapod_installer_test.sh
+git commit -m "Load the install warning library once in install.sh"
+```
+
+---
+
+### Task 4: Inline the library into three always-run scripts
+
+Converts the straightforward trio users. `run_before_10` is deliberately excluded — it carries two extra complications and gets its own task.
+
+**Files:**
+- Modify: `.chezmoiscripts/run_after_20-install-mise-tools.sh.tmpl:8-42`
+- Modify: `.chezmoiscripts/run_before_30-install-shell-integrations.sh.tmpl:7-49`
+- Modify: `.chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl:8-32`, `:46-60`
+- Modify: `tests/terrapod_command_test.sh:1252-1334`
+
+**Interfaces:**
+- Consumes: `mark_install_warning`, `install_warning_recorded`, `exit_after_install_warning`, `clear_install_warning` from Task 1's `install-warning-script.sh`.
+- Produces: nothing later tasks depend on.
+
+- [ ] **Step 1: Convert run_after_20**
+
+In `.chezmoiscripts/run_after_20-install-mise-tools.sh.tmpl`, replace lines 8-42 — the `install_warnings_lib=` block through the closing `}` of `clear_install_warning` — with:
+
+```
+{{ include "dot_local/lib/terrapod/install-warnings.sh" }}
+
+{{ include "dot_local/lib/terrapod/install-warning-script.sh" }}
+```
+
+Leave `set -eu` at `:4` and the `homebrew-prefix.sh` include at `:6` alone. The call sites at `:58-62`, `:65`, and `:74-78` are unchanged: they already use `mark_install_warning …` followed by `exit_after_install_warning`.
+
+- [ ] **Step 2: Convert run_before_30**
+
+In `.chezmoiscripts/run_before_30-install-shell-integrations.sh.tmpl`, replace lines 7-41 — the `install_warnings_lib=` block through the closing `}` of `clear_install_warning` — with:
+
+```
+{{ include "dot_local/lib/terrapod/install-warnings.sh" }}
+
+{{ include "dot_local/lib/terrapod/install-warning-script.sh" }}
+```
+
+Then replace `shell_integrations_warning_exists` (`:43-49`) with:
+
+```sh
+shell_integrations_warning_exists() {
+  terrapod_install_warning_existing_path shell-integrations >/dev/null 2>&1
+}
+```
+
+It stays in this script: it is bound to one category, not to `INSTALL_WARNING_RECORDED`.
+
+- [ ] **Step 3: Convert run_before_60**
+
+In `.chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl`, replace lines 8-32 — the `install_warnings_lib=` block through the closing `}` of `clear_install_warning` — with:
+
+```
+{{ include "dot_local/lib/terrapod/install-warnings.sh" }}
+
+{{ include "dot_local/lib/terrapod/install-warning-script.sh" }}
+```
+
+Move `AI_CLI_WARNING_CATEGORY=optional-ai-cli-tools` from `:7` to **below** the includes, so the head of the file reads:
+
+```
+{{- if or (eq .chezmoi.os "darwin") (eq .chezmoi.os "linux") -}}
+#!/bin/sh
+set -eu
+
+{{ include "dot_local/lib/terrapod/homebrew-prefix.sh" }}
+
+{{ include "dot_local/lib/terrapod/install-warnings.sh" }}
+
+{{ include "dot_local/lib/terrapod/install-warning-script.sh" }}
+
+AI_CLI_WARNING_CATEGORY=optional-ai-cli-tools
+```
+
+The position matters: Step 4 anchors a test stub to that line, and the stub must land *after* the inlined definitions to override them.
+
+This script has the one call site that read the old return value. Replace `finish_ai_cli_install` (`:46-60`) with:
+
+```sh
+finish_ai_cli_install() {
+  if [ "$1" -ne 0 ]; then
+    mark_install_warning \
+      "$AI_CLI_WARNING_CATEGORY" \
+      "Optional AI CLI tool install needs attention" \
+      "Homebrew setup or the AI CLI bundle failed. Review Homebrew output and network access, then rerun tpod apply."
+
+    if ! install_warning_recorded; then
+      echo "Failed to record Optional AI CLI tool install warning." >&2
+      return 1
+    fi
+
+    return 0
+  fi
+
+  clear_install_warning "$AI_CLI_WARNING_CATEGORY"
+}
+```
+
+- [ ] **Step 4: Repair the four run_before_60 tests built on a missing library**
+
+`tests/terrapod_command_test.sh:1252-1334` holds four assertions that render `run_before_60` with `"sourceDir":"/missing-terrapod-source"` so the library cannot load. Inlining reads from `--source "$repo_root"`, not from the `sourceDir` override, so that premise no longer exists. Two of them pass by accident and two break.
+
+First, retire the two whose meaning is now false. At `:1268-1275`, change the two messages and the `sourceDir`:
+
+```sh
+chezmoi execute-template \
+  --source "$repo_root" \
+  --override-data "{\"chezmoi\":{\"os\":\"darwin\",\"sourceDir\":\"$repo_root\"},\"enableAiCliTools\":true}" \
+  --file "$repo_root/.chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl" \
+  | sed "s#/opt/homebrew/bin/brew#$fake_warning_bin/brew#g" \
+  >"$fake_ai_cli_installer"
+
+if ! HOME="$fake_ai_cli_home" FAKE_INSTALL_WARNING_CALLS="$fake_warning_calls" TERRAPOD_MACHINE_ARCH=aarch64 PATH="$fake_warning_bin:/usr/bin:/bin" /bin/sh "$fake_ai_cli_installer" >"$tmp_dir/fake-ai-cli-installer.out" 2>"$tmp_dir/fake-ai-cli-installer.err"; then
+  fail "rendered installer fixture succeeds when the Homebrew AI CLI bundle succeeds"
+fi
+
+if [ -e "$fake_warning_calls" ]; then
+  fail "installer scripts ignore PATH fake install warning helpers"
+fi
+pass "installer scripts ignore PATH fake install warning helpers"
+```
+
+Second, delete the block at `:1277-1299` in full — from `fake_ai_cli_failure_home="$tmp_dir/fake-ai-cli-failure-home"` through its `pass "rendered installer fixture fails when optional AI CLI failures cannot be recorded without the shared library"`. It asserts the script fails when the library is missing, which inlining makes unreachable. The next block covers the case that still matters: the library loads and the marker write fails.
+
+Third, rewrite that next block (`:1301-1334`) to plant its stub by appending after the include rather than by placing a file in a source directory the include no longer reads. Replace the whole block with:
+
+```sh
+fake_ai_cli_write_failure_home="$tmp_dir/fake-ai-cli-write-failure-home"
+fake_ai_cli_warning_stub="$tmp_dir/fake-ai-cli-warning-stub.sh"
+mkdir -p "$fake_ai_cli_write_failure_home/.local/bin"
+cat >"$fake_ai_cli_warning_stub" <<'STUB'
+terrapod_install_warning_write() {
+  printf "%s\n" "write failed:$*" >&2
+  return 1
+}
+terrapod_install_warning_clear() {
+  return 0
+}
+STUB
+write_stub "$fake_ai_cli_write_failure_home/.local/bin/brew" \
+  'case "$1" in' \
+  '  shellenv) printf "%s\n" ":" ;;' \
+  '  bundle) exit 42 ;;' \
+  '  *) exit 64 ;;' \
+  'esac'
+
+# The script inlines install-warnings.sh, so the stub is appended after the
+# category assignment to override the real definitions.
+fake_ai_cli_write_failure_installer="$tmp_dir/fake-ai-cli-write-failure-installer.sh"
+chezmoi execute-template \
+  --source "$repo_root" \
+  --override-data '{"chezmoi":{"os":"darwin"},"enableAiCliTools":true}' \
+  --file "$repo_root/.chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl" \
+  | sed \
+    -e "s#/opt/homebrew/bin/brew#$fake_ai_cli_write_failure_home/.local/bin/brew#g" \
+    -e "/^AI_CLI_WARNING_CATEGORY=/r $fake_ai_cli_warning_stub" \
+  >"$fake_ai_cli_write_failure_installer"
+
+fake_ai_cli_write_failure_status=0
+HOME="$fake_ai_cli_write_failure_home" TERRAPOD_MACHINE_ARCH=aarch64 PATH="$fake_ai_cli_write_failure_home/.local/bin:/usr/bin:/bin" /bin/sh "$fake_ai_cli_write_failure_installer" >"$tmp_dir/fake-ai-cli-write-failure.out" 2>"$tmp_dir/fake-ai-cli-write-failure.err" || fake_ai_cli_write_failure_status=$?
+if [ "$fake_ai_cli_write_failure_status" -eq 0 ]; then
+  fail "rendered installer fixture fails when optional AI CLI failures cannot be recorded after marker write failure"
+fi
+pass "rendered installer fixture fails when optional AI CLI failures cannot be recorded after marker write failure"
+```
+
+The `r` command inserts the stub after `AI_CLI_WARNING_CATEGORY=`, which Step 3 placed below the includes — so the stub's definitions override the inlined ones. Confirm the ordering before running the test:
+
+```bash
+chezmoi execute-template --source . \
+  --override-data '{"chezmoi":{"os":"darwin"},"enableAiCliTools":true}' \
+  --file .chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl \
+  | grep -n 'terrapod_install_warning_write() {\|^AI_CLI_WARNING_CATEGORY='
+```
+
+Expected: the `terrapod_install_warning_write() {` line number is smaller than the `AI_CLI_WARNING_CATEGORY=` one. If it is not, Step 3's reordering was not applied.
+
+- [ ] **Step 5: Verify all three render as valid POSIX shell**
+
+```bash
+for f in run_after_20-install-mise-tools run_before_30-install-shell-integrations run_before_60-install-ai-cli-tools; do
+  chezmoi execute-template --source . \
+    --override-data '{"chezmoi":{"os":"darwin"},"enableAiCliTools":true}' \
+    --file ".chezmoiscripts/$f.sh.tmpl" | sh -n && echo "ok $f"
+done
+```
+
+Expected: `ok` for all three. A rendered script that still contains `install_warnings_lib=` means an include line did not replace the block.
+
+- [ ] **Step 6: Run the affected tests**
+
+Run: `sh tests/shell_integrations_test.sh && sh tests/terrapod_command_test.sh && sh tests/chezmoiignore_test.sh`
+Expected: PASS. `chezmoiignore_test.sh` exercises the Optional AI Tool Stack warning paths that Step 3 rewrote, and `terrapod_command_test.sh` runs the four assertions Step 4 repaired.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add .chezmoiscripts/run_after_20-install-mise-tools.sh.tmpl \
+        .chezmoiscripts/run_before_30-install-shell-integrations.sh.tmpl \
+        .chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl \
+        tests/terrapod_command_test.sh
+git commit -m "Inline the install warning libraries into three always-run scripts"
+```
+
+---
+
+### Task 5: Inline both libraries into run_before_10
+
+The largest consumer. It also guards `homebrew-core-bundle.sh` the same way, and it has the one call site that relied on `mark_install_warning` returning non-zero.
+
+**Files:**
+- Modify: `.chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl:17-68`, `:300-325`, `:343-348`
+- Modify: `tests/terrapod_command_test.sh:551-575`
+
+**Interfaces:**
+- Consumes: the five functions from Task 1.
+- Produces: nothing later tasks depend on.
+
+- [ ] **Step 1: Add the new library to the apply fixture**
+
+`copy_desktop_apply_source_fixture` in `tests/terrapod_command_test.sh` builds a source tree and runs a real `chezmoi apply` against it. `{{ include }}` reads from that tree at render time, so the render fails without the new file. Find:
+
+```sh
+  cp "$install_warnings_lib" "$source_dir/dot_local/lib/terrapod/install-warnings.sh"
+```
+
+and add after it:
+
+```sh
+  cp "$repo_root/dot_local/lib/terrapod/install-warning-script.sh" \
+    "$source_dir/dot_local/lib/terrapod/install-warning-script.sh"
+```
+
+- [ ] **Step 2: Replace the two loader blocks and the trio**
+
+Replace lines 17-68 — from `install_warnings_lib=` through the closing `}` of `clear_install_warning` — with:
+
+```
+{{ include "dot_local/lib/terrapod/install-warnings.sh" }}
+
+{{ include "dot_local/lib/terrapod/install-warning-script.sh" }}
+
+{{ include "dot_local/lib/terrapod/homebrew-core-bundle.sh" }}
+```
+
+This drops `TERRAPOD_HOMEBREW_CORE_BUNDLE_LOADED` along with `TERRAPOD_INSTALL_WARNINGS_LOADED`; the library can no longer be missing, so neither guard has anything to decide.
+
+- [ ] **Step 3: Delete the core-bundle fallback branch**
+
+The `else` branch at `:314-324` exists only for the case where `homebrew-core-bundle.sh` failed to load, and it runs a bare `brew bundle` without the library's guidance text. That case is now impossible. Replace the whole block at `:300-325`:
+
+```sh
+if [ -f "$core_brewfile" ]; then
+  if [ "${TERRAPOD_HOMEBREW_CORE_BUNDLE_LOADED:-}" = "1" ]; then
+    if terrapod_homebrew_core_run_bundle "$core_brewfile"; then
+      clear_install_warning homebrew-core
+    else
+      if [ -z "${TERRAPOD_HOMEBREW_CORE_FAILURE_GUIDANCE_TEXT:-}" ]; then
+        TERRAPOD_HOMEBREW_CORE_FAILURE_GUIDANCE_TEXT="Review Homebrew core bundle output, fix package access, then rerun tpod apply."
+      fi
+      mark_install_warning \
+        homebrew-core \
+        "Homebrew core install needs attention" \
+        "$TERRAPOD_HOMEBREW_CORE_FAILURE_GUIDANCE_TEXT"
+      continue_after_core_install_warning
+    fi
+  else
+    if HOMEBREW_NO_AUTO_UPDATE=1 brew bundle --no-upgrade --file="$core_brewfile"; then
+      clear_install_warning homebrew-core
+    else
+      mark_install_warning \
+        homebrew-core \
+        "Homebrew core install needs attention" \
+        "Review Homebrew core bundle output, fix package access, then rerun tpod apply."
+      continue_after_core_install_warning
+    fi
+  fi
+fi
+```
+
+with:
+
+```sh
+if [ -f "$core_brewfile" ]; then
+  if terrapod_homebrew_core_run_bundle "$core_brewfile"; then
+    clear_install_warning homebrew-core
+  else
+    if [ -z "${TERRAPOD_HOMEBREW_CORE_FAILURE_GUIDANCE_TEXT:-}" ]; then
+      TERRAPOD_HOMEBREW_CORE_FAILURE_GUIDANCE_TEXT="Review Homebrew core bundle output, fix package access, then rerun tpod apply."
+    fi
+    mark_install_warning \
+      homebrew-core \
+      "Homebrew core install needs attention" \
+      "$TERRAPOD_HOMEBREW_CORE_FAILURE_GUIDANCE_TEXT"
+    continue_after_core_install_warning
+  fi
+fi
+```
+
+- [ ] **Step 4: Convert the desktop-apps call site**
+
+At `:343-348` the desktop-apps branch relies on the old non-zero return. Replace:
+
+```sh
+    mark_install_warning \
+      homebrew-desktop-apps \
+      "Homebrew desktop app install needs attention" \
+      "$desktop_app_failure_guidance_text" ||
+      exit 1
+    exit 0
+```
+
+with:
+
+```sh
+    mark_install_warning \
+      homebrew-desktop-apps \
+      "Homebrew desktop app install needs attention" \
+      "$desktop_app_failure_guidance_text"
+    exit_after_install_warning
+```
+
+The exit codes are identical: recorded exits 0, not recorded exits 1.
+
+The remaining `mark_install_warning` call sites (`:254`, `:262`, `:274`, `:282`, `:288`) already pair with `exit_after_install_warning` and need no change.
+
+- [ ] **Step 5: Verify the render**
+
+```bash
+chezmoi execute-template --source . \
+  --override-data '{"chezmoi":{"os":"darwin"},"enableMacosAppGroupTerminalApps":true}' \
+  --file .chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl | sh -n && echo ok
+```
+
+Expected: `ok`.
+
+- [ ] **Step 6: Run the affected tests**
+
+Run: `sh tests/terrapod_command_test.sh && sh tests/chezmoiignore_test.sh`
+Expected: PASS. `terrapod_command_test.sh` runs the real apply fixture from Step 1; `chezmoiignore_test.sh:284-296` renders `run_before_10` under six data sets.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add .chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl tests/terrapod_command_test.sh
+git commit -m "Inline the install warning and Homebrew core bundle libraries into run_before_10"
+```
+
+---
+
+### Task 6: Inline the library into the Ubuntu retry script
+
+`run_before_01` is the variant that exits 0 when the library is missing, reporting success for a retry it never attempted.
+
+**Files:**
+- Modify: `.chezmoiscripts/run_before_01-retry-ubuntu-bootstrap.sh.tmpl:5-9`
+- Test: `tests/bootstrap_ubuntu_test.sh`
+
+**Interfaces:**
+- Consumes: `terrapod_install_warning_existing_path`, `terrapod_install_warning_clear`, `terrapod_install_warning_write` from the marker API. It does not use the policy layer.
+- Produces: nothing later tasks depend on.
+
+- [ ] **Step 1: Replace the guard with an include**
+
+Replace lines 5-9:
+
+```sh
+install_warnings_lib="{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/install-warnings.sh"
+if [ ! -f "$install_warnings_lib" ]; then
+  exit 0
+fi
+. "$install_warnings_lib"
+```
+
+with:
+
+```
+{{ include "dot_local/lib/terrapod/install-warnings.sh" }}
+```
+
+Leave `set -eu` at `:3` and the `ubuntu_bootstrap_lib` source at `:15-16` alone — the latter is already unguarded under `set -e`, which is the behavior this change is spreading.
+
+- [ ] **Step 2: Verify the render**
+
+```bash
+chezmoi execute-template --source . \
+  --override-data '{"chezmoi":{"os":"linux","osRelease":{"id":"ubuntu","versionID":"24.04"}}}' \
+  --file .chezmoiscripts/run_before_01-retry-ubuntu-bootstrap.sh.tmpl | sh -n && echo ok
+```
+
+Expected: `ok`.
+
+- [ ] **Step 3: Run the affected test**
+
+Run: `sh tests/bootstrap_ubuntu_test.sh`
+Expected: PASS. `:286` and `:295` render this template and exercise the retry path.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .chezmoiscripts/run_before_01-retry-ubuntu-bootstrap.sh.tmpl
+git commit -m "Inline the install warning library into the Ubuntu bootstrap retry"
+```
+
+---
+
+### Task 7: Inline the library into the two always-run Jetendard scripts
+
+Fixes symptom 3. These run `set -u` without `set -e`, so a failed source leaves undefined functions that return 127 — read as "no marker" in the retry, and as a post-success failure in the settings script. Also repairs the test fixture seam that inlining breaks.
+
+**Files:**
+- Modify: `.chezmoiscripts/run_before_02-retry-jetendard-font.sh.tmpl:2-7`
+- Modify: `.chezmoiscripts/run_after_70-apply-jetendard-settings.sh.tmpl:2-15`
+- Modify: `tests/chezmoiignore_test.sh:403-411`, and append a new case
+
+**Interfaces:**
+- Consumes: the marker API only.
+- Produces: nothing later tasks depend on.
+
+- [ ] **Step 1: Fix the fixture seam first**
+
+`render_jetendard_adapter_fixture` swaps the stub library in by rewriting the `^warnings_lib=` line. Inlining deletes that line, so the `sed` would silently no-op and the real library would run. Switch to inserting the stub *after* the library, using the surviving `font_helper=` / `settings_helper=` lines as anchors — shell function redefinition then wins. Replace `:403-411`:
+
+```sh
+render_jetendard_adapter_fixture() {
+  rendered="$1"
+  destination="$2"
+  printf '%s\n' "$rendered" |
+    sed \
+      -e "s#^warnings_lib=.*#warnings_lib=\"$jetendard_warnings_stub\"#" \
+      -e "s#^font_helper=.*#font_helper=\"$jetendard_helper_stub\"#" \
+      -e "s#^settings_helper=.*#settings_helper=\"$jetendard_helper_stub\"#" \
+      >"$destination"
+}
+```
+
+with:
+
+```sh
+# The adapters inline install-warnings.sh, so the stub is appended after the
+# helper assignment to override the real definitions rather than replacing a path.
+render_jetendard_adapter_fixture() {
+  rendered="$1"
+  destination="$2"
+  printf '%s\n' "$rendered" |
+    sed \
+      -e "s#^warnings_lib=.*#warnings_lib=\"$jetendard_warnings_stub\"#" \
+      -e "s#^font_helper=.*#font_helper=\"$jetendard_helper_stub\"#" \
+      -e "s#^settings_helper=.*#settings_helper=\"$jetendard_helper_stub\"#" \
+      -e "/^font_helper=/r $jetendard_warnings_stub" \
+      -e "/^settings_helper=/r $jetendard_warnings_stub" \
+      >"$destination"
+}
+```
+
+The two `s#^warnings_lib=...#` and path substitutions stay because `run_onchange_after_65` still has a `warnings_lib=` line after Task 8.
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `tests/chezmoiignore_test.sh`, after the existing Jetendard adapter cases (after the `:437` block). It pins symptom 3: with `python3` gone, the settings script records the warning and exits 0.
+
+```sh
+jetendard_no_python_bin="$tmp_dir/jetendard-no-python-bin"
+mkdir -p "$jetendard_no_python_bin"
+
+: >"$jetendard_adapter_log"
+if ! JETENDARD_ADAPTER_LOG="$jetendard_adapter_log" \
+  JETENDARD_MARKER_EXISTS=0 \
+  JETENDARD_CLEAR_FAIL=0 \
+  PATH="$jetendard_no_python_bin" \
+  sh "$jetendard_settings_fixture" >/dev/null 2>&1; then
+  fail "Jetendard settings adapter records a warning and succeeds without python3"
+fi
+pass "Jetendard settings adapter records a warning and succeeds without python3"
+
+assert_text_equals \
+  "$(cat "$jetendard_adapter_log")" \
+  'write' \
+  "Jetendard settings adapter writes exactly one warning when python3 is missing"
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `sh tests/chezmoiignore_test.sh`
+Expected: FAIL. Today `run_after_70` has no `set -e`; the real library is not stubbed after Step 1's change until the script is inlined, so the assertions do not hold yet.
+
+- [ ] **Step 4: Convert run_before_02**
+
+Replace lines 2-7 of `.chezmoiscripts/run_before_02-retry-jetendard-font.sh.tmpl`:
+
+```sh
+#!/bin/sh
+set -u
+
+warnings_lib="{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/install-warnings.sh"
+font_helper="{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/executable_jetendard-font"
+. "$warnings_lib"
+```
+
+with:
+
+```
+#!/bin/sh
+set -eu
+
+{{ include "dot_local/lib/terrapod/install-warnings.sh" }}
+
+font_helper="{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/executable_jetendard-font"
+```
+
+The `font_helper=` line must stay last of the two so the fixture's `r` command inserts the stub after the library.
+
+- [ ] **Step 5: Convert run_after_70**
+
+Replace lines 2-7 of `.chezmoiscripts/run_after_70-apply-jetendard-settings.sh.tmpl` the same way, keeping `settings_helper=` after the include:
+
+```
+#!/bin/sh
+set -eu
+
+{{ include "dot_local/lib/terrapod/install-warnings.sh" }}
+
+settings_helper="{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/executable_jetendard-settings"
+```
+
+Then fix the `$?` capture, which `set -e` would otherwise abort on. Replace:
+
+```sh
+python3 "$settings_helper" apply
+settings_status="$?"
+```
+
+with:
+
+```sh
+settings_status=0
+python3 "$settings_helper" apply || settings_status="$?"
+```
+
+Leave the `case "$settings_status" in` block and all three branches unchanged.
+
+- [ ] **Step 6: Verify both renders**
+
+```bash
+for f in run_before_02-retry-jetendard-font run_after_70-apply-jetendard-settings; do
+  chezmoi execute-template --source . \
+    --override-data '{"chezmoi":{"os":"darwin"}}' \
+    --file ".chezmoiscripts/$f.sh.tmpl" | sh -n && echo "ok $f"
+done
+```
+
+Expected: `ok` for both.
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `sh tests/chezmoiignore_test.sh`
+Expected: PASS, including the three original adapter assertions at `:421-437` and the two new ones.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add .chezmoiscripts/run_before_02-retry-jetendard-font.sh.tmpl \
+        .chezmoiscripts/run_after_70-apply-jetendard-settings.sh.tmpl \
+        tests/chezmoiignore_test.sh
+git commit -m "Inline the install warning library into the always-run Jetendard scripts"
+```
+
+---
+
+### Task 8: Make the two run_onchange_ scripts fail loudly instead of inlining
+
+These are the exception. Chezmoi triggers `run_onchange_` scripts on rendered-content change, so inlining would put the library's bytes in the hash and re-run an `apt` bootstrap and a full GitHub font download on every library edit — seven such edits between `4d3a9dd` and `f314327`. Removing the guard and adding `set -e` fixes the silent failure without the hash coupling.
+
+**Files:**
+- Modify: `.chezmoiscripts/run_onchange_before_00-bootstrap-ubuntu.sh.tmpl:5-42`
+- Modify: `.chezmoiscripts/run_onchange_after_65-install-jetendard-font.sh.tmpl:3`
+- Test: `tests/bootstrap_ubuntu_test.sh`, `tests/chezmoiignore_test.sh`
+
+**Interfaces:**
+- Consumes: the marker API in both; the policy layer in `run_onchange_before_00` only.
+- Produces: nothing later tasks depend on.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/bootstrap_ubuntu_test.sh`. It asserts that a source tree with no library stops the script instead of no-op'ing its warning writes.
+
+```sh
+missing_lib_source="$tmp_dir/onchange-missing-lib"
+mkdir -p "$missing_lib_source"
+
+rendered_missing_lib="$tmp_dir/onchange-missing-lib.sh"
+chezmoi execute-template \
+  --source "$repo_root" \
+  --override-data "{\"chezmoi\":{\"os\":\"linux\",\"sourceDir\":\"$missing_lib_source\",\"osRelease\":{\"id\":\"ubuntu\",\"versionID\":\"24.04\"}}}" \
+  --file "$repo_root/.chezmoiscripts/run_onchange_before_00-bootstrap-ubuntu.sh.tmpl" \
+  >"$rendered_missing_lib"
+
+if sh "$rendered_missing_lib" >/dev/null 2>&1; then
+  fail "Ubuntu bootstrap stops when the install warning library is missing"
+fi
+pass "Ubuntu bootstrap stops when the install warning library is missing"
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `sh tests/bootstrap_ubuntu_test.sh`
+Expected: FAIL with `not ok - Ubuntu bootstrap stops when the install warning library is missing`. Today the guard swallows the missing file and the script proceeds with no-op warning writes.
+
+- [ ] **Step 3: Convert run_onchange_before_00**
+
+Replace lines 5-42 of `.chezmoiscripts/run_onchange_before_00-bootstrap-ubuntu.sh.tmpl` — the `install_warnings_lib=` block through the closing `}` of `clear_install_warning`, but keeping the `ubuntu_bootstrap_lib` lines at `:11-13` — so the head of the file reads:
+
+```sh
+#!/bin/sh
+set -eu
+
+# Sourced by path rather than inlined: inlining would put this library into the
+# run_onchange_ content hash, re-running the apt bootstrap on every library edit.
+. "{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/install-warnings.sh"
+. "{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/install-warning-script.sh"
+
+# Ubuntu bootstrap helper checksum: {{ include "dot_local/lib/terrapod/ubuntu-bootstrap.sh" | sha256sum }}
+ubuntu_bootstrap_lib="{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/ubuntu-bootstrap.sh"
+. "$ubuntu_bootstrap_lib"
+```
+
+The call sites at `:49-53` and `:56` are unchanged.
+
+Note the existing `sha256sum` comment stays: coupling this script to `ubuntu-bootstrap.sh`, its actual subject, is deliberate and predates this change.
+
+- [ ] **Step 4: Convert run_onchange_after_65**
+
+In `.chezmoiscripts/run_onchange_after_65-install-jetendard-font.sh.tmpl`, change line 3 from `set -u` to `set -eu`, and add the explanatory comment above the existing source:
+
+```sh
+#!/bin/sh
+set -eu
+
+# Sourced by path rather than inlined: inlining would put this library into the
+# run_onchange_ content hash, re-downloading the font on every library edit.
+warnings_lib="{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/install-warnings.sh"
+font_helper="{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/executable_jetendard-font"
+# Jetendard font helper checksum: {{ include "dot_local/lib/terrapod/executable_jetendard-font" | sha256sum }}
+. "$warnings_lib"
+```
+
+The source was already unguarded; `set -e` is what turns its 127 into a stop. The `warnings_lib=` line stays, so Task 7's fixture substitution keeps covering this adapter.
+
+- [ ] **Step 5: Verify both renders**
+
+```bash
+chezmoi execute-template --source . \
+  --override-data '{"chezmoi":{"os":"linux","osRelease":{"id":"ubuntu","versionID":"24.04"}}}' \
+  --file .chezmoiscripts/run_onchange_before_00-bootstrap-ubuntu.sh.tmpl | sh -n && echo ok-00
+chezmoi execute-template --source . \
+  --override-data '{"chezmoi":{"os":"darwin"}}' \
+  --file .chezmoiscripts/run_onchange_after_65-install-jetendard-font.sh.tmpl | sh -n && echo ok-65
+```
+
+Expected: `ok-00` and `ok-65`.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `sh tests/bootstrap_ubuntu_test.sh && sh tests/chezmoiignore_test.sh`
+Expected: PASS, including the new assertion and the three Jetendard adapter assertions.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add .chezmoiscripts/run_onchange_before_00-bootstrap-ubuntu.sh.tmpl \
+        .chezmoiscripts/run_onchange_after_65-install-jetendard-font.sh.tmpl \
+        tests/bootstrap_ubuntu_test.sh
+git commit -m "Stop the run_onchange scripts when the install warning library is missing"
+```
+
+---
+
+### Task 9: Pin the loading-rule split and record the decision
+
+The nine templates now follow two rules. This task adds the test that keeps the split from drifting and writes the ADR that explains why it is two rules rather than one.
+
+**Files:**
+- Modify: `tests/chezmoiignore_test.sh` (append)
+- Create: `docs/adr/0016-load-install-warnings-by-a-chosen-rule.md`
+
+**Interfaces:**
+- Consumes: the final state of all nine templates from Tasks 4-8.
+- Produces: nothing.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/chezmoiignore_test.sh`:
+
+```sh
+inlined_warning_scripts="
+.chezmoiscripts/run_before_01-retry-ubuntu-bootstrap.sh.tmpl
+.chezmoiscripts/run_before_02-retry-jetendard-font.sh.tmpl
+.chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl
+.chezmoiscripts/run_before_30-install-shell-integrations.sh.tmpl
+.chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl
+.chezmoiscripts/run_after_20-install-mise-tools.sh.tmpl
+.chezmoiscripts/run_after_70-apply-jetendard-settings.sh.tmpl
+"
+
+path_sourced_warning_scripts="
+.chezmoiscripts/run_onchange_before_00-bootstrap-ubuntu.sh.tmpl
+.chezmoiscripts/run_onchange_after_65-install-jetendard-font.sh.tmpl
+"
+
+warning_script_data() {
+  case "$1" in
+    *run_before_01*|*run_onchange_before_00*)
+      printf '%s' "$ubuntu_data"
+      ;;
+    *)
+      printf '%s' "$macos_data"
+      ;;
+  esac
+}
+
+for warning_script in $inlined_warning_scripts; do
+  rendered_warning_script="$(render_template "$(warning_script_data "$warning_script")" "$warning_script")"
+
+  assert_contains_text \
+    "$rendered_warning_script" \
+    "terrapod_install_warning_write() {" \
+    "always-run script inlines the marker library: $warning_script"
+
+  assert_not_contains_text \
+    "$rendered_warning_script" \
+    'if [ -f "$install_warnings_lib" ]; then' \
+    "always-run script keeps no install warning loader guard: $warning_script"
+done
+
+for warning_script in $path_sourced_warning_scripts; do
+  rendered_warning_script="$(render_template "$(warning_script_data "$warning_script")" "$warning_script")"
+
+  assert_not_contains_text \
+    "$rendered_warning_script" \
+    "terrapod_install_warning_write() {" \
+    "run_onchange script keeps the marker library out of its content hash: $warning_script"
+
+  assert_contains_text \
+    "$rendered_warning_script" \
+    "/dot_local/lib/terrapod/install-warnings.sh" \
+    "run_onchange script sources the marker library by path: $warning_script"
+
+  assert_not_contains_text \
+    "$rendered_warning_script" \
+    'if [ -f "$install_warnings_lib" ]; then' \
+    "run_onchange script keeps no install warning loader guard: $warning_script"
+done
+```
+
+Place it after `ubuntu_data` and `macos_data` are defined (`:194-196`) and after `render_template` (`:54`). Appending at the end of the file satisfies both.
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `sh tests/chezmoiignore_test.sh`
+Expected: PASS. Unlike earlier tasks this test is written last and should pass immediately — it pins state Tasks 4-8 already produced. If any assertion fails, a template was missed; fix the template, not the test.
+
+- [ ] **Step 3: Verify the test would catch a regression**
+
+Temporarily change `run_after_20` back to a path source, run the test, confirm it fails with `not ok - always-run script inlines the marker library`, then revert:
+
+```bash
+git stash && sh tests/chezmoiignore_test.sh; git stash pop
+```
+
+Skip this step only if the working tree is not clean enough to stash safely; in that case verify by hand-editing one template and reverting it.
+
+- [ ] **Step 4: Write the ADR**
+
+Create `docs/adr/0016-load-install-warnings-by-a-chosen-rule.md`:
+
+```markdown
+# Load install warnings by a chosen rule per entry point
+
+Every consumer of `install-warnings.sh` loads it by one of three rules, chosen
+for that entry point rather than by habit. No rule can degrade quietly: the
+library is either compiled in, or its absence stops the script.
+
+Always-run chezmoi scripts inline the library with `{{ include }}`. Compile-time
+inlining is the default because it is the only rule under which the library
+cannot be missing, so no guard is needed and none can be reintroduced.
+
+The two `run_onchange_` scripts are the exception. They source the library by
+path, unguarded, under `set -e`. Chezmoi triggers `run_onchange_` scripts on
+rendered-content change, so inlining would put the library's bytes into the
+hash and re-run the work on every library edit — and neither piece of work is
+cheap. `install()` in `executable_jetendard-font` has no installed-state
+short-circuit: it always calls the GitHub releases API and downloads the full
+archive. `ubuntu-bootstrap.sh` always runs `apt-get update` and escalates
+through `sudo` for a non-root user. Both need network; one can raise an
+unexpected password prompt. Any future `run_onchange_` script that records
+install warnings follows this rule.
+
+`tpod` resolves the library lazily at each call site. A decision made once at
+process start is always wrong during the first-run apply, because the library
+target is created by that very apply.
+
+`install.sh` cannot use `{{ include }}` — it is a `curl | sh` bootstrap, not a
+chezmoi template. It loads the library once from the checkout and treats absence
+as fatal, since a checkout missing the library is a broken clone.
+
+`TERRAPOD_INSTALL_WARNINGS_LOADED` is a load memo for `tpod` and nothing else.
+It never again decides whether warnings work.
+
+## Considered Options
+
+- Inline everywhere, including the two `run_onchange_` scripts: rejected on the
+  cost above. `install-warnings.sh` changed seven times between `4d3a9dd` and
+  `f314327`, and its most common edit — a new name in
+  `terrapod_install_warning_categories()` — happens whenever a new install step
+  gains a warning category. Paying an `apt` run and a font download on every
+  machine for that is a worse trade than one documented exception.
+- Move `prune_retired_install_warnings` after the apply delegation so the
+  first-run prune works: rejected because ADR 0014 fixes that ordering so the
+  directory stays consistent when apply fails, and reversing it on unrelated
+  grounds is not this change's business.
+- Give `tpod` a `chezmoi source-path` fallback: rejected as machinery for a
+  state no code path produces. `tpod` already resolves the library relative to
+  its own directory, which covers running from a checkout; the only remaining
+  gap needs markers written by an apply that never wrote the library.
+
+## Consequences
+
+- The first-run prune remains a no-op, because it runs before the apply that
+  installs the library. A fresh machine has no markers to prune, so this costs
+  nothing. It is not a bug.
+- `mark_install_warning` never returns non-zero. Callers run under `set -e`, so
+  a failing bare call would kill the script before its exit policy runs. Code
+  that needs the outcome calls `install_warning_recorded`.
+- Editing `install-warnings.sh` does not re-run any `run_onchange_` script. A
+  future author who inlines it into one silently reintroduces that cost; the
+  loading-rule assertions in `tests/chezmoiignore_test.sh` fail if they do.
+- `install-warning-script.sh` deploys to `~/.local/lib/terrapod/` even though
+  only chezmoi scripts use it, following `homebrew-core-bundle.sh`. Making it
+  source-tree-only would need an unconditional `.chezmoiignore` entry, a shape
+  this repo does not otherwise use.
+- `run_before_10` no longer has a fallback branch that runs a bare `brew bundle`
+  when `homebrew-core-bundle.sh` fails to load. That branch existed only for a
+  state inlining makes impossible.
+```
+
+- [ ] **Step 5: Run the full suite**
+
+Run each of these and confirm all pass:
+
+```bash
+sh tests/terrapod_command_test.sh
+sh tests/terrapod_installer_test.sh
+sh tests/chezmoiignore_test.sh
+sh tests/bootstrap_ubuntu_test.sh
+sh tests/shell_integrations_test.sh
+```
+
+Expected: PASS for all five.
+
+- [ ] **Step 6: Confirm no loader guard survives anywhere**
+
+```bash
+grep -rn 'TERRAPOD_INSTALL_WARNINGS_LOADED' --exclude-dir=.git --exclude-dir=docs .
+```
+
+Expected: exactly two hits — the assignment in `dot_local/lib/terrapod/install-warnings.sh:3`, and the memo read inside `ensure_install_warnings_loaded` in `dot_local/bin/executable_terrapod`. Any other hit is a missed guard.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tests/chezmoiignore_test.sh docs/adr/0016-load-install-warnings-by-a-chosen-rule.md
+git commit -m "Pin the install warning loading rules and record ADR 0016"
+```
+
+---
+
+## Verification Against The Issue
+
+After Task 9, each symptom in #153 has a test that fails without its fix:
+
+| Symptom | Fixed by | Pinned by |
+|---|---|---|
+| 1. `tpod` decides once at startup; first apply reports nothing | Task 2 | `terrapod_command_test.sh`, lazy-library apply case |
+| 2. Five scripts no-op silently; five drifted trio copies | Tasks 1, 4, 5 | `chezmoiignore_test.sh` loading-rule assertions |
+| 2b. `run_before_01` exits 0 for a retry it never ran | Task 6 | `chezmoiignore_test.sh` loading-rule assertions |
+| 3. Jetendard 127 continues past a failed source | Tasks 7, 8 | `chezmoiignore_test.sh` no-python3 settings case; `bootstrap_ubuntu_test.sh` missing-library case |
+| Dead code in `install.sh`; snapshot skipped silently | Task 3 | `terrapod_installer_test.sh` |

--- a/docs/superpowers/specs/2026-09-01-install-warnings-loading-design.md
+++ b/docs/superpowers/specs/2026-09-01-install-warnings-loading-design.md
@@ -320,10 +320,10 @@ approach covers all three adapters uniformly rather than branching per script.
 ### Fixture source directories gain a file
 
 Both the `{{ include }}` rule and the path-source rule read from the source
-directory — one at render time, one at run time. The synthetic source trees in
-`tests/terrapod_command_test.sh:558-575`, `tests/terrapod_installer_test.sh:640`,
-and `:816` must therefore also copy `install-warning-script.sh`. Omitting it now
-fails the chezmoi render rather than producing a silently degraded script.
+directory — one at render time, one at run time. The synthetic source tree built
+by `copy_desktop_apply_source_fixture` in `tests/terrapod_command_test.sh:558-575`
+must therefore also copy `install-warning-script.sh`. Omitting it now fails the
+chezmoi render rather than producing a silently degraded script.
 
 ### Deployment assertion
 

--- a/docs/superpowers/specs/2026-09-01-install-warnings-loading-design.md
+++ b/docs/superpowers/specs/2026-09-01-install-warnings-loading-design.md
@@ -1,0 +1,397 @@
+# Install Warnings Loading Design
+
+## Goal
+
+Give every consumer of `install-warnings.sh` a loading rule chosen on purpose, so
+that a missing library can no longer silently disable warning recording, warning
+reporting, or the retry path.
+
+Today eleven entry points load the library four different ways, and three of
+those ways fail silently. Afterwards there are three ways, each with a stated
+reason, and none of them can degrade quietly: the library is either compiled in,
+or its absence stops the script.
+
+This resolves issue #153.
+
+## Current State
+
+**One-shot decision at process start.** `dot_local/bin/executable_terrapod:25-27`
+tests `~/.local/lib/terrapod/install-warnings.sh` once and records the result in
+`TERRAPOD_INSTALL_WARNINGS_LOADED`. Four call sites (`:1244`, `:1519`, `:1660`,
+`:1685`) read that variable and return early when it is not `1`.
+
+During the first-run apply this decision is always wrong.
+`install.sh:1103-1121` copies `terrapod` into `~/.local/bin` and links `tpod`
+beside it, then `install.sh:1260` runs `tpod apply`. The library target under
+`~/.local/lib` is created by that very apply, so at the moment `tpod` starts it
+does not exist. `prune_retired_install_warnings` (`:1519`) and
+`print_remaining_install_warnings` (`:1685`) no-op for the whole run — the run
+most likely to produce warnings.
+
+**Guarded source by source-directory path.** Five chezmoi scripts —
+`run_before_10:17-21`, `run_after_20:8-12`, `run_onchange_before_00:5-9`,
+`run_before_30:7-11`, `run_before_60:8-12` — source the library behind
+`if [ -f … ]`. When the file is absent every warning write becomes a no-op and
+`exit_after_install_warning` exits 1 with no marker and no message: the script
+fails and says nothing about why.
+
+Each of the five also carries its own 30-40-line copy of the
+`mark_install_warning` / `clear_install_warning` / `exit_after_install_warning`
+trio, and the copies have drifted. `run_before_10:31-44` returns a status;
+`run_after_20:16-26` does not.
+
+Issue #153 lists six such scripts, naming `run_onchange_before_30` and
+`run_before_31`. #187 (`bd1a784`) merged those two into `run_before_30`, so the
+count is five.
+
+**Guarded source that exits 0.** `run_before_01:5-9` is a sixth variant: when the
+library is missing it exits 0, reporting success for a retry it never attempted.
+
+**Unguarded source under `set -u` without `set -e`.** The three Jetendard scripts
+— `run_after_70:7`, `run_before_02:7`, `run_onchange_after_65:8` — source the
+library with no guard, but execution continues past a failed `.`. In
+`run_after_70` a resulting 127 makes `|| exit 1` fire after the settings were
+applied successfully. In `run_before_02:9` the undefined
+`terrapod_install_warning_existing_path` returns 127, which reads as "no marker"
+and silently disables the retry path.
+
+**Bootstrap loaders.** `install.sh` repeats the guarded-source pattern three
+times: `mark_install_warning_from_source:986`,
+`clear_install_warning_from_source:1003`, and
+`load_install_warnings_from_source:1018`. The first two are defined and never
+called. The third is called from `snapshot_install_warnings_from_source:1035`
+with `|| return 0` and from `install_warning_markers_changed_since_snapshot:1052`
+with `|| return 1`.
+
+## Layers
+
+The library splits in two.
+
+**`dot_local/lib/terrapod/install-warnings.sh` — marker API.** Unchanged. It
+defines functions and sets no policy.
+
+**`dot_local/lib/terrapod/install-warning-script.sh` — installer policy.** New.
+It holds the `INSTALL_WARNING_RECORDED` flag and the four functions that read it.
+
+Splitting rather than merging keeps `exit`-calling functions and mutable global
+state out of the file `tpod` sources into its own runtime namespace.
+
+Both files deploy to `~/.local/lib/terrapod/` with no `.chezmoiignore` entry.
+`homebrew-core-bundle.sh` is the precedent: it is inlined into `run_before_10`
+and nothing else, and it still deploys. (`ubuntu-bootstrap.sh` is *not* a
+precedent for source-tree-only libraries — `.chezmoiignore:29-32` scopes it to
+Linux, so Ubuntu machines do receive it.) Inventing an unconditional-ignore shape
+to save twenty lines in the home directory is not worth a new pattern.
+
+## Recording Contract
+
+`mark_install_warning` becomes total. It never returns non-zero, and every
+decision reads the flag:
+
+```sh
+INSTALL_WARNING_RECORDED=0
+
+mark_install_warning() {
+  category="$1"
+  summary="$2"
+  guidance="$3"
+  INSTALL_WARNING_RECORDED=0
+
+  if terrapod_install_warning_write "$category" "$summary" "$guidance"; then
+    INSTALL_WARNING_RECORDED=1
+  fi
+
+  return 0
+}
+
+install_warning_recorded() {
+  [ "$INSTALL_WARNING_RECORDED" -eq 1 ]
+}
+
+exit_after_install_warning() {
+  if install_warning_recorded; then
+    exit 0
+  fi
+
+  exit 1
+}
+
+continue_after_core_install_warning() {
+  if ! install_warning_recorded; then
+    exit 1
+  fi
+
+  return 0
+}
+
+clear_install_warning() {
+  terrapod_install_warning_clear "$1" || true
+}
+```
+
+Totality is required, not stylistic. Every caller runs under `set -e` and writes
+
+```sh
+mark_install_warning \
+  homebrew-core \
+  "…" \
+  "…"
+exit_after_install_warning
+```
+
+Promoting `run_before_10`'s status-returning variant to the shared helper would
+make `set -e` kill the script on the `mark_install_warning` statement itself, so
+`exit_after_install_warning` would never run and the user would get an exit code
+with no explanation. Making the recorder total and the policy explicit removes
+that trap and resolves the drift between the five copies.
+
+`run_before_60:48` is the one call site that reads the old return value. It
+becomes `mark_install_warning …` followed by `if ! install_warning_recorded`.
+
+`continue_after_core_install_warning` moves into the shared helper even though
+only `run_before_10` calls it: it is policy over the same flag, and leaving it
+behind would recreate the divergence this design removes.
+
+`shell_integrations_warning_exists` stays in `run_before_30`. It is bound to one
+category, not to the flag, and once the guard is gone it reduces to
+`terrapod_install_warning_existing_path shell-integrations >/dev/null 2>&1`.
+
+## Loading Rules
+
+Three rules, each chosen for a reason. All nine chezmoi scripts run under
+`set -eu`.
+
+### Always-run scripts inline both layers
+
+Seven templates replace their loader block with `{{ include }}`, following
+`homebrew-prefix.sh`. Compile-time inlining is the strongest rule available: the
+library cannot be missing, so no guard is needed and none can be reintroduced.
+
+Four of them use the trio and inline both files: `run_before_10`,
+`run_after_20`, `run_before_30`, `run_before_60`.
+
+Three call the marker API directly and inline only `install-warnings.sh`:
+`run_before_01`, `run_before_02`, `run_after_70`.
+
+`run_before_10` inlines `homebrew-core-bundle.sh` the same way and drops its
+`TERRAPOD_HOMEBREW_CORE_BUNDLE_LOADED` guard (`:24`, `:301`). It is the identical
+defect in a file this change rewrites; leaving it would put a guarded loader back
+next to two inlined ones.
+
+The Jetendard scripts gain `set -e`, which requires one change:
+`run_after_70:14-15` captures `$?` from `python3` as a bare command. It becomes
+
+```sh
+settings_status=0
+python3 "$settings_helper" apply || settings_status="$?"
+```
+
+Inlining also removes the failure mode that motivated the missing `set -e`: with
+no `.` of an external path left in these scripts, there is no 127 to continue
+past.
+
+### The two `run_onchange_` scripts source by path, unguarded
+
+`run_onchange_before_00` and `run_onchange_after_65` keep a path-based source,
+with the guard removed and `set -e` in force:
+
+```sh
+. "{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/install-warnings.sh"
+```
+
+`run_onchange_before_00` sources `install-warning-script.sh` the same way.
+`run_onchange_after_65` needs only the marker API. `run_onchange_after_65` also
+moves from `set -u` to `set -eu`, which is what converts its silent 127 into a
+stop.
+
+This fixes the defect the issue reports — a missing library stops the script
+instead of disabling warnings — without inlining, and inlining is what these two
+scripts cannot afford.
+
+Chezmoi triggers `run_onchange_` scripts on rendered-content change. Inlining
+would put the library's bytes in the hash, so **any** edit to
+`install-warnings.sh` would re-run the Ubuntu bootstrap and the Jetendard font
+install on every machine. Neither is a cheap no-op:
+
+- `executable_jetendard-font:228-237` has no installed-state short-circuit.
+  `install()` always calls the GitHub releases API and always downloads the full
+  `Jetendard-TTF.zip`.
+- `ubuntu-bootstrap.sh:30` always runs `apt-get update`, and `:18-26` escalates
+  through `sudo` for any non-root user.
+
+Both therefore require network, and one can raise an unexpected `sudo` prompt.
+On an offline machine a one-line library edit would manufacture two fresh install
+warnings.
+
+The trigger is not hypothetical: `install-warnings.sh` changed seven times
+between `4d3a9dd` and `f314327`, and its most common edit — adding a name to
+`terrapod_install_warning_categories()` — happens every time a new install step
+gains a warning category.
+
+Path-sourcing carries the cost that a third loading rule exists and a future
+author could copy the wrong one. The regression test below pins the split, and
+ADR 0016 records why it is two rules rather than one.
+
+### `tpod` resolves lazily
+
+Lines 25-27 are deleted and replaced by
+
+```sh
+ensure_install_warnings_loaded() {
+  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ]; then
+    return 0
+  fi
+  if [ ! -f "$install_warnings_lib" ]; then
+    return 1
+  fi
+
+  . "$install_warnings_lib"
+}
+```
+
+Each of the four call sites opens with
+`if ! ensure_install_warnings_loaded; then return; fi` in place of its
+`TERRAPOD_INSTALL_WARNINGS_LOADED` test.
+
+The expanded form is deliberate. Written as
+`[ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ] && return 0`, a failing test
+makes the whole AND-list fail, and `set -eu` at `executable_terrapod:2` kills
+`tpod`.
+
+`tpod` needs no source-tree fallback. `install_warnings_lib` is derived from the
+command's own directory (`:16`), so running
+`./dot_local/bin/executable_terrapod` from a checkout already resolves
+`dot_local/lib/terrapod/install-warnings.sh`. The remaining gap — the library
+absent from `~/.local/lib` while markers exist in `~/.local/state` — requires an
+apply to have written markers without ever writing the library, which no code
+path produces.
+
+### `install.sh` loads once and fails loudly
+
+`mark_install_warning_from_source` (`:986`) and
+`clear_install_warning_from_source` (`:1003`) are deleted; nothing calls them.
+`load_install_warnings_from_source` sources the library unconditionally and is
+called once from `main`, immediately after `ensure_first_run_setup` (`:1353`)
+where the checkout is guaranteed:
+
+```sh
+load_install_warnings_from_source "$source_dir" ||
+  fatal "failed to load the install warning library from $source_dir"
+```
+
+The `|| return 0` at `:1035` and `|| return 1` at `:1052` are removed with it. A
+checkout missing the library now fails the install with a message instead of
+silently skipping the snapshot that decides whether the first run reports
+warnings.
+
+`install.sh` is a `curl | sh` bootstrap, not a chezmoi template, so `{{ include }}`
+is unavailable to it. Its checkout is a fresh clone, so a missing library means a
+broken clone, which is a fatal condition rather than one to work around.
+
+## The Sentinel
+
+`TERRAPOD_INSTALL_WARNINGS_LOADED=1` stays in `install-warnings.sh`. What this
+design deletes is every *guard* built on it — the sites that treat a non-`1`
+value as "warnings are off." The variable survives with one job:
+`ensure_install_warnings_loaded` reads it to know whether `tpod` has already
+sourced the file. It never again decides whether a feature runs.
+
+## Testing
+
+### Jetendard adapter fixtures need a new seam
+
+`tests/chezmoiignore_test.sh:403-411` renders each Jetendard script and rewrites
+the `^warnings_lib=` line with `sed` to point at a stub library. Two of the three
+adapters — `run_before_02` and `run_after_70` — are inlined by this design, so
+that line disappears, the `sed` silently no-ops, the real library runs, the
+stub's action log stays empty, and the assertions at `:421-437` fail.
+
+The fix inserts the stub after the inlined library instead of replacing a path.
+Shell function redefinition wins, and the `font_helper=` / `settings_helper=`
+lines survive as anchors:
+
+```sh
+sed -e "/^font_helper=/r $jetendard_warnings_stub" …
+```
+
+`run_onchange_after_65` keeps its `warnings_lib=` line, so the same insertion
+approach covers all three adapters uniformly rather than branching per script.
+
+### Fixture source directories gain a file
+
+Both the `{{ include }}` rule and the path-source rule read from the source
+directory — one at render time, one at run time. The synthetic source trees in
+`tests/terrapod_command_test.sh:558-575`, `tests/terrapod_installer_test.sh:640`,
+and `:816` must therefore also copy `install-warning-script.sh`. Omitting it now
+fails the chezmoi render rather than producing a silently degraded script.
+
+### Deployment assertion
+
+`tests/terrapod_command_test.sh:846-848` asserts that
+`.local/lib/terrapod/install-warnings.sh` is a managed target. An assertion for
+`.local/lib/terrapod/install-warning-script.sh` joins it. The new file has no
+profile scope, so it does not belong in the `macos_only_entries` or
+`linux_only_entries` lists of `tests/chezmoiignore_test.sh:238-276`.
+
+### Four regression tests
+
+Each must fail against the current code.
+
+1. With no `~/.local/lib/terrapod/install-warnings.sh` at process start and a
+   stub chezmoi that creates it during apply, `tpod apply` reports the remaining
+   warning. Today `print_remaining_install_warnings` prints nothing.
+2. `run_after_70` rendered and run with `python3` absent from `PATH` records the
+   `jetendard-settings` warning and exits 0, rather than exiting 1 from a 127
+   after the settings applied.
+3. `run_onchange_before_00` and `run_onchange_after_65`, rendered against a
+   source directory with no `install-warnings.sh`, exit non-zero. Today
+   `run_onchange_before_00` no-ops its warning writes and
+   `run_onchange_after_65` treats a 127 as a missing marker.
+4. Every rendered template is checked against the split: the seven always-run
+   scripts contain a `terrapod_install_warning_write` definition in their body,
+   the two `run_onchange_` scripts contain an unguarded `.` of the library path,
+   and none of the nine contains an `if [ -f "$install_warnings_lib" ]` guard. A
+   cheap text assertion, and the thing that stops a future entry point from
+   inventing a fourth rule or putting the library into an onchange hash.
+
+`sh -n` validation of `install-warning-script.sh` is added next to the existing
+check at `tests/terrapod_command_test.sh:916`.
+
+## Documentation
+
+**ADR 0016, "Load install warnings by a chosen rule per entry point."** Three
+decisions belong on the record:
+
+- Compile-time inlining is the default for chezmoi scripts, because it is the
+  only rule that cannot be silently degraded.
+- `run_onchange_` scripts are the exception and source by path, unguarded, under
+  `set -e`. Inlining would put the library into the rendered-content hash, and
+  neither the Ubuntu bootstrap nor the Jetendard font install is cheap enough to
+  re-run on every library edit. Any future `run_onchange_` script that records
+  install warnings follows this rule.
+- `TERRAPOD_INSTALL_WARNINGS_LOADED` is a load memo for `tpod`, never a feature
+  gate.
+
+The ADR also records that the first-run prune stays a no-op. ADR 0014 fixes the
+prune before the `chezmoi apply` delegation so the directory is consistent even
+when apply fails, and that ordering is pinned by a test. A fresh machine has no
+markers to prune, so the no-op costs nothing — but writing it down keeps it from
+being refiled as a bug.
+
+This design contradicts no existing ADR.
+
+## Out of Scope
+
+`executable_terrapod:29-31` guards `homebrew-prefix.sh` with the same one-shot
+`TERRAPOD_HOMEBREW_PREFIX_LOADED` pattern. It is a different library with no
+observed symptom — `tpod` reaches its Homebrew paths only after the first apply
+has deployed the file — and it gets its own issue.
+
+Moving `prune_retired_install_warnings` after the apply delegation would make the
+first-run prune work, but it reverses an ADR 0014 decision on unrelated grounds.
+Revisiting that ordering is a separate change with its own ADR.
+
+Giving `executable_jetendard-font` an installed-state short-circuit would remove
+the strongest objection to inlining in `run_onchange_after_65`. It is a real
+improvement and unrelated to this issue; it gets its own issue rather than
+riding along.

--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -22,15 +22,24 @@ if [ ! -e "$executable_selection_helper" ] &&
 fi
 jetendard_font_helper="${TERRAPOD_JETENDARD_FONT_HELPER:-$command_dir/../lib/terrapod/jetendard-font}"
 jetendard_settings_helper="${TERRAPOD_JETENDARD_SETTINGS_HELPER:-$command_dir/../lib/terrapod/jetendard-settings}"
-TERRAPOD_INSTALL_WARNINGS_LOADED=
-if [ -f "$install_warnings_lib" ]; then
-  . "$install_warnings_lib"
-fi
-
 TERRAPOD_HOMEBREW_PREFIX_LOADED=
 if [ -f "$homebrew_prefix_lib" ]; then
   . "$homebrew_prefix_lib"
 fi
+
+# Resolved per call rather than once at startup: during the first-run apply the
+# library target does not exist yet when tpod starts, but does by the time the
+# post-apply readers run.
+ensure_install_warnings_loaded() {
+  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ]; then
+    return 0
+  fi
+  if [ ! -f "$install_warnings_lib" ]; then
+    return 1
+  fi
+
+  . "$install_warnings_lib"
+}
 
 run_jetendard_check() {
   helper="$1"
@@ -1241,7 +1250,7 @@ print_status_warnings() {
 install_warning_categories_csv() {
   categories=
 
-  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" != "1" ]; then
+  if ! ensure_install_warnings_loaded; then
     return 0
   fi
 
@@ -1516,7 +1525,7 @@ show_apply_context() {
 }
 
 prune_retired_install_warnings() {
-  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" != "1" ]; then
+  if ! ensure_install_warnings_loaded; then
     return
   fi
 
@@ -1657,7 +1666,7 @@ install_warning_value_or_unknown() {
 }
 
 doctor_check_install_warnings() {
-  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" != "1" ]; then
+  if ! ensure_install_warnings_loaded; then
     doctor_ok "No install warning marker reader is installed"
     return
   fi
@@ -1682,7 +1691,7 @@ doctor_check_install_warnings() {
 }
 
 print_remaining_install_warnings() {
-  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" != "1" ]; then
+  if ! ensure_install_warnings_loaded; then
     return
   fi
 

--- a/dot_local/lib/terrapod/install-warning-script.sh
+++ b/dot_local/lib/terrapod/install-warning-script.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+# Installer-side policy over the install warning markers. Chezmoi scripts inline
+# or source this beside install-warnings.sh; tpod does not use it.
+#
+# There is deliberately no TERRAPOD_..._LOADED sentinel here. Nothing may branch
+# on whether this file loaded — that branch is the defect this library removes.
+
+INSTALL_WARNING_RECORDED=0
+
+# Records a warning marker. Never fails: callers run under `set -e`, and a
+# non-zero return here would kill the script before it reaches its exit policy.
+mark_install_warning() {
+  category="$1"
+  summary="$2"
+  guidance="$3"
+  INSTALL_WARNING_RECORDED=0
+
+  if terrapod_install_warning_write "$category" "$summary" "$guidance"; then
+    INSTALL_WARNING_RECORDED=1
+  fi
+
+  return 0
+}
+
+install_warning_recorded() {
+  [ "$INSTALL_WARNING_RECORDED" -eq 1 ]
+}
+
+# The user was told what went wrong, so the apply continues. If we could not
+# even record the warning, fail loudly instead of failing silently.
+exit_after_install_warning() {
+  if install_warning_recorded; then
+    exit 0
+  fi
+
+  exit 1
+}
+
+continue_after_core_install_warning() {
+  if ! install_warning_recorded; then
+    exit 1
+  fi
+
+  return 0
+}
+
+clear_install_warning() {
+  terrapod_install_warning_clear "$1" || true
+}

--- a/install.sh
+++ b/install.sh
@@ -983,48 +983,13 @@ find_homebrew() {
   return 1
 }
 
-mark_install_warning_from_source() {
-  source_dir="$1"
-  category="$2"
-  summary="$3"
-  guidance="$4"
-  install_warnings_lib="$source_dir/dot_local/lib/terrapod/install-warnings.sh"
-  TERRAPOD_INSTALL_WARNINGS_LOADED=
-
-  if [ -f "$install_warnings_lib" ]; then
-    . "$install_warnings_lib"
-  fi
-
-  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ]; then
-    terrapod_install_warning_write "$category" "$summary" "$guidance" || true
-  fi
-}
-
-clear_install_warning_from_source() {
-  source_dir="$1"
-  category="$2"
-  install_warnings_lib="$source_dir/dot_local/lib/terrapod/install-warnings.sh"
-  TERRAPOD_INSTALL_WARNINGS_LOADED=
-
-  if [ -f "$install_warnings_lib" ]; then
-    . "$install_warnings_lib"
-  fi
-
-  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ]; then
-    terrapod_install_warning_clear "$category" || true
-  fi
-}
-
 load_install_warnings_from_source() {
   source_dir="$1"
   install_warnings_lib="$source_dir/dot_local/lib/terrapod/install-warnings.sh"
-  TERRAPOD_INSTALL_WARNINGS_LOADED=
 
-  if [ -f "$install_warnings_lib" ]; then
-    . "$install_warnings_lib"
-  fi
+  [ -f "$install_warnings_lib" ] || return 1
 
-  [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" = "1" ]
+  . "$install_warnings_lib"
 }
 
 snapshot_install_warnings_from_source() {
@@ -1032,7 +997,6 @@ snapshot_install_warnings_from_source() {
   snapshot_dir="$2"
 
   mkdir -p "$snapshot_dir" || return 1
-  load_install_warnings_from_source "$source_dir" || return 0
 
   for category in $(terrapod_install_warning_categories); do
     if terrapod_install_warning_read "$category" >"$snapshot_dir/$category" 2>/dev/null; then
@@ -1048,8 +1012,6 @@ install_warning_markers_changed_since_snapshot() {
   source_dir="$1"
   snapshot_dir="$2"
   changed=false
-
-  load_install_warnings_from_source "$source_dir" || return 1
 
   for category in $(terrapod_install_warning_categories); do
     current_file="$snapshot_dir/current-$category"
@@ -1351,6 +1313,8 @@ main() {
     initialize_source_repository "$chezmoi_bin"
   fi
   ensure_first_run_setup "$profile" "$source_dir" "$chezmoi_bin"
+  load_install_warnings_from_source "$source_dir" ||
+    fatal "failed to load the install warning library from $source_dir"
   apply_recovery_core_command_surface "$profile" "$source_dir" "$local_bin_dir"
   apply_recovery_core_shell_startup_files "$profile" "$chezmoi_bin"
   initial_apply_status=0

--- a/tests/bootstrap_ubuntu_test.sh
+++ b/tests/bootstrap_ubuntu_test.sh
@@ -346,3 +346,22 @@ if [ -e "$ubuntu_bootstrap_marker" ]; then
   fail "Ubuntu bootstrap retry should clear the ubuntu-bootstrap warning after a successful retry"
 fi
 pass "Ubuntu bootstrap retry clears the ubuntu-bootstrap warning after a successful retry"
+
+missing_lib_source="$tmp_dir/onchange-missing-lib"
+mkdir -p "$missing_lib_source"
+cp -R "$repo_root/dot_local" "$missing_lib_source/dot_local"
+rm -f \
+  "$missing_lib_source/dot_local/lib/terrapod/install-warnings.sh" \
+  "$missing_lib_source/dot_local/lib/terrapod/install-warning-script.sh"
+
+rendered_missing_lib="$tmp_dir/onchange-missing-lib.sh"
+"$chezmoi_bin" execute-template \
+  --source "$repo_root" \
+  --override-data "{\"chezmoi\":{\"os\":\"linux\",\"sourceDir\":\"$missing_lib_source\",\"osRelease\":{\"id\":\"ubuntu\",\"versionID\":\"24.04\"}}}" \
+  --file "$repo_root/.chezmoiscripts/run_onchange_before_00-bootstrap-ubuntu.sh.tmpl" \
+  >"$rendered_missing_lib"
+
+if sh "$rendered_missing_lib" >/dev/null 2>&1; then
+  fail "Ubuntu bootstrap stops when the install warning library is missing"
+fi
+pass "Ubuntu bootstrap stops when the install warning library is missing"

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -374,6 +374,22 @@ assert_contains_text \
   'python3 "$font_helper" install' \
   "Jetendard retry invokes the helper install command"
 
+jetendard_missing_lib_source="$tmp_dir/jetendard-onchange-missing-lib"
+mkdir -p "$jetendard_missing_lib_source"
+cp -R "$repo_root/dot_local" "$jetendard_missing_lib_source/dot_local"
+rm -f "$jetendard_missing_lib_source/dot_local/lib/terrapod/install-warnings.sh"
+
+jetendard_missing_lib_data="{\"chezmoi\":{\"os\":\"darwin\",\"sourceDir\":\"$jetendard_missing_lib_source\"},\"enableEditorStack\":false,\"enableAiCliTools\":false,\"enableDevelopmentWorkspace\":false}"
+macos_jetendard_installer_missing_lib="$(render_template "$jetendard_missing_lib_data" ".chezmoiscripts/run_onchange_after_65-install-jetendard-font.sh.tmpl")"
+
+macos_jetendard_installer_missing_lib_script="$tmp_dir/macos-jetendard-installer-missing-lib.sh"
+printf '%s\n' "$macos_jetendard_installer_missing_lib" >"$macos_jetendard_installer_missing_lib_script"
+
+if sh "$macos_jetendard_installer_missing_lib_script" >/dev/null 2>&1; then
+  fail "Jetendard font install should stop when the install warning library is missing"
+fi
+pass "Jetendard font install stops when the install warning library is missing"
+
 jetendard_adapter_fixture="$tmp_dir/jetendard-adapter-fixture"
 mkdir -p "$jetendard_adapter_fixture"
 jetendard_adapter_log="$jetendard_adapter_fixture/actions.log"

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -2118,3 +2118,62 @@ if ! printf '%s\n' "$development_workspace_zellij_layout" |
 fi
 
 pass "enableDevelopmentWorkspace passes supported permission skip mode to the Antigravity pane"
+
+inlined_warning_scripts="
+.chezmoiscripts/run_before_01-retry-ubuntu-bootstrap.sh.tmpl
+.chezmoiscripts/run_before_02-retry-jetendard-font.sh.tmpl
+.chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl
+.chezmoiscripts/run_before_30-install-shell-integrations.sh.tmpl
+.chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl
+.chezmoiscripts/run_after_20-install-mise-tools.sh.tmpl
+.chezmoiscripts/run_after_70-apply-jetendard-settings.sh.tmpl
+"
+
+path_sourced_warning_scripts="
+.chezmoiscripts/run_onchange_before_00-bootstrap-ubuntu.sh.tmpl
+.chezmoiscripts/run_onchange_after_65-install-jetendard-font.sh.tmpl
+"
+
+warning_script_data() {
+  case "$1" in
+    *run_before_01*|*run_onchange_before_00*)
+      printf '%s' "$ubuntu_data"
+      ;;
+    *)
+      printf '%s' "$macos_data"
+      ;;
+  esac
+}
+
+for warning_script in $inlined_warning_scripts; do
+  rendered_warning_script="$(render_template "$(warning_script_data "$warning_script")" "$warning_script")"
+
+  assert_contains_text \
+    "$rendered_warning_script" \
+    "terrapod_install_warning_write() {" \
+    "always-run script inlines the marker library: $warning_script"
+
+  assert_not_contains_text \
+    "$rendered_warning_script" \
+    'if [ -f "$install_warnings_lib" ]; then' \
+    "always-run script keeps no install warning loader guard: $warning_script"
+done
+
+for warning_script in $path_sourced_warning_scripts; do
+  rendered_warning_script="$(render_template "$(warning_script_data "$warning_script")" "$warning_script")"
+
+  assert_not_contains_text \
+    "$rendered_warning_script" \
+    "terrapod_install_warning_write() {" \
+    "run_onchange script keeps the marker library out of its content hash: $warning_script"
+
+  assert_contains_text \
+    "$rendered_warning_script" \
+    "/dot_local/lib/terrapod/install-warnings.sh" \
+    "run_onchange script sources the marker library by path: $warning_script"
+
+  assert_not_contains_text \
+    "$rendered_warning_script" \
+    'if [ -f "$install_warnings_lib" ]; then' \
+    "run_onchange script keeps no install warning loader guard: $warning_script"
+done

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -400,6 +400,8 @@ with Path(os.environ["JETENDARD_ADAPTER_LOG"]).open("a") as stream:
     stream.write("helper\n")
 PY
 
+# The adapters inline install-warnings.sh, so the stub is appended after the
+# helper assignment to override the real definitions rather than replacing a path.
 render_jetendard_adapter_fixture() {
   rendered="$1"
   destination="$2"
@@ -408,6 +410,8 @@ render_jetendard_adapter_fixture() {
       -e "s#^warnings_lib=.*#warnings_lib=\"$jetendard_warnings_stub\"#" \
       -e "s#^font_helper=.*#font_helper=\"$jetendard_helper_stub\"#" \
       -e "s#^settings_helper=.*#settings_helper=\"$jetendard_helper_stub\"#" \
+      -e "/^font_helper=/r $jetendard_warnings_stub" \
+      -e "/^settings_helper=/r $jetendard_warnings_stub" \
       >"$destination"
 }
 
@@ -437,6 +441,31 @@ assert_text_equals "$(cat "$jetendard_adapter_log")" 'marker-check
 helper
 clear' \
   "Jetendard retry checks the marker before install and clear"
+
+jetendard_no_python_bin="$tmp_dir/jetendard-no-python-bin"
+mkdir -p "$jetendard_no_python_bin"
+
+# Invoke the fixture by its own shebang rather than "sh $file": with PATH
+# restricted to an empty directory, a bare "sh" word would itself fail to
+# resolve (the shell searches the temporary PATH for "sh" too), which would
+# fail before the script ever ran. Direct execution resolves the interpreter
+# via the kernel's shebang handling, so only the script's internal PATH
+# lookups (e.g. "command -v python3") are affected.
+chmod +x "$jetendard_settings_fixture"
+: >"$jetendard_adapter_log"
+if ! JETENDARD_ADAPTER_LOG="$jetendard_adapter_log" \
+  JETENDARD_MARKER_EXISTS=0 \
+  JETENDARD_CLEAR_FAIL=0 \
+  PATH="$jetendard_no_python_bin" \
+  "$jetendard_settings_fixture" >/dev/null 2>&1; then
+  fail "Jetendard settings adapter records a warning and succeeds without python3"
+fi
+pass "Jetendard settings adapter records a warning and succeeds without python3"
+
+assert_text_equals \
+  "$(cat "$jetendard_adapter_log")" \
+  'write' \
+  "Jetendard settings adapter writes exactly one warning when python3 is missing"
 
 macos_mise_missing_script="$tmp_dir/macos-mise-missing.sh"
 printf '%s\n' "$macos_mise_tools_installer" |

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -3884,3 +3884,71 @@ assert_not_contains \
   "$apply_override_validation_error" \
   "Run 'terrapod chezmoi -- --config $diff_config managed'" \
   "Terrapod apply avoids old config-aware post-apply validation command"
+
+lazy_home="$tmp_dir/lazy-lib-home"
+lazy_state="$lazy_home/.local/state"
+lazy_lib="$tmp_dir/lazy-lib/install-warnings.sh"
+lazy_bin="$tmp_dir/lazy-lib-bin"
+lazy_config="$tmp_dir/lazy-lib-chezmoi.toml"
+mkdir -p "$lazy_home" "$lazy_state" "$lazy_bin" "$tmp_dir/lazy-lib"
+# A complete managed setup config, so the run reaches the delegated chezmoi
+# apply instead of failing preflight on missing managed setup keys.
+cat >"$lazy_config" <<'TOML'
+[data]
+profile = "macos-terminal"
+enableEditorStack = true
+enableAiCliTools = true
+enableDevelopmentWorkspace = true
+enableMacosAppGroupTerminalApps = true
+enableMacosAppGroupAutomation = true
+enableMacosAppGroupLauncher = true
+enableMacosAppGroupMonitoring = false
+enableMacosAppGroupDevelopmentApps = true
+enableMacosAppGroupMobileDev = true
+TOML
+
+if [ -e "$lazy_lib" ]; then
+  fail "lazy library fixture starts without the install warning library"
+fi
+
+# The stub apply creates the library mid-run, exactly as the first real apply does.
+# Scan all args (not just $1): run_chezmoi_command prepends "--config <path>"
+# ahead of the "apply" subcommand whenever TERRAPOD_CHEZMOI_CONFIG is set.
+write_stub "$lazy_bin/chezmoi" \
+  'is_apply=' \
+  'for arg do' \
+  '  if [ "$arg" = "apply" ]; then' \
+  '    is_apply=1' \
+  '  fi' \
+  'done' \
+  'if [ "$is_apply" = "1" ]; then' \
+  '  mkdir -p "$(dirname "$LAZY_LIB_TARGET")"' \
+  '  cp "$LAZY_LIB_SOURCE" "$LAZY_LIB_TARGET"' \
+  '  HOME="$LAZY_HOME" XDG_STATE_HOME="$LAZY_STATE" sh -c '"'"'. "$1"; terrapod_install_warning_write mise-tools "mise tool install needs attention" "Rerun tpod apply."'"'"' sh "$LAZY_LIB_TARGET"' \
+  '  printf "%s\n" "stub apply output"' \
+  'fi' \
+  'exit 0'
+
+lazy_output="$(
+  LAZY_LIB_TARGET="$lazy_lib" \
+  LAZY_LIB_SOURCE="$repo_root/dot_local/lib/terrapod/install-warnings.sh" \
+  LAZY_HOME="$lazy_home" \
+  LAZY_STATE="$lazy_state" \
+  HOME="$lazy_home" \
+  XDG_STATE_HOME="$lazy_state" \
+  TERRAPOD_INSTALL_WARNINGS_LIB="$lazy_lib" \
+  TERRAPOD_PROFILE=macos-terminal \
+  TERRAPOD_CHEZMOI_CONFIG="$lazy_config" \
+  PATH="$lazy_bin:$PATH" \
+    "$terrapod" apply 2>&1
+)" || true
+
+assert_contains \
+  "$lazy_output" \
+  "Remaining install warnings:" \
+  "Terrapod apply reports warnings written by an apply that also installed the marker library"
+
+assert_contains \
+  "$lazy_output" \
+  "mise-tools: mise tool install needs attention" \
+  "Terrapod apply reads the marker library that appeared during the delegated apply"

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -572,6 +572,8 @@ copy_desktop_apply_source_fixture() {
     "$repo_root/dot_local/lib/terrapod/homebrew-prefix.sh" \
     >"$source_dir/dot_local/lib/terrapod/homebrew-prefix.sh"
   cp "$install_warnings_lib" "$source_dir/dot_local/lib/terrapod/install-warnings.sh"
+  cp "$repo_root/dot_local/lib/terrapod/install-warning-script.sh" \
+    "$source_dir/dot_local/lib/terrapod/install-warning-script.sh"
 }
 
 write_desktop_apply_config() {

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -1275,57 +1275,32 @@ write_stub "$fake_warning_bin/brew" \
 fake_ai_cli_installer="$tmp_dir/fake-ai-cli-installer.sh"
 chezmoi execute-template \
   --source "$repo_root" \
-  --override-data '{"chezmoi":{"os":"darwin","sourceDir":"/missing-terrapod-source"},"enableAiCliTools":true}' \
+  --override-data "{\"chezmoi\":{\"os\":\"darwin\",\"sourceDir\":\"$repo_root\"},\"enableAiCliTools\":true}" \
   --file "$repo_root/.chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl" \
   | sed "s#/opt/homebrew/bin/brew#$fake_warning_bin/brew#g" \
   >"$fake_ai_cli_installer"
 
 if ! HOME="$fake_ai_cli_home" FAKE_INSTALL_WARNING_CALLS="$fake_warning_calls" TERRAPOD_MACHINE_ARCH=aarch64 PATH="$fake_warning_bin:/usr/bin:/bin" /bin/sh "$fake_ai_cli_installer" >"$tmp_dir/fake-ai-cli-installer.out" 2>"$tmp_dir/fake-ai-cli-installer.err"; then
-  fail "rendered installer fixture succeeds when the Homebrew AI CLI bundle succeeds and the shared library is missing"
+  fail "rendered installer fixture succeeds when the Homebrew AI CLI bundle succeeds"
 fi
 
 if [ -e "$fake_warning_calls" ]; then
-  fail "installer scripts ignore PATH fake install warning helpers when the shared library is not loaded"
+  fail "installer scripts ignore PATH fake install warning helpers"
 fi
-pass "installer scripts ignore PATH fake install warning helpers when the shared library is not loaded"
+pass "installer scripts ignore PATH fake install warning helpers"
 
-fake_ai_cli_failure_home="$tmp_dir/fake-ai-cli-failure-home"
-mkdir -p "$fake_ai_cli_failure_home/.local/bin"
-write_stub "$fake_ai_cli_failure_home/.local/bin/brew" \
-  'case "$1" in' \
-  '  shellenv) printf "%s\n" ":" ;;' \
-  '  bundle) exit 42 ;;' \
-  '  *) exit 64 ;;' \
-  'esac'
-
-fake_ai_cli_failure_installer="$tmp_dir/fake-ai-cli-failure-installer.sh"
-chezmoi execute-template \
-  --source "$repo_root" \
-  --override-data '{"chezmoi":{"os":"darwin","sourceDir":"/missing-terrapod-source"},"enableAiCliTools":true}' \
-  --file "$repo_root/.chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl" \
-  | sed "s#/opt/homebrew/bin/brew#$fake_ai_cli_failure_home/.local/bin/brew#g" \
-  >"$fake_ai_cli_failure_installer"
-
-fake_ai_cli_failure_status=0
-HOME="$fake_ai_cli_failure_home" TERRAPOD_MACHINE_ARCH=aarch64 PATH="$fake_ai_cli_failure_home/.local/bin:/usr/bin:/bin" /bin/sh "$fake_ai_cli_failure_installer" >"$tmp_dir/fake-ai-cli-failure.out" 2>"$tmp_dir/fake-ai-cli-failure.err" || fake_ai_cli_failure_status=$?
-if [ "$fake_ai_cli_failure_status" -eq 0 ]; then
-  fail "rendered installer fixture fails when optional AI CLI failures cannot be recorded without the shared library"
-fi
-pass "rendered installer fixture fails when optional AI CLI failures cannot be recorded without the shared library"
-
-fake_ai_cli_warning_source="$tmp_dir/fake-ai-cli-warning-source"
 fake_ai_cli_write_failure_home="$tmp_dir/fake-ai-cli-write-failure-home"
-mkdir -p "$fake_ai_cli_warning_source/dot_local/lib/terrapod" "$fake_ai_cli_write_failure_home/.local/bin"
-printf '%s\n' \
-  'TERRAPOD_INSTALL_WARNINGS_LOADED=1' \
-  'terrapod_install_warning_write() {' \
-  '  printf "%s\n" "write failed:$*" >&2' \
-  '  return 1' \
-  '}' \
-  'terrapod_install_warning_clear() {' \
-  '  return 0' \
-  '}' \
-  >"$fake_ai_cli_warning_source/dot_local/lib/terrapod/install-warnings.sh"
+fake_ai_cli_warning_stub="$tmp_dir/fake-ai-cli-warning-stub.sh"
+mkdir -p "$fake_ai_cli_write_failure_home/.local/bin"
+cat >"$fake_ai_cli_warning_stub" <<'STUB'
+terrapod_install_warning_write() {
+  printf "%s\n" "write failed:$*" >&2
+  return 1
+}
+terrapod_install_warning_clear() {
+  return 0
+}
+STUB
 write_stub "$fake_ai_cli_write_failure_home/.local/bin/brew" \
   'case "$1" in' \
   '  shellenv) printf "%s\n" ":" ;;' \
@@ -1333,12 +1308,16 @@ write_stub "$fake_ai_cli_write_failure_home/.local/bin/brew" \
   '  *) exit 64 ;;' \
   'esac'
 
+# The script inlines install-warnings.sh, so the stub is appended after the
+# category assignment to override the real definitions.
 fake_ai_cli_write_failure_installer="$tmp_dir/fake-ai-cli-write-failure-installer.sh"
 chezmoi execute-template \
   --source "$repo_root" \
-  --override-data "{\"chezmoi\":{\"os\":\"darwin\",\"sourceDir\":\"$fake_ai_cli_warning_source\"},\"enableAiCliTools\":true}" \
+  --override-data '{"chezmoi":{"os":"darwin"},"enableAiCliTools":true}' \
   --file "$repo_root/.chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl" \
-  | sed "s#/opt/homebrew/bin/brew#$fake_ai_cli_write_failure_home/.local/bin/brew#g" \
+  | sed \
+    -e "s#/opt/homebrew/bin/brew#$fake_ai_cli_write_failure_home/.local/bin/brew#g" \
+    -e "/^AI_CLI_WARNING_CATEGORY=/r $fake_ai_cli_warning_stub" \
   >"$fake_ai_cli_write_failure_installer"
 
 fake_ai_cli_write_failure_status=0

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -850,6 +850,11 @@ assert_line \
 
 assert_line \
   "$managed_targets" \
+  ".local/lib/terrapod/install-warning-script.sh" \
+  "chezmoi manages the shared install warning script helper library"
+
+assert_line \
+  "$managed_targets" \
   ".local/lib/terrapod/executable-selection" \
   "chezmoi manages the executable selection helper"
 
@@ -915,6 +920,16 @@ pass "shared install warning marker library source exists"
 
 sh -n "$install_warnings_lib" || fail "shared install warning marker library is valid POSIX shell"
 pass "shared install warning marker library is valid POSIX shell"
+
+install_warning_script_lib="$repo_root/dot_local/lib/terrapod/install-warning-script.sh"
+
+if [ ! -f "$install_warning_script_lib" ]; then
+  fail "shared install warning script helper library exists"
+fi
+pass "shared install warning script helper library exists"
+
+sh -n "$install_warning_script_lib" || fail "shared install warning script helper library is valid POSIX shell"
+pass "shared install warning script helper library is valid POSIX shell"
 
 sh -n "$executable_selection_helper" || fail "executable selection helper is valid POSIX shell"
 pass "executable selection helper is valid POSIX shell"

--- a/tests/terrapod_installer_test.sh
+++ b/tests/terrapod_installer_test.sh
@@ -2709,3 +2709,48 @@ if grep -n "load_install_warnings_from_source .* || return 0" "$repo_root/instal
   fail "install.sh no longer skips the marker snapshot when the library is missing"
 fi
 pass "install.sh no longer skips the marker snapshot when the library is missing"
+
+install_warnings_loader_case="$(make_case_dir install-warnings-loader)"
+install_warnings_loader_functions="$install_warnings_loader_case/install-functions.sh"
+sed '$d' "$repo_root/install.sh" >"$install_warnings_loader_functions"
+
+install_warnings_loader_empty_source="$install_warnings_loader_case/empty-source"
+mkdir -p "$install_warnings_loader_empty_source"
+if sh -c '. "$1"; load_install_warnings_from_source "$2"' \
+  sh "$install_warnings_loader_functions" "$install_warnings_loader_empty_source"; then
+  fail "install.sh treats a checkout without the marker library as fatal"
+fi
+pass "install.sh treats a checkout without the marker library as fatal"
+
+install_warnings_loader_real_source="$install_warnings_loader_case/real-source"
+mkdir -p "$install_warnings_loader_real_source/dot_local/lib/terrapod"
+cp "$repo_root/dot_local/lib/terrapod/install-warnings.sh" \
+  "$install_warnings_loader_real_source/dot_local/lib/terrapod/install-warnings.sh"
+if ! install_warnings_loader_categories="$(
+  sh -c '. "$1"; load_install_warnings_from_source "$2" && terrapod_install_warning_categories' \
+    sh "$install_warnings_loader_functions" "$install_warnings_loader_real_source"
+)"; then
+  fail "install.sh loads the install warning library from a real checkout and makes terrapod_install_warning_categories callable"
+fi
+assert_contains "$install_warnings_loader_categories" "homebrew-core" \
+  "install.sh loads the install warning library from a real checkout and makes terrapod_install_warning_categories callable"
+
+missing_install_warnings_library_case="$(make_case_dir missing-install-warnings-library)"
+write_uname_stub "$missing_install_warnings_library_case" "Darwin"
+write_command_call_stubs "$missing_install_warnings_library_case" "curl" "wget" "git" "sh"
+write_gum_command_stub "$missing_install_warnings_library_case"
+mkdir -p "$missing_install_warnings_library_case/home/.local/bin"
+write_chezmoi_flow_stub "$missing_install_warnings_library_case/home/.local/bin/chezmoi"
+TERRAPOD_STUB_CALL_LOG="$missing_install_warnings_library_case/command-calls"
+export TERRAPOD_STUB_CALL_LOG
+TERRAPOD_INSTALL_WARNINGS_LIB_TEMPLATE=
+export TERRAPOD_INSTALL_WARNINGS_LIB_TEMPLATE
+run_installer_case "$missing_install_warnings_library_case" 'minimal
+'
+TERRAPOD_INSTALL_WARNINGS_LIB_TEMPLATE="$install_warnings_lib_template"
+export TERRAPOD_INSTALL_WARNINGS_LIB_TEMPLATE
+unset TERRAPOD_STUB_CALL_LOG
+assert_failure "$installer_status" "installer fails when the checked-out source is missing the install warning library"
+assert_contains "$(cat "$missing_install_warnings_library_case/stderr")" \
+  "failed to load the install warning library" \
+  "missing install warning library failure is explicit"

--- a/tests/terrapod_installer_test.sh
+++ b/tests/terrapod_installer_test.sh
@@ -2699,3 +2699,13 @@ tpod_help_failure_stderr="$(cat "$tpod_help_failure_case/stderr")"
 tpod_help_failure_log_text="$(cat "$tpod_help_failure_log" 2>/dev/null || true)"
 assert_contains "$tpod_help_failure_stderr" "tpod help failed after recovery-core apply" "tpod help failure explains recovery-core validation failure"
 assert_not_contains "$tpod_help_failure_log_text" "chezmoi args:apply" "tpod help failure stops before full apply"
+
+if grep -n "mark_install_warning_from_source" "$repo_root/install.sh" >/dev/null; then
+  fail "install.sh no longer defines the never-called mark_install_warning_from_source"
+fi
+pass "install.sh no longer defines the never-called mark_install_warning_from_source"
+
+if grep -n "load_install_warnings_from_source .* || return 0" "$repo_root/install.sh" >/dev/null; then
+  fail "install.sh no longer skips the marker snapshot when the library is missing"
+fi
+pass "install.sh no longer skips the marker snapshot when the library is missing"


### PR DESCRIPTION
Closes #153

## Problem

Eleven entry points loaded `dot_local/lib/terrapod/install-warnings.sh`, each its own way, and three of those ways failed silently.

`executable_terrapod:25-27` decided once at startup whether the library existed. During the first-run install that decision is always wrong: `install.sh` copies `terrapod` into `~/.local/bin` and runs `tpod apply` *before* the apply that creates `~/.local/lib/terrapod/install-warnings.sh`. So `print_remaining_install_warnings` no-opped for the entire first run — the run most likely to produce warnings.

Five chezmoiscripts sourced the library behind `if [ -f … ]`. When it was absent every warning write became a no-op and `exit_after_install_warning` exited 1 with no marker and no message. Each also carried its own 30-40 line `mark`/`clear`/`exit` trio, and the five copies had drifted: `run_before_10` returned a status, `run_after_20` did not.

The three Jetendard scripts ran `set -u` without `set -e` and sourced the library unguarded, so a failed source left the marker functions undefined. In `run_after_70` the resulting 127 made `|| exit 1` fire *after* the settings applied successfully; in `run_before_02` an undefined `terrapod_install_warning_existing_path` read as "no marker" and silently disabled the retry path.

Two things the issue did not capture: `run_before_01` is a sixth variant that exits 0 for a retry it never attempted, and `install.sh:986`/`:1003` define two loaders nothing ever calls. The issue also lists six trio-carrying scripts; #187 merged two of them, so it is five.

## Approach

Three loading rules, each chosen for its entry point, none able to degrade quietly.

**Always-run chezmoi scripts inline both libraries** with `{{ include }}`, following `homebrew-prefix.sh`. Compile-time inlining is the default because it is the only rule under which the library cannot be missing — no guard is needed and none can be reintroduced. Seven templates: `run_before_01/02/10/30/60`, `run_after_20/70`. `run_before_10` inlines `homebrew-core-bundle.sh` the same way and drops its identical guard.

**The two `run_onchange_` scripts are the exception.** They source by path, unguarded, under `set -e`. Chezmoi triggers `run_onchange_` scripts on rendered-content change, so inlining would put the library's bytes in the hash and re-run the work on every library edit — and neither is cheap. `install()` in `executable_jetendard-font` has no installed-state short-circuit: it always calls the GitHub releases API and downloads the full archive. `ubuntu-bootstrap.sh` always runs `apt-get update` and escalates through `sudo`. `install-warnings.sh` changed seven times between `4d3a9dd` and `f314327`, and its most common edit is a new category name — exactly what happens when a new install step gains a warning.

**`tpod` resolves lazily** at each of its four call sites. `install.sh` cannot use `{{ include }}` (it is a `curl | sh` bootstrap), so it loads once from the checkout and treats absence as fatal.

The trio moves into a new `dot_local/lib/terrapod/install-warning-script.sh`, and `mark_install_warning` becomes total:

```sh
mark_install_warning() {
  INSTALL_WARNING_RECORDED=0
  if terrapod_install_warning_write "$1" "$2" "$3"; then
    INSTALL_WARNING_RECORDED=1
  fi
  return 0
}
```

Totality is required, not stylistic. Every caller runs under `set -e` and writes `mark_install_warning …` followed by `exit_after_install_warning`. Promoting `run_before_10`'s status-returning variant would make `set -e` kill the script on the `mark_install_warning` statement itself, so the user would get an exit code with no explanation. Decisions read the flag instead: `install_warning_recorded`, `exit_after_install_warning`, `continue_after_core_install_warning`.

`TERRAPOD_INSTALL_WARNINGS_LOADED` survives with one job — the memo `ensure_install_warnings_loaded` reads to know `tpod` already sourced the file. Every guard built on it is gone; the repo is down to two references.

Two branches were deleted because inlining makes their state unreachable: `run_before_10`'s bare-`brew bundle` fallback for a failed `homebrew-core-bundle.sh` load, and the `run_before_60` assertion that the script fails when the library is missing.

## Tests

One regression test per symptom, each failing against the pre-change code:

- `terrapod_command_test.sh` — a stub chezmoi that creates the library mid-apply; `tpod apply` must then report the warning. Red before, green after.
- `chezmoiignore_test.sh` — `run_after_70` with `python3` absent from `PATH` records the warning and exits 0 instead of exiting 1 from a 127.
- `bootstrap_ubuntu_test.sh` and `chezmoiignore_test.sh` — both `run_onchange_` scripts exit non-zero when the source tree lacks the library.
- `chezmoiignore_test.sh` — a loading-rule assertion over all nine templates: the seven inlined ones carry the definition, the two path-sourced ones do not, and none carries a guard. This is what stops a future entry point from inventing a fourth rule or putting the library into an onchange hash.
- `terrapod_installer_test.sh` — `load_install_warnings_from_source` in both directions, plus an end-to-end case asserting `main` reaches its `fatal`. The positive direction is the load-bearing half: deleting the call from `main` reproduces the original silent degradation (empty snapshot, rc 0, "clean" first run with warnings on disk) without tripping `set -e`, because the failing command substitution sits in a `for` word list.

The Jetendard adapter fixtures needed a new seam. They swapped a stub library by rewriting the `^warnings_lib=` line; inlining deletes that line, so the `sed` would silently no-op and the real library would run. Stubs are now inserted after the inlined definitions, where function redefinition wins.

Full suite green: 20 test files, 1969 assertions. `homebrew_ubuntu_smoke.sh` skipped (needs a container). Assertion count 1226 → 1255 on the five suites this change touches; the two that disappear are provably unreachable after inlining.

ADR 0016 records the three rules, the accepted `run_onchange_` re-run cost, and that the first-run prune stays a no-op — ADR 0014 fixes that ordering deliberately and this change does not disturb it.

Net: +2228 / −312 across 19 files, of which −312 is duplicated wrapper code and dead loaders.

## Follow-ups

Deliberately out of scope, each worth its own issue:

- `executable_terrapod:29-31` guards `homebrew-prefix.sh` with the same one-shot pattern. Same defect, no observed symptom — `tpod` reaches its Homebrew paths only after the first apply has deployed the file.
- `executable_jetendard-font`'s `install()` could gain an installed-state short-circuit, which would remove the strongest objection to inlining in `run_onchange_after_65`.
- Revisiting ADR 0014's prune-before-delegation ordering would make the first-run prune work, but on unrelated grounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J7AYYCkwKt1Jdc4jk9BMx2
