### PR TITLE
Install Claude Code through its vendor installer

### DIFF
--- a/.chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl
+++ b/.chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl
@@ -15,19 +15,33 @@ clear_install_warning "$AI_CLI_WARNING_CATEGORY"
 exit 0
 {{ else }}
 ai_cli_brewfile=
+claude_code_installer=
+failed_ai_cli_tools=
+
+CLAUDE_CODE_CANONICAL_EXECUTABLE="$HOME/.local/bin/claude"
+CLAUDE_CODE_INSTALLER_URL=https://claude.ai/install.sh
 
 cleanup_ai_cli_install() {
   [ -z "$ai_cli_brewfile" ] || rm -f "$ai_cli_brewfile"
+  [ -z "$claude_code_installer" ] || rm -f "$claude_code_installer"
 }
 
 trap cleanup_ai_cli_install EXIT HUP INT TERM
 
+append_failed_ai_cli_tool() {
+  if [ -z "$failed_ai_cli_tools" ]; then
+    failed_ai_cli_tools="$1"
+  else
+    failed_ai_cli_tools="$failed_ai_cli_tools, $1"
+  fi
+}
+
 finish_ai_cli_install() {
-  if [ "$1" -ne 0 ]; then
+  if [ -n "$failed_ai_cli_tools" ]; then
     mark_install_warning \
       "$AI_CLI_WARNING_CATEGORY" \
       "Optional AI CLI tool install needs attention" \
-      "Homebrew setup or the AI CLI bundle failed. Review Homebrew output and network access, then rerun tpod apply."
+      "Failed: $failed_ai_cli_tools. Review the installer output and network access, then rerun tpod apply."
 
     if ! install_warning_recorded; then
       echo "Failed to record Optional AI CLI tool install warning." >&2
@@ -64,10 +78,31 @@ BREWFILE
   HOMEBREW_NO_AUTO_UPDATE=1 "$brew_bin" bundle --no-upgrade --file="$ai_cli_brewfile"
 }
 
+install_claude_code() {
+  # The vendor installer always downloads the latest build, so running it on an
+  # existing install would upgrade Claude Code on every apply. Terrapod restores
+  # a missing install only; Claude Code's own updater owns version freshness.
+  [ ! -x "$CLAUDE_CODE_CANONICAL_EXECUTABLE" ] || return 0
+
+  echo "Installing Claude Code..."
+  claude_code_installer="$(mktemp "${TMPDIR:-/tmp}/terrapod-claude-code-installer.XXXXXX")" || return 1
+  curl -fsSL "$CLAUDE_CODE_INSTALLER_URL" -o "$claude_code_installer" || return 1
+
+  # bash, not sh: the vendor script declares #!/bin/bash and uses [[ =~ ]],
+  # BASH_REMATCH, and $'...' quoting.
+  # </dev/null: the vendor script ends by running `claude install`, which has no
+  # unattended flag and can wait on a terminal UI. First-run apply runs in an
+  # interactive terminal, so an install that prompts would stall it.
+  bash "$claude_code_installer" </dev/null || return 1
+
+  [ -x "$CLAUDE_CODE_CANONICAL_EXECUTABLE" ]
+}
+
 # Optional AI Tool Stack Brewfile checksum: {{ includeTemplate "Brewfile.ai-cli-tools.tmpl" . | sha256sum }}
-ai_cli_install_status=0
-install_ai_cli_bundle || ai_cli_install_status=$?
-if ! finish_ai_cli_install "$ai_cli_install_status"; then
+install_ai_cli_bundle || append_failed_ai_cli_tool "Homebrew bundle"
+install_claude_code || append_failed_ai_cli_tool "Claude Code"
+
+if ! finish_ai_cli_install; then
   exit 1
 fi
 exit 0

--- a/Brewfile.ai-cli-tools.tmpl
+++ b/Brewfile.ai-cli-tools.tmpl
@@ -1,5 +1,4 @@
 {{- if and (eq .chezmoi.os "darwin") (or (default false (get . "enableAiCliTools")) (default false (get . "enableDevelopmentWorkspace"))) -}}
 cask "antigravity-cli"
-cask "claude-code"
 cask "codex"
 {{- end -}}

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,6 +32,10 @@ _Avoid_: core shell editor, mandatory editor config, default LazyVim setup
 The opt-in command-line AI tools that may be installed on selected **macOS Terminal Profile** development machines.
 _Avoid_: core shell tools, mandatory AI tools, cross-profile AI tools
 
+**Claude Code Installer**:
+The vendor-published install script at `https://claude.ai/install.sh` that owns Claude Code on the **macOS Terminal Profile**.
+_Avoid_: claude-code cask, Terrapod installer
+
 **Optional Development Workspace**:
 The opt-in full development stack bundle for machines that need rich editor configuration, AI tools, and an integrated terminal workspace together.
 _Avoid_: core terminal multiplexer config, default dev layout, mandatory workspace
@@ -179,10 +183,13 @@ _Avoid_: separate Korean introduction, independent README, self-labeled translat
 - pnpm belongs to the **Development Runtime Stack** through Node.js Corepack, not as a mise-managed tool.
 - Rich Neovim configuration belongs to the **Optional Editor Stack**, not the **Core Shell Stack**, and is opt-in for every machine profile.
 - Antigravity CLI, Claude Code, and Codex belong to the **Optional AI Tool Stack**, not the **Core Shell Stack**.
-- The **Optional AI Tool Stack** installs Homebrew casks `antigravity-cli`, `claude-code`, and `codex` on the **macOS Terminal Profile** only; Homebrew publishes those three as casks, which Linux Homebrew does not install.
+- The **Optional AI Tool Stack** installs Homebrew casks `antigravity-cli` and `codex` and installs Claude Code through the **Claude Code Installer**, on the **macOS Terminal Profile** only; Homebrew publishes those two as casks, which Linux Homebrew does not install.
 - The **Optional AI Tool Stack** is not applicable on the **VPS Shell Profile**. Terrapod Setup does not offer it there, the development **Preset** writes it disabled there, and `tpod status` and `tpod doctor` report it as not applicable rather than missing.
-- `Brewfile.ai-cli-tools.tmpl` is the canonical declaration for Optional AI Tool Stack packages and renders empty outside the **macOS Terminal Profile**.
-- The **Modern CLI Provider** installs the 20 mandatory formulae declared in `Brewfile` on both supported profiles and owns the three Optional AI Tool Stack casks on macOS when that stack is enabled.
+- `Brewfile.ai-cli-tools.tmpl` is the canonical declaration for the **Optional AI Tool Stack**'s Homebrew packages and renders empty outside the **macOS Terminal Profile**.
+- The **Modern CLI Provider** installs the 20 mandatory formulae declared in `Brewfile` on both supported profiles and owns the two Optional AI Tool Stack casks on macOS when that stack is enabled.
+- The **Claude Code Installer** is the canonical provider for Claude Code; its canonical executable is `$HOME/.local/bin/claude`.
+- `tpod apply` runs the **Claude Code Installer** only when that canonical executable is absent. Claude Code's own updater owns version freshness, occupying the same place as the no-upgrade contract for Homebrew packages.
+- Claude Code stays scoped to the **macOS Terminal Profile** even though the **Claude Code Installer** supports Linux; stack applicability is a profile decision, not a consequence of the package source.
 - The **VPS Shell Profile** installs Homebrew at `/home/linuxbrew/.linuxbrew` for every **Preset** on supported `x86_64` and `aarch64` systems.
 - The **VPS Shell Profile** supports one non-root management user with initial sudo access; it does not manage multi-user Homebrew prefix ownership.
 - The recommended **VPS Shell Profile** floor is 1 vCPU, 1 GiB RAM, and 3 GiB free disk, with 2 GiB RAM comfortable; the installer warns below 3 GiB but does not make this recommendation a hard gate.
@@ -234,7 +241,7 @@ _Avoid_: separate Korean introduction, independent README, self-labeled translat
 - Terrapod install warnings do not include a retained installer log; recovery guidance should direct users to rerun the relevant apply path for fresh command output.
 - Terrapod install warning marker path resolution, atomic write, timestamp creation, and clear behavior should be implemented through shared shell helper logic rather than duplicated independently in each installer script.
 - Source-side installer scripts and installed `tpod` commands should share the same Terrapod install warning marker contract even if the helper file placement is decided during implementation.
-- The optional AI CLI tools warning marker keeps one category for the **Optional AI Tool Stack** but includes the failed tool names in its summary or guidance fields.
+- The optional AI CLI tools warning marker keeps one category for the **Optional AI Tool Stack** across both of its package sources but includes the failed tool names in its summary or guidance fields.
 - The Homebrew desktop app warning marker keeps one category for the **macOS Desktop App Stack** but includes failed cask names and, when available, their **macOS App Group** names in its summary or guidance fields.
 - The Homebrew core warning marker includes failed formula or cask names only when they can be identified reliably; otherwise it records the core bundle failure summary and points users to the visible installer output and rerun guidance.
 - Terrapod install warning marker detail should reflect reliable observations only; bulk installers may record bulk failure summaries when failed item names cannot be identified without brittle output parsing.

--- a/README.ko.md
+++ b/README.ko.md
@@ -147,6 +147,8 @@ Apple Silicon에서는 Homebrew를 `/opt/homebrew`에 설치하고, Intel Mac에
 - mise를 통한 Bun, Node.js 24, Python 3.13, uv/uvx
 - Node.js Corepack을 통한 pnpm
 - 해당 stack이 활성화된 경우 Homebrew를 통한 Optional AI Tool Stack cask
+- 해당 stack이 활성화된 경우 vendor-published script `https://claude.ai/install.sh`인
+  Claude Code Installer를 통한 Claude Code
 
 Terrapod은 해당 Jetendard release의 모든 TTF를 설치하고 GitHub에서 제공하는 asset digest를 검증합니다. Terrapod은 managed font installer source가 변경되거나 실패한 설치를 재시도할 때만 최신 Jetendard release를 확인합니다. Ghostty, Zed buffer와 terminal, Orca terminal에서 사용하는 font-family key만 설정합니다. Jetendard 설정 적용이 보류되면 Orca를 종료한 뒤 `tpod apply`를 다시 실행합니다. Terrapod은 기존에 설치된 JetBrains Mono Nerd Font 또는 D2Coding을 제거하지 않습니다. 기존 window가 cached font를 계속 사용하면 Ghostty, Zed 또는 Orca를 다시 시작해야 할 수 있습니다.
 
@@ -202,8 +204,10 @@ Ubuntu에서는 initial apply가 VPS shell profile을 위한 setup script를 실
 
 VPS Shell Profile은 headless입니다. macOS App Group과 다른 GUI application은 optional
 macOS Desktop App Stack에만 속하며 Ubuntu에는 설치되지 않습니다. Optional AI Tool Stack도
-macOS 전용입니다. Homebrew가 Antigravity CLI, Claude Code, Codex를 cask로 배포하는데
-Linux Homebrew는 cask를 설치하지 않기 때문입니다. VPS에서는 setup이 이 stack을 묻지 않고,
+macOS 전용입니다. Homebrew가 Antigravity CLI와 Codex를 cask로 배포하고 Linux Homebrew는
+cask를 설치하지 않기 때문입니다.
+Claude Code는 package source의 결과가 아니라 profile 결정으로 macOS 전용을 유지합니다.
+VPS에서는 setup이 이 stack을 묻지 않고,
 `development` Preset도 비활성 상태로 기록하며, `tpod status`와 `tpod doctor`는 not
 applicable로 보고합니다. VPS에서 write access가 나중에 필요할 때만 GitHub
 authentication을 설정하세요.

--- a/README.ko.md
+++ b/README.ko.md
@@ -242,10 +242,11 @@ sudo apt upgrade
 CLI upgrade는 명시적인 Homebrew operation으로만 수행합니다. 모든 Homebrew-managed
 CLI를 올리려면 `brew update`와 `brew upgrade`를 사용하고, AI CLI cask만 의도한 경우
 대상을 지정합니다.
+Claude Code는 자체적으로 업데이트하며 이 명령의 대상이 아닙니다.
 
 ```sh
 brew update
-brew upgrade --cask claude-code codex antigravity-cli
+brew upgrade --cask codex antigravity-cli
 ```
 
 development runtime을 의도적으로 업데이트할 때는 mise를 직접 사용합니다.
@@ -291,7 +292,7 @@ Optional stack profile과 macOS App Group setting은 기본적으로 disabled입
 | --- | --- | --- |
 | `profile` | setup/configure가 감지 | 활성 Terrapod machine profile을 기록합니다. |
 | `enableEditorStack` | `false` | rich Neovim configuration을 관리하는 Optional Editor Stack을 활성화합니다. Plain Neovim은 어느 쪽이든 Core Shell Stack에 남아 있습니다. |
-| `enableAiCliTools` | `false` | Homebrew cask `antigravity-cli`, `claude-code`, `codex`를 통해 Antigravity CLI, Claude Code, Codex를 설치합니다. macOS Terminal Profile 전용이며 VPS Shell Profile에서는 무시됩니다. |
+| `enableAiCliTools` | `false` | Antigravity CLI, Claude Code, Codex를 설치합니다. Antigravity CLI와 Codex는 Homebrew cask `antigravity-cli`, `codex`로, Claude Code는 공식 installer로 설치합니다. macOS Terminal Profile 전용이며 VPS Shell Profile에서는 무시됩니다. |
 | `enableDevelopmentWorkspace` | `false` | Optional Editor Stack, 적용 가능한 경우의 Optional AI Tool Stack, development-specific Zellij workspace surface를 포함하는 Optional Development Workspace preset을 활성화합니다. |
 | `enableMacosAppGroupTerminalApps` | `false` | terminal-apps macOS App Group에 포함된 Ghostty를 설치합니다. |
 | `enableMacosAppGroupAutomation` | `false` | automation macOS App Group인 Hammerspoon, Karabiner-Elements, Scroll Reverser를 설치합니다. |

--- a/README.md
+++ b/README.md
@@ -255,10 +255,11 @@ sudo apt upgrade
 Intentional CLI upgrades are explicit Homebrew operations. Upgrade all
 Homebrew-managed CLIs with `brew update` and `brew upgrade`, or target only the
 AI CLI casks when that is the intended scope.
+Claude Code updates itself and is not part of that command.
 
 ```sh
 brew update
-brew upgrade --cask claude-code codex antigravity-cli
+brew upgrade --cask codex antigravity-cli
 ```
 
 Use mise directly when intentionally updating development runtimes.
@@ -313,7 +314,7 @@ Optional stack profiles and macOS App Group settings are disabled by default.
 | --- | --- | --- |
 | `profile` | Detected by setup/configure | Records the active Terrapod machine profile. |
 | `enableEditorStack` | `false` | Enables the Optional Editor Stack, which manages the rich Neovim configuration. Plain Neovim remains in the Core Shell Stack either way. |
-| `enableAiCliTools` | `false` | Installs Antigravity CLI, Claude Code, and Codex through Homebrew casks `antigravity-cli`, `claude-code`, and `codex`. macOS Terminal Profile only; ignored on the VPS Shell Profile. |
+| `enableAiCliTools` | `false` | Installs Antigravity CLI, Claude Code, and Codex: Antigravity CLI and Codex through Homebrew casks `antigravity-cli` and `codex`, and Claude Code through its official installer. macOS Terminal Profile only; ignored on the VPS Shell Profile. |
 | `enableDevelopmentWorkspace` | `false` | Enables the Optional Development Workspace preset, including the Optional Editor Stack, the Optional AI Tool Stack where it applies, and development-specific Zellij workspace surfaces. |
 | `enableMacosAppGroupTerminalApps` | `false` | Installs the terminal-apps macOS App Group: Ghostty. |
 | `enableMacosAppGroupAutomation` | `false` | Installs the automation macOS App Group: Hammerspoon, Karabiner-Elements, and Scroll Reverser. |

--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ On Apple Silicon, Homebrew installs at `/opt/homebrew`; on Intel Macs, it instal
 - Bun, Node.js 24, Python 3.13, and uv/uvx through mise
 - pnpm through Node.js Corepack
 - Optional AI Tool Stack casks through Homebrew when that stack is enabled
+- Claude Code through the Claude Code Installer, the vendor-published script at
+  `https://claude.ai/install.sh`, when that stack is enabled
 
 Terrapod installs every TTF in that Jetendard release and verifies the asset digest published by GitHub. Terrapod checks the latest Jetendard release only when its managed font installer source changes or a failed install is retried. It sets only the font-family keys used by Ghostty, Zed buffers and terminals, and Orca terminals. Quit Orca before rerunning `tpod apply` when Jetendard settings are deferred. Terrapod does not uninstall existing JetBrains Mono Nerd Font or D2Coding copies. Restart Ghostty, Zed, or Orca if an existing window still uses a cached font.
 
@@ -211,10 +213,11 @@ On Ubuntu, the initial apply runs setup scripts for the VPS shell profile:
 The VPS Shell Profile is headless: macOS App Groups and other GUI applications
 remain in the optional macOS Desktop App Stack and are never installed on Ubuntu.
 The Optional AI Tool Stack is also macOS-only, because Homebrew publishes
-Antigravity CLI, Claude Code, and Codex as casks and Homebrew on Linux does not
-install casks. Setup does not offer the stack on a VPS, the `development` Preset
-writes it disabled there, and `tpod status` and `tpod doctor` report it as not
-applicable.
+Antigravity CLI and Codex as casks and Homebrew on Linux does not install
+casks. Claude Code stays macOS-only as a profile decision rather than a
+consequence of its package source. Setup does not offer the stack on a VPS,
+the `development` Preset writes it disabled there, and `tpod status` and
+`tpod doctor` report it as not applicable.
 Only configure GitHub authentication on a VPS if write access is needed later.
 
 If the login shell could not be changed automatically, switch it after the first apply and reconnect.

--- a/docs/adr/0017-install-claude-code-through-its-vendor-installer.md
+++ b/docs/adr/0017-install-claude-code-through-its-vendor-installer.md
@@ -1,0 +1,53 @@
+# Install Claude Code through its vendor installer
+
+The **Optional AI Tool Stack** installs Claude Code through the **Claude Code
+Installer**, the vendor-published script at `https://claude.ai/install.sh`,
+instead of the `claude-code` Homebrew cask. `antigravity-cli` and `codex` remain
+Homebrew casks. The canonical Claude Code executable is `$HOME/.local/bin/claude`.
+
+The Homebrew cask lags vendor releases, and Claude Code releases often enough for
+that lag to show in daily use.
+
+This decision supersedes ADR 0008's package-source choice for Claude Code alone;
+ADR 0008 stays in force for the other two casks, and Homebrew remains the
+**Modern CLI Provider**. It also corrects ADR 0015's stated reason as it applies
+to Claude Code: the stack stays scoped to the **macOS Terminal Profile**, but for
+Claude Code that scope is now a profile decision rather than a consequence of
+Homebrew not installing casks on Linux. ADR 0010's no-upgrade contract and ADR
+0012's advisory-only migration policy remain in force.
+
+## Considered Options
+
+- Keep the cask and accept the release lag: rejected because the lag is the
+  problem being solved.
+- Move the whole stack back to vendor installers: rejected because ADR 0008's
+  single declared source still holds for `antigravity-cli` and `codex`, whose
+  release cadence does not create the same pressure.
+- Run the vendor installer on every apply: rejected because the script always
+  downloads the latest build, which would make apply an upgrade and break ADR
+  0010's `brew bundle --no-upgrade` contract.
+- Extend the stack to the **VPS Shell Profile** now that its installer supports
+  Linux: rejected because it confuses a package-source change with a profile
+  decision.
+
+## Consequences
+
+- `Brewfile.ai-cli-tools.tmpl` declares two casks; the **Optional AI Tool Stack**
+  draws from two package sources on the **macOS Terminal Profile**.
+- `.chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl` runs the vendor
+  installer only when `$HOME/.local/bin/claude` is absent. Claude Code's own
+  updater owns version freshness.
+- The Homebrew bundle step and the Claude Code step run independently; either
+  failure records the single `optional-ai-cli-tools` warning, naming the failed
+  source, and apply continues.
+- `executable-selection` gains the `claude-installer` provider. A missing install
+  reports `claude-code is not installed through the Claude Code installer`.
+- A machine that still has the `claude-code` cask keeps resolving `claude` to the
+  cask copy, because `dot_zshenv.tmpl` evaluates Homebrew's `shellenv` after
+  prepending `$HOME/.local/bin`. Terrapod reports the provenance-neutral advisory
+  and removes nothing, per ADR 0012.
+- `claude install` may edit shell startup files. `run_before_60` runs before
+  chezmoi writes the managed `.zshenv` and `.zshrc`, so those edits are
+  overwritten; nothing is lost, because the managed PATH already includes
+  `$HOME/.local/bin`.
+- Intentional cask upgrades use `brew upgrade --cask codex antigravity-cli`.

--- a/docs/superpowers/plans/2026-09-02-claude-code-vendor-installer.md
+++ b/docs/superpowers/plans/2026-09-02-claude-code-vendor-installer.md
@@ -1,0 +1,821 @@
+# Claude Code Vendor Installer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Install Claude Code through its vendor-published install script instead of the `claude-code` Homebrew cask, because the cask lags vendor releases.
+
+**Architecture:** The **Optional AI Tool Stack** gains a second package source on the **macOS Terminal Profile**. `run_before_60-install-ai-cli-tools.sh.tmpl` keeps its Homebrew bundle step and gains an independent Claude Code step that runs the vendor script only when `$HOME/.local/bin/claude` is absent, so the no-upgrade contract holds and Claude Code's own updater owns freshness. `executable-selection` gains a fourth provider, `claude-installer`, so status and doctor keep reporting every declaration through one path. The stack keeps one warning category, one status line, and its macOS-only scope.
+
+**Tech Stack:** POSIX `sh`, chezmoi templates (Go text/template), shell test scripts under `tests/` run as `sh tests/<name>.sh`.
+
+**Spec:** `docs/superpowers/specs/2026-09-02-claude-code-vendor-installer-design.md`
+
+## Global Constraints
+
+- Every shell file in this repository is POSIX `sh`. No bashisms, no `local`. The one place `bash` appears is as the *interpreter Terrapod invokes* for the downloaded vendor script — never as the interpreter of a Terrapod file.
+- Every chezmoi script under `.chezmoiscripts/` runs `set -eu`.
+- The vendor installer URL is exactly `https://claude.ai/install.sh`.
+- The canonical Claude Code executable is exactly `$HOME/.local/bin/claude`.
+- The new executable-selection provider token is exactly `claude-installer`. The package token stays `claude-code`. The provider label is exactly `the Claude Code installer`.
+- `mark_install_warning` must never return non-zero; callers run under `set -e`.
+- Install warning marker values stay single-line.
+- The warning category stays `optional-ai-cli-tools`. No task adds or removes a category.
+- The stack stays scoped to the **macOS Terminal Profile**. No task makes it applicable on the **VPS Shell Profile**.
+- Terrapod never removes an alternate installation. No task adds uninstall guidance or provenance-specific advice.
+- Run a test file with `sh tests/<name>.sh`. It prints `ok - …` per assertion and exits non-zero on the first `not ok`.
+- The full relevant suite for this plan is: `tests/chezmoiignore_test.sh` (~11s), `tests/executable_selection_test.sh`, `tests/homebrew_manifests_test.sh`, `tests/terrapod_command_test.sh`, `tests/readme_korean_test.sh`, `tests/readme_optional_stack_profiles_test.sh`.
+
+---
+
+## Task Ordering Rationale
+
+Tasks are ordered so every intermediate commit leaves a coherent machine state.
+
+Task 1 adds the vendor install step while the cask is still declared: a machine gets Claude Code from both sources, which is harmless. Task 2 points executable selection at the vendor path, which Task 1 already populates. Only then does Task 3 stop declaring the cask. Reversing this order would leave a commit where doctor looks for a cask nothing installs.
+
+---
+
+## File Structure
+
+**Created:**
+- `docs/adr/0017-install-claude-code-through-its-vendor-installer.md` — records the package-source decision for Claude Code alone.
+
+**Modified:**
+- `.chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl` — gains the Claude Code install step and per-source failure naming.
+- `dot_local/lib/terrapod/executable_executable-selection` — gains the `claude-installer` provider.
+- `Brewfile.ai-cli-tools.tmpl` — drops `cask "claude-code"`.
+- `CONTEXT.md` — glossary entry plus four changed and three new rules.
+- `README.md`, `README.ko.md` — upgrade command, one sentence about self-updating, `enableAiCliTools` row.
+
+**Test files modified:**
+- `tests/chezmoiignore_test.sh` — vendor installer stubs and coverage; cask assertions removed in Task 3.
+- `tests/executable_selection_test.sh` — `claude-installer` provider coverage.
+- `tests/homebrew_manifests_test.sh` — expected cask list.
+- `tests/terrapod_command_test.sh` — stubbed executable-selection strings.
+- `tests/readme_korean_test.sh`, `tests/readme_optional_stack_profiles_test.sh` — expected README strings.
+
+---
+
+### Task 1: Install Claude Code through the vendor installer
+
+**Files:**
+- Modify: `.chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl`
+- Test: `tests/chezmoiignore_test.sh:1925-2148`
+
+**Interfaces:**
+- Consumes: `mark_install_warning`, `install_warning_recorded`, `clear_install_warning` from `dot_local/lib/terrapod/install-warning-script.sh`; `terrapod_standard_homebrew_brew_path` from `homebrew-prefix.sh`. All already inlined by this template.
+- Produces: a machine-side guarantee that `$HOME/.local/bin/claude` exists after a successful apply on the **macOS Terminal Profile**. Task 2 depends on that path.
+
+The vendor script is fetched at apply time, so tests must never reach the network. The stubs added in Step 1 sit in the stub directory the harness already puts first on `PATH`, which insulates every existing case in this file as well as the new ones.
+
+- [ ] **Step 1: Add vendor installer stubs to the test harness**
+
+In `tests/chezmoiignore_test.sh`, add this helper immediately after the closing `}` of `write_ai_brew_stub` (currently ends near line 2013):
+
+```sh
+write_claude_installer_stubs() {
+  stub_dir="$1"
+  write_stub "$stub_dir/curl" \
+    'log="${CLAUDE_INSTALLER_LOG:-/dev/null}"' \
+    'printf "%s\n" "curl args:$*" >>"$log"' \
+    'output=' \
+    'while [ "$#" -gt 0 ]; do' \
+    '  if [ "$1" = "-o" ]; then output="$2"; shift 2; else shift; fi' \
+    'done' \
+    '[ -n "$output" ] || exit 2' \
+    'printf "%s\n" "#!/bin/bash" "exit 0" >"$output"'
+  write_stub "$stub_dir/bash" \
+    'log="${CLAUDE_INSTALLER_LOG:-/dev/null}"' \
+    'printf "%s\n" "bash args:$*" >>"$log"' \
+    '[ "${CLAUDE_INSTALLER_FAIL:-0}" = "0" ] || exit 3' \
+    'mkdir -p "$HOME/.local/bin"' \
+    'printf "%s\n" "#!/bin/sh" "exit 0" >"$HOME/.local/bin/claude"' \
+    'chmod +x "$HOME/.local/bin/claude"'
+}
+```
+
+Then, immediately after the existing two `write_ai_brew_stub` calls and the `uname` stub (currently lines 2016-2019, ending with `write_stub "$macos_ai_brew_bin/uname" ...`), add:
+
+```sh
+write_claude_installer_stubs "$macos_ai_brew_bin"
+```
+
+Only `$macos_ai_brew_bin` needs stubs: every macOS case runs with `PATH="$macos_ai_brew_bin:/usr/bin:/bin"`, and the Ubuntu rendering has no Claude Code step.
+
+- [ ] **Step 2: Write the failing tests**
+
+In `tests/chezmoiignore_test.sh`, replace the existing vendor-URL loop (currently lines 2065-2072) with this, which keeps the two casks' URLs banned and asserts the Claude Code URL renders on macOS only:
+
+```sh
+for vendor_url in \
+  "https://antigravity.google/cli/install.sh" \
+  "https://chatgpt.com/codex/install.sh"
+do
+  assert_not_contains_text "$ai_cli_tools_installer" "$vendor_url" "Optional AI Tool Stack no longer renders vendor installer URL: $vendor_url"
+  assert_not_contains_text "$macos_ai_cli_tools_installer" "$vendor_url" "macOS Optional AI Tool Stack no longer renders vendor installer URL: $vendor_url"
+done
+
+assert_contains_text "$macos_ai_cli_tools_installer" "https://claude.ai/install.sh" \
+  "macOS Optional AI Tool Stack renders the Claude Code installer URL"
+assert_not_contains_text "$ai_cli_tools_installer" "https://claude.ai/install.sh" \
+  "Ubuntu Optional AI Tool Stack renders no Claude Code installer URL"
+assert_contains_text "$macos_ai_cli_tools_installer" 'bash "$claude_code_installer" </dev/null' \
+  "Claude Code installer runs under bash with stdin detached"
+```
+
+Then append the behavioral cases at the end of the AI section, immediately after the `pass "successful Optional AI Tool Stack retry clears warning marker"` line (currently line 2148):
+
+```sh
+claude_fresh_home="$tmp_dir/claude-fresh-home"
+claude_fresh_state="$tmp_dir/claude-fresh-state"
+claude_fresh_brew_log="$tmp_dir/claude-fresh-brew.log"
+claude_fresh_installer_log="$tmp_dir/claude-fresh-installer.log"
+mkdir -p "$claude_fresh_home"
+HOME="$claude_fresh_home" XDG_STATE_HOME="$claude_fresh_state" \
+  AI_UNAME_ARCH=arm64 AI_BREW_BIN="$macos_ai_brew_bin" AI_BREW_LOG="$claude_fresh_brew_log" AI_BREW_FAIL=0 \
+  CLAUDE_INSTALLER_LOG="$claude_fresh_installer_log" \
+  PATH="$macos_ai_brew_bin:/usr/bin:/bin" sh "$macos_ai_cli_tools_installer_script"
+assert_contains_text "$(cat "$claude_fresh_installer_log")" "curl args:" \
+  "Optional AI Tool Stack downloads the Claude Code installer when Claude Code is absent"
+assert_contains_text "$(cat "$claude_fresh_installer_log")" "bash args:" \
+  "Optional AI Tool Stack runs the Claude Code installer when Claude Code is absent"
+if [ ! -x "$claude_fresh_home/.local/bin/claude" ]; then
+  fail "Optional AI Tool Stack installs the canonical Claude Code executable"
+fi
+pass "Optional AI Tool Stack installs the canonical Claude Code executable"
+if [ -e "$claude_fresh_state/terrapod/install-warnings/optional-ai-cli-tools" ]; then
+  fail "a successful Optional AI Tool Stack apply records no warning"
+fi
+pass "a successful Optional AI Tool Stack apply records no warning"
+
+claude_present_home="$tmp_dir/claude-present-home"
+claude_present_state="$tmp_dir/claude-present-state"
+claude_present_brew_log="$tmp_dir/claude-present-brew.log"
+claude_present_installer_log="$tmp_dir/claude-present-installer.log"
+mkdir -p "$claude_present_home/.local/bin"
+write_stub "$claude_present_home/.local/bin/claude" 'exit 0'
+HOME="$claude_present_home" XDG_STATE_HOME="$claude_present_state" \
+  AI_UNAME_ARCH=arm64 AI_BREW_BIN="$macos_ai_brew_bin" AI_BREW_LOG="$claude_present_brew_log" AI_BREW_FAIL=0 \
+  CLAUDE_INSTALLER_LOG="$claude_present_installer_log" \
+  PATH="$macos_ai_brew_bin:/usr/bin:/bin" sh "$macos_ai_cli_tools_installer_script"
+if [ -e "$claude_present_installer_log" ]; then
+  fail "an existing Claude Code install should not rerun the vendor installer"
+fi
+pass "an existing Claude Code install does not rerun the vendor installer"
+
+claude_failure_home="$tmp_dir/claude-failure-home"
+claude_failure_state="$tmp_dir/claude-failure-state"
+claude_failure_brew_log="$tmp_dir/claude-failure-brew.log"
+mkdir -p "$claude_failure_home"
+claude_failure_status=0
+HOME="$claude_failure_home" XDG_STATE_HOME="$claude_failure_state" \
+  AI_UNAME_ARCH=arm64 AI_BREW_BIN="$macos_ai_brew_bin" AI_BREW_LOG="$claude_failure_brew_log" AI_BREW_FAIL=0 \
+  CLAUDE_INSTALLER_FAIL=1 \
+  PATH="$macos_ai_brew_bin:/usr/bin:/bin" sh "$macos_ai_cli_tools_installer_script" >/dev/null 2>&1 ||
+  claude_failure_status=$?
+if [ "$claude_failure_status" -ne 0 ]; then
+  fail "a Claude Code install failure should continue apply after recording a warning"
+fi
+claude_failure_marker="$claude_failure_state/terrapod/install-warnings/optional-ai-cli-tools"
+if [ ! -f "$claude_failure_marker" ]; then
+  fail "a Claude Code install failure records the optional-ai-cli-tools marker"
+fi
+assert_contains_text "$(cat "$claude_failure_marker")" "Claude Code" \
+  "a Claude Code install failure names Claude Code in its marker"
+pass "a Claude Code install failure records a warning and exits zero"
+
+claude_bundle_failure_home="$tmp_dir/claude-bundle-failure-home"
+claude_bundle_failure_state="$tmp_dir/claude-bundle-failure-state"
+claude_bundle_failure_brew_log="$tmp_dir/claude-bundle-failure-brew.log"
+claude_bundle_failure_installer_log="$tmp_dir/claude-bundle-failure-installer.log"
+mkdir -p "$claude_bundle_failure_home"
+claude_bundle_failure_status=0
+HOME="$claude_bundle_failure_home" XDG_STATE_HOME="$claude_bundle_failure_state" \
+  AI_UNAME_ARCH=arm64 AI_BREW_BIN="$macos_ai_brew_bin" AI_BREW_LOG="$claude_bundle_failure_brew_log" AI_BREW_FAIL=1 \
+  CLAUDE_INSTALLER_LOG="$claude_bundle_failure_installer_log" \
+  PATH="$macos_ai_brew_bin:/usr/bin:/bin" sh "$macos_ai_cli_tools_installer_script" >/dev/null 2>&1 ||
+  claude_bundle_failure_status=$?
+if [ "$claude_bundle_failure_status" -ne 0 ]; then
+  fail "a Homebrew bundle failure should continue apply after recording a warning"
+fi
+assert_contains_text "$(cat "$claude_bundle_failure_installer_log")" "bash args:" \
+  "a Homebrew bundle failure does not skip the Claude Code step"
+claude_bundle_failure_marker="$claude_bundle_failure_state/terrapod/install-warnings/optional-ai-cli-tools"
+assert_contains_text "$(cat "$claude_bundle_failure_marker")" "Homebrew bundle" \
+  "a Homebrew bundle failure names the bundle in its marker"
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `sh tests/chezmoiignore_test.sh`
+Expected: FAIL at `not ok - macOS Optional AI Tool Stack renders the Claude Code installer URL`, because the template has no Claude Code step yet.
+
+- [ ] **Step 4: Add the Claude Code step to the installer template**
+
+In `.chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl`, inside the `{{ else }}` branch, replace everything from `ai_cli_brewfile=` down to the final `exit 0` with:
+
+```sh
+ai_cli_brewfile=
+claude_code_installer=
+failed_ai_cli_tools=
+
+CLAUDE_CODE_CANONICAL_EXECUTABLE="$HOME/.local/bin/claude"
+CLAUDE_CODE_INSTALLER_URL=https://claude.ai/install.sh
+
+cleanup_ai_cli_install() {
+  [ -z "$ai_cli_brewfile" ] || rm -f "$ai_cli_brewfile"
+  [ -z "$claude_code_installer" ] || rm -f "$claude_code_installer"
+}
+
+trap cleanup_ai_cli_install EXIT HUP INT TERM
+
+append_failed_ai_cli_tool() {
+  if [ -z "$failed_ai_cli_tools" ]; then
+    failed_ai_cli_tools="$1"
+  else
+    failed_ai_cli_tools="$failed_ai_cli_tools, $1"
+  fi
+}
+
+finish_ai_cli_install() {
+  if [ -n "$failed_ai_cli_tools" ]; then
+    mark_install_warning \
+      "$AI_CLI_WARNING_CATEGORY" \
+      "Optional AI CLI tool install needs attention" \
+      "Failed: $failed_ai_cli_tools. Review the installer output and network access, then rerun tpod apply."
+
+    if ! install_warning_recorded; then
+      echo "Failed to record Optional AI CLI tool install warning." >&2
+      return 1
+    fi
+
+    return 0
+  fi
+
+  clear_install_warning "$AI_CLI_WARNING_CATEGORY"
+}
+
+standard_brew_path() {
+  terrapod_standard_homebrew_brew_path "{{ .chezmoi.os }}"
+}
+
+setup_brew_environment() {
+  brew_bin="$(standard_brew_path || true)"
+  if [ -z "$brew_bin" ] || [ ! -x "$brew_bin" ]; then
+    echo "Mandatory standard-prefix Homebrew is unavailable for the Optional AI Tool Stack." >&2
+    return 1
+  fi
+  brew_shellenv="$("$brew_bin" shellenv)" || return 1
+  eval "$brew_shellenv"
+}
+
+install_ai_cli_bundle() {
+  setup_brew_environment || return 1
+  ai_cli_brewfile="$(mktemp "${TMPDIR:-/tmp}/terrapod-ai-cli-brewfile.XXXXXX")" || return 1
+  cat >"$ai_cli_brewfile" <<'BREWFILE'
+{{ includeTemplate "Brewfile.ai-cli-tools.tmpl" . }}
+BREWFILE
+
+  HOMEBREW_NO_AUTO_UPDATE=1 "$brew_bin" bundle --no-upgrade --file="$ai_cli_brewfile"
+}
+
+install_claude_code() {
+  # The vendor installer always downloads the latest build, so running it on an
+  # existing install would upgrade Claude Code on every apply. Terrapod restores
+  # a missing install only; Claude Code's own updater owns version freshness.
+  [ ! -x "$CLAUDE_CODE_CANONICAL_EXECUTABLE" ] || return 0
+
+  echo "Installing Claude Code..."
+  claude_code_installer="$(mktemp "${TMPDIR:-/tmp}/terrapod-claude-code-installer.XXXXXX")" || return 1
+  curl -fsSL "$CLAUDE_CODE_INSTALLER_URL" -o "$claude_code_installer" || return 1
+
+  # bash, not sh: the vendor script declares #!/bin/bash and uses [[ =~ ]],
+  # BASH_REMATCH, and $'...' quoting.
+  # </dev/null: the vendor script ends by running `claude install`, which has no
+  # unattended flag and can wait on a terminal UI. First-run apply runs in an
+  # interactive terminal, so an install that prompts would stall it.
+  bash "$claude_code_installer" </dev/null || return 1
+
+  [ -x "$CLAUDE_CODE_CANONICAL_EXECUTABLE" ]
+}
+
+# Optional AI Tool Stack Brewfile checksum: {{ includeTemplate "Brewfile.ai-cli-tools.tmpl" . | sha256sum }}
+install_ai_cli_bundle || append_failed_ai_cli_tool "Homebrew bundle"
+install_claude_code || append_failed_ai_cli_tool "Claude Code"
+
+if ! finish_ai_cli_install; then
+  exit 1
+fi
+exit 0
+```
+
+The two steps are separate `||` statements, so neither short-circuits the other under `set -e`. `finish_ai_cli_install` now takes no argument and decides from `$failed_ai_cli_tools`, which is what lets one marker name both sources.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `sh tests/chezmoiignore_test.sh`
+Expected: PASS, including `ok - a Claude Code install failure names Claude Code in its marker` and every pre-existing AI assertion.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl tests/chezmoiignore_test.sh
+git commit -m "Install Claude Code through its vendor installer"
+```
+
+---
+
+### Task 2: Report Claude Code through a vendor installer provider
+
+**Files:**
+- Modify: `dot_local/lib/terrapod/executable_executable-selection:74-80` (`optional_records`), `:117-137` (`provider_has_package`), `:139-145` (`provider_label`), `:147-161` (`expected_executable`)
+- Test: `tests/executable_selection_test.sh`, `tests/terrapod_command_test.sh`
+
+**Interfaces:**
+- Consumes: `$HOME/.local/bin/claude`, the canonical executable Task 1 installs.
+- Produces: the record `claude-installer|claude-code|claude` and the failure text `claude-code is not installed through the Claude Code installer`. Task 4's CONTEXT.md rules and Task 5's README row describe this provider.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/executable_selection_test.sh`, add this assertion immediately after the existing `assert_contains "$ai_enabled_output" "failure - antigravity-cli is not installed through Homebrew Cask"` block (currently ends line 227):
+
+```sh
+assert_contains "$ai_enabled_output" "failure - claude-code is not installed through the Claude Code installer" \
+  "enabled Optional AI Tool Stack checks Claude Code against its vendor installer"
+```
+
+Then append a focused block for the canonical and advisory outcomes at the end of that same AI section, immediately before the `status_output="$(run_selection status)"` line (currently line 229):
+
+```sh
+claude_home="$tmp_dir/claude-home"
+claude_path_dir="$tmp_dir/claude-path"
+mkdir -p "$claude_path_dir"
+printf '%s\n' claude-code >"$inventory/claude-installer"
+write_executable "$claude_home/.local/bin/claude"
+ln -s "$claude_home/.local/bin/claude" "$claude_path_dir/claude"
+
+run_claude_selection() {
+  HOME="$claude_home" \
+    TERRAPOD_EXECUTABLE_SELECTION_INVENTORY_DIR="$inventory" \
+    TERRAPOD_STANDARD_HOMEBREW_PREFIX="$prefix" \
+    TERRAPOD_MISE_SHIMS_DIR="$mise_shims" \
+    PATH="$claude_path_dir:/usr/bin:/bin" \
+    "$selection" doctor macos-terminal true false 2>&1 || true
+}
+
+claude_canonical_output="$(run_claude_selection)"
+assert_not_contains "$claude_canonical_output" "claude-code" \
+  "a canonical Claude Code install raises no executable selection concern"
+
+claude_shadow_dir="$tmp_dir/claude-shadow"
+mkdir -p "$claude_shadow_dir"
+write_executable "$claude_shadow_dir/claude"
+rm -f "$claude_path_dir/claude"
+ln -s "$claude_shadow_dir/claude" "$claude_path_dir/claude"
+claude_shadow_output="$(run_claude_selection)"
+assert_contains "$claude_shadow_output" "advisory - claude-code resolves to $claude_shadow_dir/claude" \
+  "a shadowed Claude Code install is advisory"
+assert_contains "$claude_shadow_output" "canonical: $claude_home/.local/bin/claude" \
+  "the Claude Code advisory names the vendor installer path"
+
+rm -f "$inventory/claude-installer"
+claude_missing_output="$(run_claude_selection)"
+assert_contains "$claude_missing_output" "failure - claude-code is not installed through the Claude Code installer" \
+  "an absent Claude Code install names the vendor installer"
+```
+
+The `assert_not_contains ... "claude-code"` check works because the other declarations in this run raise their own concerns naming their own packages; only a Claude Code concern would print the token `claude-code`.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `sh tests/executable_selection_test.sh`
+Expected: FAIL at `not ok - enabled Optional AI Tool Stack checks Claude Code against its vendor installer (missing: failure - claude-code is not installed through the Claude Code installer)`, because the record still says `homebrew-cask`.
+
+- [ ] **Step 3: Add the provider**
+
+In `dot_local/lib/terrapod/executable_executable-selection`, change the Claude Code line in `optional_records`:
+
+```sh
+optional_records() {
+  if [ "$ai_enabled" = true ]; then
+    printf '%s\n' \
+      "homebrew-cask|antigravity-cli|agy" \
+      "claude-installer|claude-code|claude" \
+      "homebrew-cask|codex|codex"
+  fi
+
+  if [ "$profile" = macos-terminal ] && [ "$launcher_enabled" = true ]; then
+    printf '%s\n' "homebrew-cask|1password-cli|op"
+  fi
+}
+```
+
+Add a branch to `provider_has_package`, between the `homebrew-cask)` and `mise)` branches:
+
+```sh
+    claude-installer)
+      [ -x "$HOME/.local/bin/claude" ]
+      ;;
+```
+
+Add a branch to `provider_label`:
+
+```sh
+    claude-installer) printf '%s\n' "the Claude Code installer" ;;
+```
+
+Add a branch to `expected_executable`:
+
+```sh
+    claude-installer)
+      printf '%s/.local/bin/%s\n' "$HOME" "$command"
+      ;;
+```
+
+No new environment seam: this path derives from `$HOME` alone, and the tests already override `HOME`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `sh tests/executable_selection_test.sh`
+Expected: PASS, including `ok - the Claude Code advisory names the vendor installer path`.
+
+- [ ] **Step 5: Update the stubbed strings in the command tests**
+
+`tests/terrapod_command_test.sh` feeds executable-selection output to `tpod` as opaque strings, so these do not fail — but they would leave the suite describing Claude Code as a Homebrew cask. Make three edits.
+
+At line 2360-2367, change the canonical path in the stub and the assertion label:
+
+```sh
+    TERRAPOD_EXECUTABLE_SELECTION_OUTPUT="  advisory - claude-code resolves to $status_shadow_legacy/claude
+             canonical: $tmp_dir/status-shadow-canonical/.local/bin/claude
+             Adjust PATH or remove the other installation manually, then rerun 'tpod doctor'." \
+```
+
+```sh
+assert_contains "$status_shadow_output" "advisory - claude-code resolves to $status_shadow_legacy/claude" "Terrapod status reports a legacy Claude shadowing the Claude Code installer"
+```
+
+At line 2480-2490, make the same two changes:
+
+```sh
+    TERRAPOD_EXECUTABLE_SELECTION_OUTPUT="  advisory - claude-code resolves to $doctor_ai_shadow_legacy/claude
+             canonical: $tmp_dir/doctor-ai-shadow-canonical/.local/bin/claude
+             Adjust PATH or remove the other installation manually, then rerun 'tpod doctor'." \
+```
+
+```sh
+assert_contains "$doctor_shadow_output" "advisory - claude-code resolves to $doctor_ai_shadow_legacy/claude" "Terrapod doctor reports a legacy Claude shadowing the Claude Code installer"
+```
+
+At line 2602, change the stubbed failure line:
+
+```sh
+if TERRAPOD_EXECUTABLE_SELECTION_OUTPUT="  failure - antigravity-cli is not installed through Homebrew Cask
+  failure - claude-code is not installed through the Claude Code installer
+  failure - codex is not installed through Homebrew Cask" \
+```
+
+- [ ] **Step 6: Run the command tests to verify they pass**
+
+Run: `sh tests/terrapod_command_test.sh`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add dot_local/lib/terrapod/executable_executable-selection tests/executable_selection_test.sh tests/terrapod_command_test.sh
+git commit -m "Check Claude Code against its vendor installer"
+```
+
+---
+
+### Task 3: Stop declaring the Claude Code cask
+
+**Files:**
+- Modify: `Brewfile.ai-cli-tools.tmpl`
+- Test: `tests/homebrew_manifests_test.sh:53-60`, `tests/chezmoiignore_test.sh:1939`, `:1945-1949`, `:2008`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: a two-cask manifest. Nothing later depends on it.
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/homebrew_manifests_test.sh`, remove `cask "claude-code"` from the expected list (currently lines 56-59):
+
+```sh
+printf '%s\n' \
+  'cask "antigravity-cli"' \
+  'cask "codex"' >"$expected_ai_casks"
+```
+
+In the same file, change the two messages that wrap this comparison from
+`exactly the three macOS casks` to `exactly the two macOS casks` — the `fail`
+call inside the `if ! cmp -s` block and the `pass` call after it.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `sh tests/homebrew_manifests_test.sh`
+Expected: FAIL at `not ok - Optional AI Tool Stack declares exactly the three macOS casks`, with a diff showing the extra `cask "claude-code"` line.
+
+- [ ] **Step 3: Remove the cask from the manifest**
+
+`Brewfile.ai-cli-tools.tmpl` becomes:
+
+```
+{{- if and (eq .chezmoi.os "darwin") (or (default false (get . "enableAiCliTools")) (default false (get . "enableDevelopmentWorkspace"))) -}}
+cask "antigravity-cli"
+cask "codex"
+{{- end -}}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `sh tests/homebrew_manifests_test.sh`
+Expected: PASS, printing `ok - Optional AI Tool Stack declares exactly the two macOS casks`.
+
+- [ ] **Step 5: Update the remaining cask assertions**
+
+In `tests/chezmoiignore_test.sh`, line 1939 names a cask that no longer exists anywhere. Point it at a cask that still does:
+
+```sh
+assert_not_contains_text "$ai_cli_tools_installer" 'cask "codex"' "Ubuntu AI installer renders no macOS-only casks"
+```
+
+In the `for rendered_brewfile` loop (currently lines 1945-1949), delete the Claude Code line so the loop reads:
+
+```sh
+for rendered_brewfile in "$macos_ai_cli_tools_brewfile" "$macos_development_workspace_ai_brewfile"; do
+  assert_contains_text "$rendered_brewfile" 'cask "antigravity-cli"' "Optional AI Tool Stack declares Antigravity CLI cask"
+  assert_contains_text "$rendered_brewfile" 'cask "codex"' "Optional AI Tool Stack declares Codex CLI cask"
+  assert_not_contains_text "$rendered_brewfile" 'cask "claude-code"' "Optional AI Tool Stack no longer declares a Claude Code cask"
+done
+```
+
+In `write_ai_brew_stub` (currently line 2008), delete the line `'  grep -Fx "cask \"claude-code\"" "$bundle_file" >/dev/null || exit 66' \` so the stub checks only the two remaining casks.
+
+- [ ] **Step 6: Run both suites to verify they pass**
+
+Run: `sh tests/homebrew_manifests_test.sh && sh tests/chezmoiignore_test.sh`
+Expected: PASS for both.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Brewfile.ai-cli-tools.tmpl tests/homebrew_manifests_test.sh tests/chezmoiignore_test.sh
+git commit -m "Drop the Claude Code cask from the AI CLI manifest"
+```
+
+---
+
+### Task 4: Record the decision in the domain context and an ADR
+
+**Files:**
+- Create: `docs/adr/0017-install-claude-code-through-its-vendor-installer.md`
+- Modify: `CONTEXT.md:31-33` (glossary neighborhood), `:182`, `:184`, `:185`, `:237`
+
+**Interfaces:**
+- Consumes: the provider token and canonical path fixed by Task 2.
+- Produces: the **Claude Code Installer** domain term that Task 5's README wording follows.
+
+There is no test for documentation prose here; the check is that the text matches the code the previous tasks landed.
+
+- [ ] **Step 1: Add the glossary entry**
+
+In `CONTEXT.md`, insert this entry immediately after the **Optional AI Tool Stack** entry (currently ends line 33), keeping the existing bold-term and `_Avoid_` format:
+
+```markdown
+**Claude Code Installer**:
+The vendor-published install script at `https://claude.ai/install.sh` that owns Claude Code on the **macOS Terminal Profile**.
+_Avoid_: claude-code cask, Terrapod installer
+```
+
+The `Terrapod installer` avoidance matters: this repository's own bootstrap script is also named `install.sh`.
+
+- [ ] **Step 2: Change the four existing rules**
+
+Line 182 becomes:
+
+```markdown
+- The **Optional AI Tool Stack** installs Homebrew casks `antigravity-cli` and `codex` and installs Claude Code through the **Claude Code Installer**, on the **macOS Terminal Profile** only; Homebrew publishes those two as casks, which Linux Homebrew does not install.
+```
+
+Line 184 becomes:
+
+```markdown
+- `Brewfile.ai-cli-tools.tmpl` is the canonical declaration for the **Optional AI Tool Stack**'s Homebrew packages and renders empty outside the **macOS Terminal Profile**.
+```
+
+Line 185 becomes:
+
+```markdown
+- The **Modern CLI Provider** installs the 20 mandatory formulae declared in `Brewfile` on both supported profiles and owns the two Optional AI Tool Stack casks on macOS when that stack is enabled.
+```
+
+Line 237 becomes:
+
+```markdown
+- The optional AI CLI tools warning marker keeps one category for the **Optional AI Tool Stack** across both of its package sources but includes the failed tool names in its summary or guidance fields.
+```
+
+- [ ] **Step 3: Add the three new rules**
+
+Insert these immediately after the amended line 185:
+
+```markdown
+- The **Claude Code Installer** is the canonical provider for Claude Code; its canonical executable is `$HOME/.local/bin/claude`.
+- `tpod apply` runs the **Claude Code Installer** only when that canonical executable is absent. Claude Code's own updater owns version freshness, occupying the same place as the no-upgrade contract for Homebrew packages.
+- Claude Code stays scoped to the **macOS Terminal Profile** even though the **Claude Code Installer** supports Linux; stack applicability is a profile decision, not a consequence of the package source.
+```
+
+- [ ] **Step 4: Write ADR 0017**
+
+Create `docs/adr/0017-install-claude-code-through-its-vendor-installer.md` following the existing ADR format — a title, a decision statement, a supersession paragraph, `## Considered Options`, and `## Consequences`:
+
+```markdown
+# Install Claude Code through its vendor installer
+
+The **Optional AI Tool Stack** installs Claude Code through the **Claude Code
+Installer**, the vendor-published script at `https://claude.ai/install.sh`,
+instead of the `claude-code` Homebrew cask. `antigravity-cli` and `codex` remain
+Homebrew casks. The canonical Claude Code executable is `$HOME/.local/bin/claude`.
+
+The Homebrew cask lags vendor releases, and Claude Code releases often enough for
+that lag to show in daily use.
+
+This decision supersedes ADR 0008's package-source choice for Claude Code alone;
+ADR 0008 stays in force for the other two casks, and Homebrew remains the
+**Modern CLI Provider**. It also corrects ADR 0015's stated reason as it applies
+to Claude Code: the stack stays scoped to the **macOS Terminal Profile**, but for
+Claude Code that scope is now a profile decision rather than a consequence of
+Homebrew not installing casks on Linux. ADR 0010's no-upgrade contract and ADR
+0012's advisory-only migration policy remain in force.
+
+## Considered Options
+
+- Keep the cask and accept the release lag: rejected because the lag is the
+  problem being solved.
+- Move the whole stack back to vendor installers: rejected because ADR 0008's
+  single declared source still holds for `antigravity-cli` and `codex`, whose
+  release cadence does not create the same pressure.
+- Run the vendor installer on every apply: rejected because the script always
+  downloads the latest build, which would make apply an upgrade and break ADR
+  0010's `brew bundle --no-upgrade` contract.
+- Extend the stack to the **VPS Shell Profile** now that its installer supports
+  Linux: rejected because it confuses a package-source change with a profile
+  decision.
+
+## Consequences
+
+- `Brewfile.ai-cli-tools.tmpl` declares two casks; the **Optional AI Tool Stack**
+  draws from two package sources on the **macOS Terminal Profile**.
+- `.chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl` runs the vendor
+  installer only when `$HOME/.local/bin/claude` is absent. Claude Code's own
+  updater owns version freshness.
+- The Homebrew bundle step and the Claude Code step run independently; either
+  failure records the single `optional-ai-cli-tools` warning, naming the failed
+  source, and apply continues.
+- `executable-selection` gains the `claude-installer` provider. A missing install
+  reports `claude-code is not installed through the Claude Code installer`.
+- A machine that still has the `claude-code` cask keeps resolving `claude` to the
+  cask copy, because `dot_zshenv.tmpl` evaluates Homebrew's `shellenv` after
+  prepending `$HOME/.local/bin`. Terrapod reports the provenance-neutral advisory
+  and removes nothing, per ADR 0012.
+- `claude install` may edit shell startup files. `run_before_60` runs before
+  chezmoi writes the managed `.zshenv` and `.zshrc`, so those edits are
+  overwritten; nothing is lost, because the managed PATH already includes
+  `$HOME/.local/bin`.
+- Intentional cask upgrades use `brew upgrade --cask codex antigravity-cli`.
+```
+
+- [ ] **Step 5: Verify no test regressed**
+
+Run: `sh tests/terrapod_command_test.sh && sh tests/chezmoiignore_test.sh`
+Expected: PASS. Neither suite reads `CONTEXT.md` or `docs/adr/`, so this is a guard against an accidental edit elsewhere.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add CONTEXT.md docs/adr/0017-install-claude-code-through-its-vendor-installer.md
+git commit -m "Record the Claude Code vendor installer decision"
+```
+
+---
+
+### Task 5: Update both READMEs
+
+**Files:**
+- Modify: `README.md:255-262`, `:316`; `README.ko.md:242-249`, `:294`
+- Test: `tests/readme_optional_stack_profiles_test.sh:99-102`, `:291-292`; `tests/readme_korean_test.sh:191-192`
+
+**Interfaces:**
+- Consumes: the **Claude Code Installer** term from Task 4.
+- Produces: nothing later depends on it.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/readme_optional_stack_profiles_test.sh`, replace the two Homebrew-cask expectations. At lines 99-102:
+
+```sh
+assert_key_row_contains '`enableAiCliTools`' 'Antigravity CLI, Claude Code, and Codex' \
+  "README documents the new Optional AI Tool Stack membership"
+assert_key_row_contains '`enableAiCliTools`' 'Homebrew casks `antigravity-cli` and `codex`' \
+  "README documents Homebrew-owned Optional AI Tool Stack members"
+assert_key_row_contains '`enableAiCliTools`' 'Claude Code through its official installer' \
+  "README documents the vendor-installed Optional AI Tool Stack member"
+```
+
+At line 291-292:
+
+```sh
+assert_contains 'brew upgrade --cask codex antigravity-cli' \
+  "README documents targeted AI CLI upgrades"
+assert_contains 'Claude Code updates itself and is not part of that command.' \
+  "README documents who owns Claude Code freshness"
+```
+
+In `tests/readme_korean_test.sh` at lines 191-192:
+
+```sh
+assert_contains "$korean_readme" 'brew upgrade --cask codex antigravity-cli' \
+  "README.ko.md documents targeted AI CLI upgrades"
+assert_contains "$korean_readme" 'Claude Code는 자체적으로 업데이트하며 이 명령의 대상이 아닙니다.' \
+  "README.ko.md documents who owns Claude Code freshness"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `sh tests/readme_optional_stack_profiles_test.sh`
+Expected: FAIL at `not ok - README documents Homebrew-owned Optional AI Tool Stack members`.
+
+- [ ] **Step 3: Update `README.md`**
+
+Both new sentences must stay on one physical line each: the README tests match
+literal substrings, and a wrapped sentence would never match.
+
+Replace the upgrade block (currently lines 255-262) with:
+
+````markdown
+Intentional CLI upgrades are explicit Homebrew operations. Upgrade all
+Homebrew-managed CLIs with `brew update` and `brew upgrade`, or target only the
+AI CLI casks when that is the intended scope.
+Claude Code updates itself and is not part of that command.
+
+```sh
+brew update
+brew upgrade --cask codex antigravity-cli
+```
+````
+
+Replace the `enableAiCliTools` table row (line 316) with:
+
+```markdown
+| `enableAiCliTools` | `false` | Installs Antigravity CLI, Claude Code, and Codex: Antigravity CLI and Codex through Homebrew casks `antigravity-cli` and `codex`, and Claude Code through its official installer. macOS Terminal Profile only; ignored on the VPS Shell Profile. |
+```
+
+- [ ] **Step 4: Update `README.ko.md`**
+
+Replace the upgrade block (currently lines 242-249) with:
+
+````markdown
+CLI upgrade는 명시적인 Homebrew operation으로만 수행합니다. 모든 Homebrew-managed
+CLI를 올리려면 `brew update`와 `brew upgrade`를 사용하고, AI CLI cask만 의도한 경우
+대상을 지정합니다.
+Claude Code는 자체적으로 업데이트하며 이 명령의 대상이 아닙니다.
+
+```sh
+brew update
+brew upgrade --cask codex antigravity-cli
+```
+````
+
+Replace the `enableAiCliTools` table row (line 294) with:
+
+```markdown
+| `enableAiCliTools` | `false` | Antigravity CLI, Claude Code, Codex를 설치합니다. Antigravity CLI와 Codex는 Homebrew cask `antigravity-cli`, `codex`로, Claude Code는 공식 installer로 설치합니다. macOS Terminal Profile 전용이며 VPS Shell Profile에서는 무시됩니다. |
+```
+
+- [ ] **Step 5: Run the README tests to verify they pass**
+
+Run: `sh tests/readme_optional_stack_profiles_test.sh && sh tests/readme_korean_test.sh`
+Expected: PASS for both.
+
+- [ ] **Step 6: Run the full relevant suite**
+
+Run:
+
+```bash
+for suite in chezmoiignore executable_selection homebrew_manifests terrapod_command readme_korean readme_optional_stack_profiles; do
+  printf '== %s ==\n' "$suite"
+  sh "tests/${suite}_test.sh" >/dev/null || { printf 'FAILED: %s\n' "$suite"; break; }
+done
+```
+
+Expected: every suite prints its header and none prints `FAILED`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add README.md README.ko.md tests/readme_optional_stack_profiles_test.sh tests/readme_korean_test.sh
+git commit -m "Document the Claude Code vendor installer in both READMEs"
+```

--- a/docs/superpowers/specs/2026-09-02-claude-code-vendor-installer-design.md
+++ b/docs/superpowers/specs/2026-09-02-claude-code-vendor-installer-design.md
@@ -1,0 +1,272 @@
+# Claude Code Vendor Installer Design
+
+## Goal
+
+Install Claude Code through its vendor-published install script instead of the
+`claude-code` Homebrew cask, because the cask lags vendor releases and Claude
+Code releases often enough for that lag to show in daily use.
+
+Only Claude Code moves. `antigravity-cli` and `codex` stay Homebrew casks, the
+**Optional AI Tool Stack** stays scoped to the **macOS Terminal Profile**, and
+the stack keeps one install warning category and one status and doctor report.
+
+This change is non-destructive. An existing `claude-code` cask is not
+uninstalled; executable selection reports it as an advisory the way it reports
+any other alternate installation.
+
+## Current State
+
+- `Brewfile.ai-cli-tools.tmpl` declares `antigravity-cli`, `claude-code`, and
+  `codex`, and renders empty outside the **macOS Terminal Profile**.
+- `.chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl` renders that
+  manifest into a temporary Brewfile and runs
+  `HOMEBREW_NO_AUTO_UPDATE=1 brew bundle --no-upgrade`. Failure records the
+  `optional-ai-cli-tools` install warning and lets apply continue.
+- `executable-selection` carries the record `homebrew-cask|claude-code|claude`
+  and knows three providers: `homebrew-formula`, `homebrew-cask`, and `mise`.
+- `README.md` and `README.ko.md` document
+  `brew upgrade --cask claude-code codex antigravity-cli` as the explicit
+  upgrade command and describe `enableAiCliTools` as installing three casks.
+
+ADR 0008 chose Homebrew over vendor installers for all three tools. ADR 0015
+scoped the stack to macOS because all three are casks and Homebrew on Linux
+does not install casks. ADR 0010 established the `brew bundle --no-upgrade`
+contract, and ADR 0012 established the read-only three-step check that
+`executable-selection` performs.
+
+## Considered Approaches
+
+### A Claude Code specific provider in the executable selection registry
+
+Add a fourth provider, `claude-installer`, and change the stack's Claude Code
+record to `claude-installer|claude-code|claude`. Provider presence is the
+canonical executable at `$HOME/.local/bin/claude`, and the provider label makes
+the failure text name the vendor installer rather than Homebrew Cask.
+
+This is the selected approach. Reporting stays on one path, and the change is
+confined to one record and three `case` branches.
+
+### A general vendor installer provider carrying its own path
+
+Extend the record format with a fourth field holding the install path, so other
+tools could move later. Rejected as unused generality: only Claude Code moves,
+and widening this provider later is a record-format change, not a redesign.
+
+### Check Claude Code outside the registry
+
+Leave `executable-selection` alone and special-case Claude Code in the `tpod`
+command. Rejected because it splits reporting in two and exempts one tool from
+the provider, canonical executable, and PATH precedence model that ADR 0012
+established for every other declaration.
+
+## Package Ownership
+
+The **Optional AI Tool Stack** now draws from two package sources on the
+**macOS Terminal Profile**:
+
+- The **Modern CLI Provider** owns the casks `antigravity-cli`, providing `agy`,
+  and `codex`, providing `codex`.
+- The **Claude Code Installer** owns Claude Code, providing `claude` at
+  `$HOME/.local/bin/claude`.
+
+**Claude Code Installer** is the vendor-published install script at
+`https://claude.ai/install.sh`. The glossary entry needs an explicit _Avoid_
+line for "Terrapod installer", because this repository's own bootstrap script
+is also named `install.sh`.
+
+The stack stays macOS-only. The vendor installer supports Linux, so ADR 0015's
+recorded reason no longer holds for Claude Code; applicability is a profile
+decision rather than a consequence of the package source, and ADR 0017 records
+that correction.
+
+## Installation
+
+The Claude Code step lives inside the existing
+`run_before_60-install-ai-cli-tools.sh.tmpl` rather than in a new script,
+because the `optional-ai-cli-tools` warning category is one per stack. Two
+scripts sharing a category would overwrite each other's marker.
+
+The existing template gate is unchanged: the body renders only when
+`.chezmoi.os` is `darwin` and the stack is effectively enabled. Inside that
+body, the Homebrew bundle step and the Claude Code step run independently. A
+failing bundle does not skip Claude Code, and a failing Claude Code install does
+not affect the bundle result.
+
+### Install only when the canonical executable is absent
+
+The vendor script always downloads the latest build and then runs
+`claude install`. Running it unconditionally would upgrade Claude Code on every
+apply, which contradicts the no-upgrade contract that governs every other
+declared package. The step therefore returns early when
+`$HOME/.local/bin/claude` is executable.
+
+Version freshness belongs to Claude Code's own updater. Terrapod restores a
+missing install and nothing more.
+
+### Download to a temporary file and run it with bash
+
+The step follows the download-then-run pattern already used for Oh My Zsh: fetch
+with `curl` into a `mktemp` file, run it, and remove it from the existing `trap`
+handler. Two details differ from the Oh My Zsh step.
+
+The script is run with `bash`, not `sh`, invoked by name so it resolves through
+`PATH`. The vendor script declares `#!/bin/bash` and uses `[[ =~ ]]`,
+`BASH_REMATCH`, and `$'...'` quoting. Terrapod's installer scripts are
+`#!/bin/sh`, so the interpreter must be named explicitly. macOS always provides
+`/bin/bash`, and the features used work in bash 3.2.
+
+Standard input is redirected from `/dev/null`. The vendor script ends by running
+`claude install`, which has no unattended flag and can present a terminal UI —
+the vendor script itself restores the terminal with `stty sane` after a signal
+death. First-run installation happens in an interactive terminal driving `gum`
+prompts, so an install that waits for input would stall apply. This repository
+has no existing `</dev/null` precedent, so the redirection carries a comment
+explaining why it is there.
+
+### Failure recording
+
+The stack keeps one warning category covering both sources, and marker values
+stay single-line. What the marker can name differs by source:
+
+- A `brew bundle` failure cannot identify which cask failed without parsing
+  Homebrew output, so it keeps the existing bulk failure summary.
+- A **Claude Code Installer** failure covers exactly one tool, so the marker
+  names `Claude Code`.
+- When both fail, one marker records both, joined on a single line.
+
+The category is cleared only when both steps succeed. Either failure leaves a
+marker, so a partially installed stack never reports itself as ready.
+
+Apply continues in every case, and a marker that cannot be written still fails
+loudly through the existing `install_warning_recorded` policy.
+
+### Shell profile edits
+
+`claude install` sets up shell integration and may edit shell startup files.
+`run_before_60` runs before chezmoi writes the managed `.zshenv` and `.zshrc`,
+so those edits are overwritten. This is the behavior ADR 0006 already accepted
+for vendor installers. Nothing is lost in practice: `dot_zshenv.tmpl` already
+places `$HOME/.local/bin` on the managed PATH.
+
+## Executable Selection
+
+`executable-selection` gains one provider. The changes are confined to four
+places.
+
+The stack's record becomes `claude-installer|claude-code|claude`. The package
+token stays `claude-code` — it is the domain name already used in status and
+doctor output, and it does not assert a package source.
+
+`provider_has_package` gains a `claude-installer` branch testing whether
+`$HOME/.local/bin/claude` is executable. `expected_executable` gains a
+`claude-installer` branch returning `$HOME/.local/bin/$command`. No new
+environment seam is introduced: `TERRAPOD_MISE_SHIMS_DIR` exists because mise
+has its own data directory variable, whereas this path derives from `$HOME`
+alone, and the tests already override `HOME`.
+
+`provider_label` maps `claude-installer` to `the Claude Code installer`, so a
+missing install reads `claude-code is not installed through the Claude Code
+installer`. The wording overlaps slightly, but it keeps the sentence frame
+shared with the other providers and tells the reader that `brew` will not fix
+it.
+
+ADR 0012's three outcomes are preserved:
+
+| State | Report |
+| --- | --- |
+| `$HOME/.local/bin/claude` absent | failure, naming the Claude Code installer |
+| present and selected first on PATH | canonical |
+| present but another file is primary | advisory with both paths |
+
+A machine that still has the `claude-code` cask lands in the third row.
+`dot_zshenv.tmpl` prepends `$HOME/.local/bin` before evaluating Homebrew's
+`shellenv`, so the Homebrew prefix ends up ahead of it and the cask copy stays
+primary until the user removes it. Terrapod reports the advisory and does not
+remove anything, per ADR 0012.
+
+On a real machine the `claude-installer` provider makes provider presence and
+canonical executable existence the same predicate, so the
+`canonical executable is missing` branch is unreachable — an absent install is
+always caught by the first check. User-visible behavior is correct; only one
+step is formally redundant. Under the inventory seam the two are decoupled, so
+tests can still exercise both branches.
+
+## Documentation
+
+`CONTEXT.md` adds a **Claude Code Installer** glossary entry and changes four
+rules:
+
+- The stack installs the casks `antigravity-cli` and `codex` and installs Claude
+  Code through the **Claude Code Installer**, on the **macOS Terminal Profile**
+  only.
+- `Brewfile.ai-cli-tools.tmpl` is the canonical declaration for the stack's
+  Homebrew packages, not for the whole stack.
+- The **Modern CLI Provider** owns two stack casks, not three.
+- The `optional-ai-cli-tools` warning category covers both package sources.
+
+It adds three rules:
+
+- The **Claude Code Installer** is the canonical provider for Claude Code, whose
+  canonical executable is `$HOME/.local/bin/claude`.
+- `tpod apply` runs the **Claude Code Installer** only when that executable is
+  absent; Claude Code's own updater owns version freshness, occupying the same
+  place as the no-upgrade contract for Homebrew packages.
+- Claude Code stays scoped to the **macOS Terminal Profile** even though the
+  vendor installer supports Linux.
+
+ADR 0017, `Install Claude Code through its vendor installer`, records the
+decision. It supersedes ADR 0008's package-source choice for Claude Code alone
+and leaves that choice in force for the other two casks. It corrects ADR 0015's
+stated reason for the macOS scope as it applies to Claude Code. Rejected
+options: keeping the cask and accepting the lag; moving the whole stack back to
+vendor installers, which discards ADR 0008's single-source benefit for two tools
+that do not need it; running the vendor script on every apply, which breaks
+ADR 0010's no-upgrade contract; and extending the stack to the **VPS Shell
+Profile**, which confuses a package-source change with a profile decision.
+
+`README.md` and `README.ko.md` change in three places each. The explicit upgrade
+command becomes `brew upgrade --cask codex antigravity-cli`. One sentence states
+that Claude Code's own updater keeps it current, so the upgrade section does not
+leave Claude Code unexplained. The `enableAiCliTools` row describes both
+sources.
+
+The READMEs carry no migration guidance for an existing `claude-code` cask.
+Executable selection's advisory is the mechanism for that case, and ADR 0012
+requires it to stay provenance-neutral.
+
+## Testing
+
+`homebrew_manifests_test.sh` compares the rendered AI manifest against an exact
+expected list, so removing `cask "claude-code"` there is what prevents the cask
+from reappearing.
+
+`chezmoiignore_test.sh` renders and executes the installer script against
+stubs. Its `brew` stub asserts each expected cask line in the temporary
+Brewfile, so the `claude-code` assertion and the "declares Claude Code cask"
+check are removed. Four cases are added, using `curl` and `bash` stubs placed in
+the same stub directory the harness already puts on `PATH`:
+
+- An existing `$HOME/.local/bin/claude` leaves the vendor installer unrun.
+- A missing one runs it and clears the warning on success.
+- A failing vendor installer records a marker whose text names `Claude Code`.
+- A failing `brew bundle` still attempts the Claude Code step.
+
+`executable_selection_test.sh` gains `claude-installer` coverage for the three
+outcomes above: missing install, canonical selection, and an advisory when
+another file is primary.
+
+`terrapod_command_test.sh` updates the stubbed executable-selection output
+string that reads `not installed through Homebrew Cask`, and the labels of the
+shadow advisory cases that describe Claude Code as a Homebrew cask.
+
+`readme_korean_test.sh` and `readme_optional_stack_profiles_test.sh` update
+their expected README strings.
+
+## Out of Scope
+
+- Moving `antigravity-cli` or `codex` off Homebrew.
+- Making the **Optional AI Tool Stack** applicable on the **VPS Shell Profile**.
+- Removing, detecting, or advising on an existing `claude-code` cask beyond the
+  existing provenance-neutral advisory.
+- Documenting or running an explicit Claude Code upgrade command such as
+  `claude update`. The READMEs state only that Claude Code updates itself.

--- a/dot_local/lib/terrapod/executable_executable-selection
+++ b/dot_local/lib/terrapod/executable_executable-selection
@@ -75,7 +75,7 @@ optional_records() {
   if [ "$ai_enabled" = true ]; then
     printf '%s\n' \
       "homebrew-cask|antigravity-cli|agy" \
-      "homebrew-cask|claude-code|claude" \
+      "claude-installer|claude-code|claude" \
       "homebrew-cask|codex|codex"
   fi
 
@@ -135,6 +135,9 @@ provider_has_package() {
     homebrew-cask)
       line_list_contains "$homebrew_casks" "$package"
       ;;
+    claude-installer)
+      [ -x "$HOME/.local/bin/claude" ]
+      ;;
     mise)
       command -v mise >/dev/null 2>&1 &&
         mise where "$package" >/dev/null 2>&1
@@ -149,6 +152,7 @@ provider_label() {
   case "$1" in
     homebrew-formula) printf '%s\n' Homebrew ;;
     homebrew-cask) printf '%s\n' "Homebrew Cask" ;;
+    claude-installer) printf '%s\n' "the Claude Code installer" ;;
     mise) printf '%s\n' mise ;;
   esac
 }
@@ -161,6 +165,9 @@ expected_executable() {
     homebrew-formula|homebrew-cask)
       prefix="$(standard_homebrew_prefix)" || return 1
       printf '%s/bin/%s\n' "$prefix" "$command"
+      ;;
+    claude-installer)
+      printf '%s/.local/bin/%s\n' "$HOME" "$command"
       ;;
     mise)
       mise_shims_dir="${TERRAPOD_MISE_SHIMS_DIR:-${MISE_DATA_DIR:-$HOME/.local/share/mise}/shims}"

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -2017,6 +2017,7 @@ write_claude_installer_stubs() {
   write_stub "$stub_dir/curl" \
     'log="${CLAUDE_INSTALLER_LOG:-/dev/null}"' \
     'printf "%s\n" "curl args:$*" >>"$log"' \
+    '[ "${CLAUDE_INSTALLER_CURL_FAIL:-0}" = "0" ] || exit 4' \
     'output=' \
     'while [ "$#" -gt 0 ]; do' \
     '  if [ "$1" = "-o" ]; then output="$2"; shift 2; else shift; fi' \
@@ -2027,6 +2028,10 @@ write_claude_installer_stubs() {
     'log="${CLAUDE_INSTALLER_LOG:-/dev/null}"' \
     'printf "%s\n" "bash args:$*" >>"$log"' \
     '[ "${CLAUDE_INSTALLER_FAIL:-0}" = "0" ] || exit 3' \
+    'if [ "${CLAUDE_INSTALLER_SKIP_BINARY:-0}" != "0" ]; then' \
+    '  printf "%s\n" "bash skipped binary" >>"$log"' \
+    '  exit 0' \
+    'fi' \
     'mkdir -p "$HOME/.local/bin"' \
     'printf "%s\n" "#!/bin/sh" "exit 0" >"$HOME/.local/bin/claude"' \
     'chmod +x "$HOME/.local/bin/claude"'
@@ -2230,7 +2235,86 @@ if [ ! -f "$claude_failure_marker" ]; then
 fi
 assert_contains_text "$(cat "$claude_failure_marker")" "Claude Code" \
   "a Claude Code install failure names Claude Code in its marker"
+assert_not_contains_text "$(cat "$claude_failure_marker")" "Homebrew bundle" \
+  "a Claude Code install failure does not name the Homebrew bundle in its marker"
 pass "a Claude Code install failure records a warning and exits zero"
+
+claude_skip_binary_home="$tmp_dir/claude-skip-binary-home"
+claude_skip_binary_state="$tmp_dir/claude-skip-binary-state"
+claude_skip_binary_brew_log="$tmp_dir/claude-skip-binary-brew.log"
+claude_skip_binary_installer_log="$tmp_dir/claude-skip-binary-installer.log"
+mkdir -p "$claude_skip_binary_home"
+claude_skip_binary_status=0
+HOME="$claude_skip_binary_home" XDG_STATE_HOME="$claude_skip_binary_state" \
+  AI_UNAME_ARCH=arm64 AI_BREW_BIN="$macos_ai_brew_bin" AI_BREW_LOG="$claude_skip_binary_brew_log" AI_BREW_FAIL=0 \
+  CLAUDE_INSTALLER_LOG="$claude_skip_binary_installer_log" CLAUDE_INSTALLER_SKIP_BINARY=1 \
+  PATH="$macos_ai_brew_bin:/usr/bin:/bin" sh "$macos_ai_cli_tools_installer_script" >/dev/null 2>&1 ||
+  claude_skip_binary_status=$?
+if [ "$claude_skip_binary_status" -ne 0 ]; then
+  fail "a vendor installer that exits zero without installing the canonical executable should continue apply after recording a warning"
+fi
+if [ -x "$claude_skip_binary_home/.local/bin/claude" ]; then
+  fail "the CLAUDE_INSTALLER_SKIP_BINARY stub should not create the canonical executable"
+fi
+claude_skip_binary_marker="$claude_skip_binary_state/terrapod/install-warnings/optional-ai-cli-tools"
+if [ ! -f "$claude_skip_binary_marker" ]; then
+  fail "a vendor installer that exits zero without the canonical executable records the optional-ai-cli-tools marker"
+fi
+assert_contains_text "$(cat "$claude_skip_binary_marker")" "Claude Code" \
+  "a vendor installer that exits zero without the canonical executable names Claude Code in its marker"
+pass "a vendor installer that exits zero without installing the canonical executable records a warning and exits zero"
+
+claude_curl_failure_home="$tmp_dir/claude-curl-failure-home"
+claude_curl_failure_state="$tmp_dir/claude-curl-failure-state"
+claude_curl_failure_brew_log="$tmp_dir/claude-curl-failure-brew.log"
+claude_curl_failure_installer_log="$tmp_dir/claude-curl-failure-installer.log"
+mkdir -p "$claude_curl_failure_home"
+claude_curl_failure_status=0
+HOME="$claude_curl_failure_home" XDG_STATE_HOME="$claude_curl_failure_state" \
+  AI_UNAME_ARCH=arm64 AI_BREW_BIN="$macos_ai_brew_bin" AI_BREW_LOG="$claude_curl_failure_brew_log" AI_BREW_FAIL=0 \
+  CLAUDE_INSTALLER_LOG="$claude_curl_failure_installer_log" CLAUDE_INSTALLER_CURL_FAIL=1 \
+  PATH="$macos_ai_brew_bin:/usr/bin:/bin" sh "$macos_ai_cli_tools_installer_script" >/dev/null 2>&1 ||
+  claude_curl_failure_status=$?
+if [ "$claude_curl_failure_status" -ne 0 ]; then
+  fail "a Claude Code installer download failure should continue apply after recording a warning"
+fi
+if grep -F "bash args:" "$claude_curl_failure_installer_log" >/dev/null 2>&1; then
+  fail "a Claude Code installer download failure should not run the downloaded script"
+fi
+claude_curl_failure_marker="$claude_curl_failure_state/terrapod/install-warnings/optional-ai-cli-tools"
+if [ ! -f "$claude_curl_failure_marker" ]; then
+  fail "a Claude Code installer download failure records the optional-ai-cli-tools marker"
+fi
+assert_contains_text "$(cat "$claude_curl_failure_marker")" "Claude Code" \
+  "a Claude Code installer download failure names Claude Code in its marker"
+pass "a Claude Code installer download failure records a warning and exits zero"
+
+claude_both_failure_home="$tmp_dir/claude-both-failure-home"
+claude_both_failure_state="$tmp_dir/claude-both-failure-state"
+claude_both_failure_brew_log="$tmp_dir/claude-both-failure-brew.log"
+mkdir -p "$claude_both_failure_home"
+claude_both_failure_status=0
+HOME="$claude_both_failure_home" XDG_STATE_HOME="$claude_both_failure_state" \
+  AI_UNAME_ARCH=arm64 AI_BREW_BIN="$macos_ai_brew_bin" AI_BREW_LOG="$claude_both_failure_brew_log" AI_BREW_FAIL=1 \
+  CLAUDE_INSTALLER_FAIL=1 \
+  PATH="$macos_ai_brew_bin:/usr/bin:/bin" sh "$macos_ai_cli_tools_installer_script" >/dev/null 2>&1 ||
+  claude_both_failure_status=$?
+if [ "$claude_both_failure_status" -ne 0 ]; then
+  fail "a Homebrew bundle failure together with a Claude Code install failure should continue apply after recording a warning"
+fi
+claude_both_failure_marker="$claude_both_failure_state/terrapod/install-warnings/optional-ai-cli-tools"
+if [ ! -f "$claude_both_failure_marker" ]; then
+  fail "a Homebrew bundle failure together with a Claude Code install failure records the optional-ai-cli-tools marker"
+fi
+claude_both_failure_marker_text="$(cat "$claude_both_failure_marker")"
+assert_contains_text "$claude_both_failure_marker_text" "Homebrew bundle" \
+  "a combined install failure names the Homebrew bundle in its marker"
+assert_contains_text "$claude_both_failure_marker_text" "Claude Code" \
+  "a combined install failure names Claude Code in its marker"
+if ! grep -F "Failed: Homebrew bundle, Claude Code." "$claude_both_failure_marker" >/dev/null; then
+  fail "a combined install failure names both sources on a single line"
+fi
+pass "a combined install failure records both sources on a single-line marker"
 
 claude_bundle_failure_home="$tmp_dir/claude-bundle-failure-home"
 claude_bundle_failure_state="$tmp_dir/claude-bundle-failure-state"

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -1936,7 +1936,7 @@ assert_not_contains_text "$ai_cli_tools_installer" "bootstrap_linux_homebrew" "A
 assert_not_contains_text "$ai_cli_tools_installer" "raw.githubusercontent.com/Homebrew/install" "AI installer never downloads Homebrew"
 assert_not_contains_text "$ai_cli_tools_installer" "HOMEBREW_NO_AUTO_UPDATE=1" "Ubuntu AI installer runs no Homebrew bundle"
 assert_not_contains_text "$ai_cli_tools_installer" "install_ai_cli_bundle" "Ubuntu AI installer renders no Homebrew bundle step"
-assert_not_contains_text "$ai_cli_tools_installer" 'cask "claude-code"' "Ubuntu AI installer renders no macOS-only casks"
+assert_not_contains_text "$ai_cli_tools_installer" 'cask "codex"' "Ubuntu AI installer renders no macOS-only casks"
 assert_contains_text "$ai_cli_tools_installer" 'clear_install_warning "$AI_CLI_WARNING_CATEGORY"' "Ubuntu AI installer only clears stale optional AI CLI markers"
 assert_contains_text "$macos_ai_cli_tools_installer" "/opt/homebrew/bin/brew" "macOS AI installer uses mandatory standard Homebrew"
 assert_contains_text "$macos_ai_cli_tools_installer" "HOMEBREW_NO_AUTO_UPDATE=1" "AI bundle disables Homebrew auto-update"
@@ -1944,8 +1944,8 @@ assert_contains_text "$macos_terminal_apps_bootstrap" "HOMEBREW_NO_AUTO_UPDATE=1
 
 for rendered_brewfile in "$macos_ai_cli_tools_brewfile" "$macos_development_workspace_ai_brewfile"; do
   assert_contains_text "$rendered_brewfile" 'cask "antigravity-cli"' "Optional AI Tool Stack declares Antigravity CLI cask"
-  assert_contains_text "$rendered_brewfile" 'cask "claude-code"' "Optional AI Tool Stack declares Claude Code cask"
   assert_contains_text "$rendered_brewfile" 'cask "codex"' "Optional AI Tool Stack declares Codex CLI cask"
+  assert_not_contains_text "$rendered_brewfile" 'cask "claude-code"' "Optional AI Tool Stack no longer declares a Claude Code cask"
 done
 assert_text_equals "$disabled_ai_cli_tools_brewfile" "" "disabled Optional AI Tool Stack renders no Homebrew casks"
 assert_text_equals "$ai_cli_tools_brewfile" "" "Ubuntu Optional AI Tool Stack renders no Homebrew casks"
@@ -2005,8 +2005,7 @@ write_ai_brew_stub() {
     '    for arg do case "$arg" in --file=*) bundle_file="$(printf "%s" "$arg" | cut -d= -f2-)" ;; esac; done' \
     '    [ -n "$bundle_file" ] || exit 64' \
     '    grep -Fx "cask \"antigravity-cli\"" "$bundle_file" >/dev/null || exit 65' \
-    '    grep -Fx "cask \"claude-code\"" "$bundle_file" >/dev/null || exit 66' \
-    '    grep -Fx "cask \"codex\"" "$bundle_file" >/dev/null || exit 67' \
+    '    grep -Fx "cask \"codex\"" "$bundle_file" >/dev/null || exit 66' \
     '    [ "$AI_BREW_FAIL" = "0" ] || exit 42' \
     '    ;;' \
     '  *) exit 64 ;;' \

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -2013,12 +2013,33 @@ write_ai_brew_stub() {
     'esac'
 }
 
+write_claude_installer_stubs() {
+  stub_dir="$1"
+  write_stub "$stub_dir/curl" \
+    'log="${CLAUDE_INSTALLER_LOG:-/dev/null}"' \
+    'printf "%s\n" "curl args:$*" >>"$log"' \
+    'output=' \
+    'while [ "$#" -gt 0 ]; do' \
+    '  if [ "$1" = "-o" ]; then output="$2"; shift 2; else shift; fi' \
+    'done' \
+    '[ -n "$output" ] || exit 2' \
+    'printf "%s\n" "#!/bin/bash" "exit 0" >"$output"'
+  write_stub "$stub_dir/bash" \
+    'log="${CLAUDE_INSTALLER_LOG:-/dev/null}"' \
+    'printf "%s\n" "bash args:$*" >>"$log"' \
+    '[ "${CLAUDE_INSTALLER_FAIL:-0}" = "0" ] || exit 3' \
+    'mkdir -p "$HOME/.local/bin"' \
+    'printf "%s\n" "#!/bin/sh" "exit 0" >"$HOME/.local/bin/claude"' \
+    'chmod +x "$HOME/.local/bin/claude"'
+}
+
 macos_ai_brew_bin="$tmp_dir/macos-ai-brew-bin"
 macos_intel_ai_brew_bin="$tmp_dir/macos-intel-ai-brew-bin"
 mkdir -p "$macos_ai_brew_bin" "$macos_intel_ai_brew_bin"
 write_ai_brew_stub "$macos_ai_brew_bin/brew"
 write_ai_brew_stub "$macos_intel_ai_brew_bin/brew"
 write_stub "$macos_ai_brew_bin/uname" 'printf "%s\n" "${AI_UNAME_ARCH:-arm64}"'
+write_claude_installer_stubs "$macos_ai_brew_bin"
 
 run_macos_ai_arch_case() {
   arch="$1"
@@ -2065,11 +2086,18 @@ pass "Optional AI Tool Stack records a warning and stops before bundle when Home
 
 for vendor_url in \
   "https://antigravity.google/cli/install.sh" \
-  "https://claude.ai/install.sh" \
   "https://chatgpt.com/codex/install.sh"
 do
   assert_not_contains_text "$ai_cli_tools_installer" "$vendor_url" "Optional AI Tool Stack no longer renders vendor installer URL: $vendor_url"
+  assert_not_contains_text "$macos_ai_cli_tools_installer" "$vendor_url" "macOS Optional AI Tool Stack no longer renders vendor installer URL: $vendor_url"
 done
+
+assert_contains_text "$macos_ai_cli_tools_installer" "https://claude.ai/install.sh" \
+  "macOS Optional AI Tool Stack renders the Claude Code installer URL"
+assert_not_contains_text "$ai_cli_tools_installer" "https://claude.ai/install.sh" \
+  "Ubuntu Optional AI Tool Stack renders no Claude Code installer URL"
+assert_contains_text "$macos_ai_cli_tools_installer" 'bash "$claude_code_installer" </dev/null' \
+  "Claude Code installer runs under bash with stdin detached"
 
 linux_ai_brew_bin="$tmp_dir/linux-ai-brew-bin"
 linux_ai_brew_home="$tmp_dir/linux-ai-brew-home"
@@ -2146,6 +2174,87 @@ if [ -e "$ai_cli_failure_marker" ]; then
   fail "successful Optional AI Tool Stack retry clears warning marker"
 fi
 pass "successful Optional AI Tool Stack retry clears warning marker"
+
+claude_fresh_home="$tmp_dir/claude-fresh-home"
+claude_fresh_state="$tmp_dir/claude-fresh-state"
+claude_fresh_brew_log="$tmp_dir/claude-fresh-brew.log"
+claude_fresh_installer_log="$tmp_dir/claude-fresh-installer.log"
+mkdir -p "$claude_fresh_home"
+HOME="$claude_fresh_home" XDG_STATE_HOME="$claude_fresh_state" \
+  AI_UNAME_ARCH=arm64 AI_BREW_BIN="$macos_ai_brew_bin" AI_BREW_LOG="$claude_fresh_brew_log" AI_BREW_FAIL=0 \
+  CLAUDE_INSTALLER_LOG="$claude_fresh_installer_log" \
+  PATH="$macos_ai_brew_bin:/usr/bin:/bin" sh "$macos_ai_cli_tools_installer_script"
+assert_contains_text "$(cat "$claude_fresh_installer_log")" "curl args:" \
+  "Optional AI Tool Stack downloads the Claude Code installer when Claude Code is absent"
+assert_contains_text "$(cat "$claude_fresh_installer_log")" "bash args:" \
+  "Optional AI Tool Stack runs the Claude Code installer when Claude Code is absent"
+if [ ! -x "$claude_fresh_home/.local/bin/claude" ]; then
+  fail "Optional AI Tool Stack installs the canonical Claude Code executable"
+fi
+pass "Optional AI Tool Stack installs the canonical Claude Code executable"
+if [ -e "$claude_fresh_state/terrapod/install-warnings/optional-ai-cli-tools" ]; then
+  fail "a successful Optional AI Tool Stack apply records no warning"
+fi
+pass "a successful Optional AI Tool Stack apply records no warning"
+
+claude_present_home="$tmp_dir/claude-present-home"
+claude_present_state="$tmp_dir/claude-present-state"
+claude_present_brew_log="$tmp_dir/claude-present-brew.log"
+claude_present_installer_log="$tmp_dir/claude-present-installer.log"
+mkdir -p "$claude_present_home/.local/bin"
+write_stub "$claude_present_home/.local/bin/claude" 'exit 0'
+HOME="$claude_present_home" XDG_STATE_HOME="$claude_present_state" \
+  AI_UNAME_ARCH=arm64 AI_BREW_BIN="$macos_ai_brew_bin" AI_BREW_LOG="$claude_present_brew_log" AI_BREW_FAIL=0 \
+  CLAUDE_INSTALLER_LOG="$claude_present_installer_log" \
+  PATH="$macos_ai_brew_bin:/usr/bin:/bin" sh "$macos_ai_cli_tools_installer_script"
+if [ -e "$claude_present_installer_log" ]; then
+  fail "an existing Claude Code install should not rerun the vendor installer"
+fi
+pass "an existing Claude Code install does not rerun the vendor installer"
+
+claude_failure_home="$tmp_dir/claude-failure-home"
+claude_failure_state="$tmp_dir/claude-failure-state"
+claude_failure_brew_log="$tmp_dir/claude-failure-brew.log"
+mkdir -p "$claude_failure_home"
+claude_failure_status=0
+HOME="$claude_failure_home" XDG_STATE_HOME="$claude_failure_state" \
+  AI_UNAME_ARCH=arm64 AI_BREW_BIN="$macos_ai_brew_bin" AI_BREW_LOG="$claude_failure_brew_log" AI_BREW_FAIL=0 \
+  CLAUDE_INSTALLER_FAIL=1 \
+  PATH="$macos_ai_brew_bin:/usr/bin:/bin" sh "$macos_ai_cli_tools_installer_script" >/dev/null 2>&1 ||
+  claude_failure_status=$?
+if [ "$claude_failure_status" -ne 0 ]; then
+  fail "a Claude Code install failure should continue apply after recording a warning"
+fi
+claude_failure_marker="$claude_failure_state/terrapod/install-warnings/optional-ai-cli-tools"
+if [ ! -f "$claude_failure_marker" ]; then
+  fail "a Claude Code install failure records the optional-ai-cli-tools marker"
+fi
+assert_contains_text "$(cat "$claude_failure_marker")" "Claude Code" \
+  "a Claude Code install failure names Claude Code in its marker"
+pass "a Claude Code install failure records a warning and exits zero"
+
+claude_bundle_failure_home="$tmp_dir/claude-bundle-failure-home"
+claude_bundle_failure_state="$tmp_dir/claude-bundle-failure-state"
+claude_bundle_failure_brew_log="$tmp_dir/claude-bundle-failure-brew.log"
+claude_bundle_failure_installer_log="$tmp_dir/claude-bundle-failure-installer.log"
+mkdir -p "$claude_bundle_failure_home"
+claude_bundle_failure_status=0
+HOME="$claude_bundle_failure_home" XDG_STATE_HOME="$claude_bundle_failure_state" \
+  AI_UNAME_ARCH=arm64 AI_BREW_BIN="$macos_ai_brew_bin" AI_BREW_LOG="$claude_bundle_failure_brew_log" AI_BREW_FAIL=1 \
+  CLAUDE_INSTALLER_LOG="$claude_bundle_failure_installer_log" \
+  PATH="$macos_ai_brew_bin:/usr/bin:/bin" sh "$macos_ai_cli_tools_installer_script" >/dev/null 2>&1 ||
+  claude_bundle_failure_status=$?
+if [ "$claude_bundle_failure_status" -ne 0 ]; then
+  fail "a Homebrew bundle failure should continue apply after recording a warning"
+fi
+assert_contains_text "$(cat "$claude_bundle_failure_installer_log")" "bash args:" \
+  "a Homebrew bundle failure does not skip the Claude Code step"
+claude_bundle_failure_marker="$claude_bundle_failure_state/terrapod/install-warnings/optional-ai-cli-tools"
+if [ ! -f "$claude_bundle_failure_marker" ]; then
+  fail "a Homebrew bundle failure records the optional-ai-cli-tools marker"
+fi
+assert_contains_text "$(cat "$claude_bundle_failure_marker")" "Homebrew bundle" \
+  "a Homebrew bundle failure names the bundle in its marker"
 
 development_workspace_zellij_layout="$(render_managed_file "$development_workspace_data" ".config/zellij/layouts/dev.kdl")"
 

--- a/tests/executable_selection_test.sh
+++ b/tests/executable_selection_test.sh
@@ -225,6 +225,44 @@ set -e
 pass "enabled Optional AI Tool Stack participates in readiness"
 assert_contains "$ai_enabled_output" "failure - antigravity-cli is not installed through Homebrew Cask" \
   "enabled Optional AI Tool Stack checks its declared casks"
+assert_contains "$ai_enabled_output" "failure - claude-code is not installed through the Claude Code installer" \
+  "enabled Optional AI Tool Stack checks Claude Code against its vendor installer"
+
+claude_home="$tmp_dir/claude-home"
+claude_path_dir="$tmp_dir/claude-path"
+mkdir -p "$claude_path_dir"
+printf '%s\n' claude-code >"$inventory/claude-installer"
+write_executable "$claude_home/.local/bin/claude"
+ln -s "$claude_home/.local/bin/claude" "$claude_path_dir/claude"
+
+run_claude_selection() {
+  HOME="$claude_home" \
+    TERRAPOD_EXECUTABLE_SELECTION_INVENTORY_DIR="$inventory" \
+    TERRAPOD_STANDARD_HOMEBREW_PREFIX="$prefix" \
+    TERRAPOD_MISE_SHIMS_DIR="$mise_shims" \
+    PATH="$claude_path_dir:/usr/bin:/bin" \
+    "$selection" doctor macos-terminal true false 2>&1 || true
+}
+
+claude_canonical_output="$(run_claude_selection)"
+assert_not_contains "$claude_canonical_output" "claude-code" \
+  "a canonical Claude Code install raises no executable selection concern"
+
+claude_shadow_dir="$tmp_dir/claude-shadow"
+mkdir -p "$claude_shadow_dir"
+write_executable "$claude_shadow_dir/claude"
+rm -f "$claude_path_dir/claude"
+ln -s "$claude_shadow_dir/claude" "$claude_path_dir/claude"
+claude_shadow_output="$(run_claude_selection)"
+assert_contains "$claude_shadow_output" "advisory - claude-code resolves to $claude_path_dir/claude" \
+  "a shadowed Claude Code install is advisory"
+assert_contains "$claude_shadow_output" "canonical: $claude_home/.local/bin/claude" \
+  "the Claude Code advisory names the vendor installer path"
+
+rm -f "$inventory/claude-installer"
+claude_missing_output="$(run_claude_selection)"
+assert_contains "$claude_missing_output" "failure - claude-code is not installed through the Claude Code installer" \
+  "an absent Claude Code install names the vendor installer"
 
 status_output="$(run_selection status)"
 assert_contains "$status_output" "Executable selection:" \

--- a/tests/homebrew_manifests_test.sh
+++ b/tests/homebrew_manifests_test.sh
@@ -55,7 +55,6 @@ expected_ai_casks="$tmp_dir/expected-ai-casks"
 actual_ai_casks="$tmp_dir/actual-ai-casks"
 printf '%s\n' \
   'cask "antigravity-cli"' \
-  'cask "claude-code"' \
   'cask "codex"' >"$expected_ai_casks"
 
 chezmoi execute-template \
@@ -65,9 +64,9 @@ chezmoi execute-template \
 printf '\n' >>"$actual_ai_casks"
 if ! cmp -s "$expected_ai_casks" "$actual_ai_casks"; then
   diff -u "$expected_ai_casks" "$actual_ai_casks" >&2 || true
-  fail "Optional AI Tool Stack declares exactly the three macOS casks"
+  fail "Optional AI Tool Stack declares exactly the two macOS casks"
 fi
-pass "Optional AI Tool Stack declares exactly the three macOS casks"
+pass "Optional AI Tool Stack declares exactly the two macOS casks"
 
 linux_ai_casks="$tmp_dir/linux-ai-casks"
 chezmoi execute-template \

--- a/tests/readme_korean_test.sh
+++ b/tests/readme_korean_test.sh
@@ -159,6 +159,8 @@ assert_contains "$korean_readme" '선택된 executable의 installer provenance�
   "README.ko.md documents provenance-neutral executable guidance"
 assert_not_contains "$korean_readme" 'Proceed with removing these legacy package installations? [y/N]' \
   "README.ko.md removes the package migration confirmation"
+assert_contains "$korean_readme" 'Claude Code는 package source의 결과가 아니라 profile 결정으로 macOS 전용을 유지합니다.' \
+  "README.ko.md attributes Claude Code's macOS scope to a profile decision, not its package source"
 assert_contains "$korean_readme" '`development-apps`: Zed, Orca ADE(`stablyai/orca/orca`), OrbStack.' \
   "README.ko.md documents Zed, Orca ADE, and OrbStack in the development-apps inventory"
 assert_contains "$korean_readme" '| `enableMacosAppGroupDevelopmentApps` | `false` | development-apps macOS App Group인 Zed, Orca ADE(`stablyai/orca/orca`), OrbStack을 설치합니다. |' \

--- a/tests/readme_korean_test.sh
+++ b/tests/readme_korean_test.sh
@@ -189,8 +189,10 @@ assert_contains "$korean_readme" 'Terrapod은 기존에 설치된 JetBrains Mono
   "README.ko.md documents non-destructive legacy font migration"
 assert_contains "$korean_readme" 'Jetendard 설정 적용이 보류되면 Orca를 종료한 뒤 `tpod apply`를 다시 실행합니다.' \
   "README.ko.md documents Orca font-setting recovery"
-assert_contains "$korean_readme" 'brew upgrade --cask claude-code codex antigravity-cli' \
+assert_contains "$korean_readme" 'brew upgrade --cask codex antigravity-cli' \
   "README.ko.md documents targeted AI CLI upgrades"
+assert_contains "$korean_readme" 'Claude Code는 자체적으로 업데이트하며 이 명령의 대상이 아닙니다.' \
+  "README.ko.md documents who owns Claude Code freshness"
 assert_contains "$korean_readme" '`enableMacosAppGroupAiApps`는 deprecated key이며 alias로 해석하지 않습니다.' \
   "README.ko.md documents explicit development-apps key migration"
 

--- a/tests/readme_optional_stack_profiles_test.sh
+++ b/tests/readme_optional_stack_profiles_test.sh
@@ -98,8 +98,10 @@ assert_contains '| `enableAiCliTools` | `false` |' \
   "README documents enableAiCliTools default"
 assert_key_row_contains '`enableAiCliTools`' 'Antigravity CLI, Claude Code, and Codex' \
   "README documents the new Optional AI Tool Stack membership"
-assert_key_row_contains '`enableAiCliTools`' 'Homebrew casks `antigravity-cli`, `claude-code`, and `codex`' \
-  "README documents Homebrew-owned Optional AI Tool Stack"
+assert_key_row_contains '`enableAiCliTools`' 'Homebrew casks `antigravity-cli` and `codex`' \
+  "README documents Homebrew-owned Optional AI Tool Stack members"
+assert_key_row_contains '`enableAiCliTools`' 'Claude Code through its official installer' \
+  "README documents the vendor-installed Optional AI Tool Stack member"
 assert_contains '| `enableDevelopmentWorkspace` | `false` |' \
   "README documents enableDevelopmentWorkspace default"
 assert_contains '| `profile` |' \
@@ -289,8 +291,10 @@ assert_raycast_restore_contains '`enableMacosAppGroupLauncher`' \
   "README Raycast restore procedure mentions launcher App Group"
 assert_contains 'Opting out of an optional stack excludes its files from chezmoi management; it does not remove files already present on a machine.' \
   "README documents non-destructive optional stack opt-out"
-assert_contains 'brew upgrade --cask claude-code codex antigravity-cli' \
+assert_contains 'brew upgrade --cask codex antigravity-cli' \
   "README documents targeted AI CLI upgrades"
+assert_contains 'Claude Code updates itself and is not part of that command.' \
+  "README documents who owns Claude Code freshness"
 assert_contains '`enableMacosAppGroupAiApps` is deprecated and is not treated as an alias' \
   "README documents explicit development-apps key migration"
 assert_contains 'If another executable is selected first, Terrapod' \

--- a/tests/readme_optional_stack_profiles_test.sh
+++ b/tests/readme_optional_stack_profiles_test.sh
@@ -249,6 +249,8 @@ assert_ubuntu_setup_not_contains 'Optional AI Tool Stack casks through Homebrew'
   "README does not promise Optional AI Tool Stack casks on Ubuntu"
 assert_ubuntu_setup_contains 'The Optional AI Tool Stack is also macOS-only' \
   "README explains the Optional AI Tool Stack is macOS-only"
+assert_ubuntu_setup_contains 'Claude Code stays macOS-only as a profile decision rather than a' \
+  "README attributes Claude Code's macOS scope to a profile decision, not its package source"
 assert_key_row_contains '`enableAiCliTools`' 'ignored on the VPS Shell Profile' \
   "README documents that enableAiCliTools is ignored on the VPS Shell Profile"
 assert_contains 'When `enableDevelopmentWorkspace` is `true`' \

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -2358,13 +2358,13 @@ write_linux_uname_stub "$status_shadow_path/uname"
 
 status_shadow_output="$(
   TERRAPOD_EXECUTABLE_SELECTION_OUTPUT="  advisory - claude-code resolves to $status_shadow_legacy/claude
-             canonical: /home/linuxbrew/.linuxbrew/bin/claude
+             canonical: $tmp_dir/status-shadow-canonical/.local/bin/claude
              Adjust PATH or remove the other installation manually, then rerun 'tpod doctor'." \
     TERRAPOD_OS_RELEASE_FILE="$status_ubuntu_os_release" TERRAPOD_CHEZMOI_CONFIG="$status_shadow_config" PATH="$status_shadow_legacy:$status_shadow_path" \
     /bin/sh "$terrapod" status
 )"
 
-assert_contains "$status_shadow_output" "advisory - claude-code resolves to $status_shadow_legacy/claude" "Terrapod status reports legacy Claude shadowing the Homebrew cask"
+assert_contains "$status_shadow_output" "advisory - claude-code resolves to $status_shadow_legacy/claude" "Terrapod status reports a legacy Claude shadowing the Claude Code installer"
 
 status_broken_prefix_path="$(status_doctor_path broken-prefix chezmoi git zsh mise nvim zellij apt brew agy claude codex)"
 write_stub "$status_broken_prefix_path/brew" \
@@ -2478,7 +2478,7 @@ mv "$doctor_ai_shadow_path/claude" "$doctor_ai_shadow_legacy/claude"
 
 if ! doctor_shadow_output="$(
   TERRAPOD_EXECUTABLE_SELECTION_OUTPUT="  advisory - claude-code resolves to $doctor_ai_shadow_legacy/claude
-             canonical: $doctor_standard_brew_prefix/bin/claude
+             canonical: $tmp_dir/doctor-ai-shadow-canonical/.local/bin/claude
              Adjust PATH or remove the other installation manually, then rerun 'tpod doctor'." \
     TERRAPOD_OS_RELEASE_FILE="$doctor_os_release" TERRAPOD_CHEZMOI_CONFIG="$status_shadow_config" PATH="$doctor_ai_shadow_legacy:$doctor_ai_shadow_path" \
     /bin/sh "$doctor_terrapod" doctor
@@ -2487,7 +2487,7 @@ if ! doctor_shadow_output="$(
 fi
 
 assert_contains "$doctor_shadow_output" "ok - brew is available" "enabled Ubuntu Optional AI Tool Stack doctor requires Homebrew"
-assert_contains "$doctor_shadow_output" "advisory - claude-code resolves to $doctor_ai_shadow_legacy/claude" "Terrapod doctor reports legacy Claude shadowing the Homebrew cask"
+assert_contains "$doctor_shadow_output" "advisory - claude-code resolves to $doctor_ai_shadow_legacy/claude" "Terrapod doctor reports a legacy Claude shadowing the Claude Code installer"
 assert_contains "$doctor_shadow_output" "Adjust PATH or remove the other installation manually" "Terrapod doctor gives provenance-neutral cleanup guidance"
 
 if ! TERRAPOD_OS_RELEASE_FILE="$doctor_os_release" TERRAPOD_CHEZMOI_CONFIG="$status_shadow_config" PATH="$status_broken_prefix_path" \
@@ -2599,7 +2599,7 @@ doctor_missing_path="$(status_doctor_path doctor-missing chezmoi git zsh mise nv
 write_linux_uname_stub "$doctor_missing_path/uname"
 
 if TERRAPOD_EXECUTABLE_SELECTION_OUTPUT="  failure - antigravity-cli is not installed through Homebrew Cask
-  failure - claude-code is not installed through Homebrew Cask
+  failure - claude-code is not installed through the Claude Code installer
   failure - codex is not installed through Homebrew Cask" \
   TERRAPOD_EXECUTABLE_SELECTION_STATUS=1 \
   TERRAPOD_OS_RELEASE_FILE="$doctor_os_release" TERRAPOD_CHEZMOI_CONFIG="$doctor_missing_config" PATH="$doctor_missing_path" \


### PR DESCRIPTION
## Problem

`Brewfile.ai-cli-tools.tmpl` declared `claude-code` alongside `antigravity-cli` and `codex`, and `brew bundle --no-upgrade` restored it. The cask lags vendor releases, and Claude Code ships often enough that the lag shows in daily use.

Simply swapping the install command does not work. ADR 0010's no-upgrade contract says apply restores missing declared state and never upgrades, but the vendor script at `https://claude.ai/install.sh` always downloads the latest build before running `claude install` — there is no install-if-missing mode. Running it on every apply would turn `tpod apply` into an upgrade and re-download tens of megabytes each time.

`executable-selection` is the second obstacle. It knows three providers — `homebrew-formula`, `homebrew-cask`, `mise` — and derives the canonical executable from the Homebrew prefix or the mise shims directory. A vendor install at `$HOME/.local/bin/claude` fits neither, so `tpod status` and `tpod doctor` would report `claude-code is not installed through Homebrew Cask` forever.

ADR 0015 is the third. It scoped the whole Optional AI Tool Stack to the macOS Terminal Profile *because* all three tools are casks and Linux Homebrew does not install casks. That reason stops holding for Claude Code the moment it moves.

## Approach

Only Claude Code moves. `antigravity-cli` and `codex` stay casks, so ADR 0008's single declared source keeps its value for the two tools whose cadence does not create this pressure.

**Install only when the canonical executable is absent.** `install_claude_code` returns early when `$HOME/.local/bin/claude` is executable, which puts it in the same place as `--no-upgrade` for Homebrew packages: Terrapod restores a missing install, and Claude Code's own updater owns freshness. That is also where the freshness the cask was losing actually comes from.

The step lives inside `run_before_60-install-ai-cli-tools.sh.tmpl` rather than a new script, because `optional-ai-cli-tools` is one warning category per stack and two scripts sharing a category would overwrite each other's marker. The two install steps are independent statements:

```sh
install_ai_cli_bundle || append_failed_ai_cli_tool "Homebrew bundle"
install_claude_code || append_failed_ai_cli_tool "Claude Code"
```

Neither can skip the other, and `finish_ai_cli_install` decides from the accumulated list, so one marker can name both sources on one line. A `brew bundle` failure keeps the bulk summary — identifying which cask failed needs output parsing — while the Claude Code step covers exactly one tool and names it.

Two details of the vendor script drive the rest. It declares `#!/bin/bash` and uses `[[ =~ ]]`, `BASH_REMATCH`, and `$'…'`, so it is invoked as `bash <file>`, not `sh`. And it ends by running `claude install`, which has no unattended flag and can present a terminal UI — the script itself restores the terminal with `stty sane` after a signal death. First-run apply runs in an interactive terminal driving `gum` prompts, so stdin is redirected from `/dev/null`; an install that waited for input would stall apply. Download follows the existing Oh My Zsh pattern: `curl` into `mktemp`, run, remove from the pre-existing `trap`.

**`executable-selection` gains a fourth provider, `claude-installer`.** The record becomes `claude-installer|claude-code|claude`; `provider_has_package` tests `[ -x "$HOME/.local/bin/claude" ]`, `expected_executable` returns that path, and `provider_label` reads `the Claude Code installer`. No new environment seam — the path derives from `$HOME` alone and the tests already override it. ADR 0012's three outcomes survive intact: absent is a failure, canonical is silent, and another file winning on PATH is a provenance-neutral advisory.

That last row is where an existing cask lands. `dot_zshenv.tmpl` prepends `$HOME/.local/bin` and *then* evaluates `brew shellenv`, so the Homebrew prefix ends up ahead and the cask copy stays primary. Terrapod reports it and removes nothing, per ADR 0012. There is deliberately no migration guidance in the READMEs.

ADR 0017 records all of this: it reverses ADR 0008's package-source choice for Claude Code alone, and reattributes the macOS scope for Claude Code to a profile decision rather than a consequence of Homebrew's Linux cask limitation. The stack stays macOS-only even though the vendor installer supports Linux.

## Tests

The change makes every existing macOS case in `chezmoiignore_test.sh` run a step that fetches a script over the network — with `/usr/bin` on `PATH`. `write_claude_installer_stubs` puts `curl` and `bash` stubs in the directory that is already first on `PATH` for all ten invocations, so no case can reach the network. Verified by running the four network-adjacent suites behind a dead proxy.

Seven new cases in `chezmoiignore_test.sh` cover: a fresh install runs the vendor script and produces the canonical executable; an existing install does not rerun it; a download failure, a non-zero vendor exit, and a vendor exit-0-that-installs-nothing each record a marker naming `Claude Code`; a `brew bundle` failure still attempts the Claude Code step and its marker does *not* name Claude Code; and both steps failing produce one single-line marker naming both.

The exit-0-installs-nothing case is the load-bearing one. `[ -x "$CLAUDE_CODE_CANONICAL_EXECUTABLE" ]` at the end of `install_claude_code` is what catches the vendor moving its install location, and without that case deleting the guard left the whole suite green. Confirmed by deleting it — the new case fails, restoring it passes.

`executable_selection_test.sh` covers the three provider outcomes. One assertion from the plan had to change: `command -v` returns the PATH entry for a symlink, not its target, so a shadow test asserting the resolved path could not pass under any implementation.

`homebrew_manifests_test.sh` compares the rendered manifest against an exact list, which is what keeps the cask from reappearing.

Full suite green: 19 test files, 2030 assertions. `homebrew_ubuntu_smoke.sh` skipped (needs a container).

## Follow-ups

- `assert_not_contains_text "$ai_cli_tools_installer" 'cask "codex"'` is structurally vacuous — the Linux render exits before any Brewfile is included, so no cask string can ever appear there. Pre-existing, kept as a tripwire against the heredoc being hoisted above the template gate. The branch's new `https://claude.ai/install.sh` negative assertion is the same class.
- `provider_has_package`'s real (non-inventory) branches are untested for every provider, not just the new one — every test sets `TERRAPOD_EXECUTABLE_SELECTION_INVENTORY_DIR`, which short-circuits the `case`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016XNZmzF457L3BtfSeQPagi