### PR TITLE
Require an explicit yes for a non-interactive configure overwrite

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -145,7 +145,7 @@ _Avoid_: separate Korean introduction, independent README, self-labeled translat
 - **Terrapod Setup** invoked by the first-run installer is followed by initial apply, while explicit routine `tpod setup` writes config only and guides users to run `tpod apply`.
 - `terrapod setup` is the human-facing **Terrapod Setup** wizard, while `terrapod configure <Preset>` remains the script-friendly command for writing concrete settings from one **Preset**.
 - `terrapod configure <Preset>` is not a plain fallback for **Terrapod Setup**; it is a separate script-friendly configuration command without interactive customization.
-- `terrapod configure <Preset>` may overwrite existing managed setup settings non-interactively after the user explicitly invokes it; config backup rules still apply.
+- `terrapod configure <Preset>` overwrites existing managed setup settings non-interactively only when the user passes `--yes` or sets `TERRAPOD_ASSUME_YES=1`; without a terminal to confirm on it fails with that guidance instead of overwriting, and config backup rules still apply.
 - `terrapod configure <Preset>` writes config only and does not run `tpod apply` automatically; its output should guide users to the next explicit apply step.
 - `terrapod configure <Preset>` does not create shell startup file backups because it does not apply or overwrite shell startup files.
 - **Terrapod Setup** does not expose a setup presentation mode switch; it has one gum-backed interactive presentation.

--- a/README.ko.md
+++ b/README.ko.md
@@ -74,6 +74,11 @@ machine이 조용히 다시 바뀌지는 않습니다.
 `terrapod configure <Preset>`는 script-friendly Preset configuration
 command입니다. 지원되는 Preset 정확히 하나의 concrete settings를 쓰고,
 `gum`이 필요 없으며, interactive customization은 제공하지 않습니다.
+config에 이미 Terrapod-managed data key가 있으면 덮어쓰기 전에 확인을
+받습니다. 이 prompt를 건너뛰려면 `--yes`를 넘기거나
+`TERRAPOD_ASSUME_YES=1`을 설정합니다. script와 CI에는 답할 terminal이
+없으므로, `terrapod configure <Preset>`는 기존 설정을 조용히 덮어쓰지 않고
+같은 안내와 함께 실패합니다.
 `terrapod configure <Preset>`는 Terrapod Setup의 plain fallback이 아닙니다.
 `terrapod configure <Preset>`는 setup UI 없이 설정을 쓰는
 script-friendly 경로입니다. 이 경로는 Terrapod Setup과 의도적으로 분리되어

--- a/README.md
+++ b/README.md
@@ -74,8 +74,12 @@ The `workstation` Preset is available only for the macOS Terminal Profile.
 
 `terrapod configure <Preset>` is the script-friendly Preset configuration
 command. It writes concrete settings for exactly one supported Preset, does not
-require `gum`, and has no interactive customization. `terrapod configure
-<Preset>` is not a plain fallback for Terrapod Setup. Terrapod Setup and
+require `gum`, and has no interactive customization. When the config already
+holds Terrapod-managed data keys, it asks before overwriting them; pass `--yes`
+or set `TERRAPOD_ASSUME_YES=1` to skip that prompt. Scripts and CI have no
+terminal to answer on, so `terrapod configure <Preset>` fails there with that
+guidance rather than overwriting the existing settings silently. `terrapod
+configure <Preset>` is not a plain fallback for Terrapod Setup. Terrapod Setup and
 `terrapod configure <Preset>` are intentionally separate. The latter writes
 settings without the setup UI. If Terrapod Setup cannot run because `gum` or an
 interactive terminal is unavailable, fix the `gum` or

--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -164,7 +164,7 @@ show_help() {
   print_section "Usage:"
   printf '%s\n' "  tpod [help|--help|-h]"
   printf '%s\n' "  tpod setup"
-  printf '%s\n' "  tpod configure <$preset_args>"
+  printf '%s\n' "  tpod configure [--yes] <$preset_args>"
   printf '%s\n' "  tpod status"
   printf '%s\n' "  tpod doctor"
   printf '%s\n' "  tpod diff"
@@ -184,9 +184,16 @@ show_help() {
   printf '%s\n' "  update                                Refresh source, then hand off to the refreshed tpod apply."
   printf '%s\n' "  chezmoi -- <args...>                  Run raw chezmoi for advanced maintenance."
   printf '\n'
+  print_section "Options:"
+  printf '%s\n' "  --yes                                 Let configure overwrite Terrapod-managed data keys in an"
+  printf '%s\n' "                                        existing config without the confirmation prompt."
+  printf '%s\n' "                                        Set TERRAPOD_ASSUME_YES=1 for the same effect."
+  printf '%s\n' "                                        Required when configure runs without a terminal."
+  printf '\n'
   print_section "Examples:"
   printf '%s\n' "  tpod setup"
   printf '%s\n' "  tpod configure development"
+  printf '%s\n' "  tpod configure --yes development"
   printf '%s\n' "  tpod status"
   printf '%s\n' "  tpod doctor"
   printf '%s\n' "  tpod diff"
@@ -2003,11 +2010,29 @@ validate_preset_for_profile() {
   fi
 }
 
+assume_yes_requested() {
+  requested="$1"
+
+  [ "$requested" = "true" ] || [ "${TERRAPOD_ASSUME_YES:-}" = "1" ]
+}
+
 confirm_existing_config_update() {
   config_file="$1"
+  assume_yes="$2"
 
   if [ ! -f "$config_file" ]; then
     return 0
+  fi
+
+  if assume_yes_requested "$assume_yes"; then
+    return 0
+  fi
+
+  # Without a tty there is nobody to answer the prompt, and silently
+  # overwriting managed keys is the one outcome a script must never get by
+  # accident, so the confirmation has to be stated up front instead.
+  if [ ! -t 0 ]; then
+    fatal "$config_file already holds Terrapod-managed data keys; rerun with 'tpod configure --yes' or set TERRAPOD_ASSUME_YES=1 to overwrite them without a prompt"
   fi
 
   printf 'Update Terrapod-managed data keys in %s? [y/N] ' "$config_file" >&2
@@ -2476,10 +2501,11 @@ write_preset_settings() {
   config_file="$1"
   preset="$2"
   profile="$3"
+  assume_yes="$4"
 
   validate_preset "$preset"
   reject_unsupported_managed_config "$config_file"
-  confirm_existing_config_update "$config_file"
+  confirm_existing_config_update "$config_file" "$assume_yes"
   write_managed_config "$config_file" "$preset" "$profile"
 }
 
@@ -2516,16 +2542,31 @@ run_setup() {
 }
 
 run_configure() {
-  if [ "$#" -eq 0 ]; then
-    fail_usage "Preset is required"
-  fi
+  preset=
+  preset_given=false
+  assume_yes=false
 
-  if [ "$#" -gt 1 ]; then
-    fail_usage "configure accepts exactly one Preset"
-  fi
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --yes)
+        assume_yes=true
+        ;;
+      -*)
+        fail_usage "unknown configure option: $1"
+        ;;
+      *)
+        if [ "$preset_given" = "true" ]; then
+          fail_usage "configure accepts exactly one Preset"
+        fi
 
-  preset="$1"
-  if [ -z "$preset" ]; then
+        preset_given=true
+        preset="$1"
+        ;;
+    esac
+    shift
+  done
+
+  if [ "$preset_given" != "true" ] || [ -z "$preset" ]; then
     fail_usage "Preset is required"
   fi
 
@@ -2533,7 +2574,7 @@ run_configure() {
   config_file="$(chezmoi_config_file)"
 
   validate_preset_for_profile "$preset" "$profile"
-  write_preset_settings "$config_file" "$preset" "$profile"
+  write_preset_settings "$config_file" "$preset" "$profile" "$assume_yes"
   printf '%s\n' "Configured Terrapod Preset '$preset' in $config_file"
   printf '%s\n' "Run 'tpod apply' to apply these changes."
 }

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -1428,7 +1428,7 @@ assert_contains \
 
 assert_contains \
   "$help_output" \
-  "tpod configure <minimal|development|workstation>" \
+  "tpod configure [--yes] <minimal|development|workstation>" \
   "Terrapod help documents short Preset configuration"
 
 assert_contains \
@@ -1460,6 +1460,21 @@ assert_contains \
   "$help_output" \
   "tpod chezmoi -- <args...>" \
   "Terrapod help documents the raw chezmoi escape hatch"
+
+assert_contains \
+  "$help_output" \
+  "tpod configure --yes development" \
+  "Terrapod help shows a non-interactive configure example"
+
+assert_contains \
+  "$help_output" \
+  "Set TERRAPOD_ASSUME_YES=1 for the same effect." \
+  "Terrapod help documents the configure confirmation environment variable"
+
+assert_contains \
+  "$help_output" \
+  "Required when configure runs without a terminal." \
+  "Terrapod help states that configure needs the flag without a terminal"
 
 assert_contains \
   "$help_output" \
@@ -1551,14 +1566,14 @@ macos_help_output="$(TERRAPOD_PROFILE=macos-terminal sh "$terrapod" help)"
 
 assert_contains \
   "$macos_help_output" \
-  "tpod configure <minimal|development|workstation>" \
+  "tpod configure [--yes] <minimal|development|workstation>" \
   "macOS Terminal Profile help exposes workstation Preset"
 
 vps_help_output="$(TERRAPOD_PROFILE=vps-shell sh "$terrapod" help)"
 
 assert_contains \
   "$vps_help_output" \
-  "tpod configure <minimal|development>" \
+  "tpod configure [--yes] <minimal|development>" \
   "VPS Shell Profile help hides workstation Preset"
 
 assert_not_contains \

--- a/tests/terrapod_config_test.sh
+++ b/tests/terrapod_config_test.sh
@@ -420,16 +420,39 @@ assert_no_shell_startup_backups_under() {
 
 run_terrapod_configure() {
   preset="$1"
-  input="${2:-}"
+  home_dir="$2"
+  xdg_config_home="$3"
+  profile="${4:-vps-shell}"
+
+  TERRAPOD_PROFILE="$profile" TERRAPOD_CHEZMOI_CONFIG= HOME="$home_dir" XDG_CONFIG_HOME="$xdg_config_home" \
+    sh "$terrapod" configure "$preset" </dev/null
+}
+
+run_terrapod_configure_yes() {
+  preset="$1"
+  home_dir="$2"
+  xdg_config_home="$3"
+  profile="${4:-vps-shell}"
+
+  TERRAPOD_PROFILE="$profile" TERRAPOD_CHEZMOI_CONFIG= HOME="$home_dir" XDG_CONFIG_HOME="$xdg_config_home" \
+    sh "$terrapod" configure --yes "$preset" </dev/null
+}
+
+# The confirmation prompt only runs on a tty, so the answer is typed into a
+# pty. The trailing sleep keeps the pipe open until the prompt has read it.
+run_terrapod_configure_in_pty() {
+  preset="$1"
+  answer="$2"
   home_dir="$3"
   xdg_config_home="$4"
   profile="${5:-vps-shell}"
 
-  if [ -n "$input" ]; then
-    printf '%s\n' "$input" |
-      TERRAPOD_PROFILE="$profile" TERRAPOD_CHEZMOI_CONFIG= HOME="$home_dir" XDG_CONFIG_HOME="$xdg_config_home" sh "$terrapod" configure "$preset"
+  if script --version >/dev/null 2>&1; then
+    command_text="env TERM=xterm TERRAPOD_PROFILE=$(shell_quote "$profile") TERRAPOD_CHEZMOI_CONFIG= HOME=$(shell_quote "$home_dir") XDG_CONFIG_HOME=$(shell_quote "$xdg_config_home") sh $(shell_quote "$terrapod") configure $(shell_quote "$preset")"
+    { printf '%s\n' "$answer"; sleep 2; } | script -q -e -c "$command_text" /dev/null
   else
-    TERRAPOD_PROFILE="$profile" TERRAPOD_CHEZMOI_CONFIG= HOME="$home_dir" XDG_CONFIG_HOME="$xdg_config_home" sh "$terrapod" configure "$preset" </dev/null
+    { printf '%s\n' "$answer"; sleep 2; } |
+      script -q /dev/null env TERM=xterm TERRAPOD_PROFILE="$profile" TERRAPOD_CHEZMOI_CONFIG= HOME="$home_dir" XDG_CONFIG_HOME="$xdg_config_home" sh "$terrapod" configure "$preset"
   fi
 }
 
@@ -470,7 +493,7 @@ new_xdg="$tmp_dir/new-xdg"
 new_config="$new_xdg/chezmoi/chezmoi.toml"
 mkdir -p "$new_home"
 
-run_terrapod_configure minimal "" "$new_home" "$new_xdg" >"$tmp_dir/new-configure.out"
+run_terrapod_configure minimal "$new_home" "$new_xdg" >"$tmp_dir/new-configure.out"
 
 if [ ! -f "$new_config" ]; then
   fail "minimal Preset creates a chezmoi config file"
@@ -500,7 +523,7 @@ development_xdg="$tmp_dir/development-xdg"
 development_config="$development_xdg/chezmoi/chezmoi.toml"
 mkdir -p "$development_home"
 
-run_terrapod_configure development "" "$development_home" "$development_xdg"
+run_terrapod_configure development "$development_home" "$development_xdg"
 
 if [ ! -f "$development_config" ]; then
   fail "development Preset creates a chezmoi config file"
@@ -526,7 +549,7 @@ macos_development_xdg="$tmp_dir/macos-development-xdg"
 macos_development_config="$macos_development_xdg/chezmoi/chezmoi.toml"
 mkdir -p "$macos_development_home"
 
-run_terrapod_configure development "" "$macos_development_home" "$macos_development_xdg" macos-terminal
+run_terrapod_configure development "$macos_development_home" "$macos_development_xdg" macos-terminal
 
 if [ ! -f "$macos_development_config" ]; then
   fail "macOS development Preset creates a chezmoi config file"
@@ -542,7 +565,7 @@ workstation_xdg="$tmp_dir/workstation-xdg"
 workstation_config="$workstation_xdg/chezmoi/chezmoi.toml"
 mkdir -p "$workstation_home"
 
-run_terrapod_configure workstation "" "$workstation_home" "$workstation_xdg" macos-terminal
+run_terrapod_configure workstation "$workstation_home" "$workstation_xdg" macos-terminal
 
 if [ ! -f "$workstation_config" ]; then
   fail "workstation Preset creates a chezmoi config file"
@@ -1081,7 +1104,7 @@ escape_config="$tmp_dir/escape.toml"
 mkdir -p "$default_env_home"
 
 export TERRAPOD_CHEZMOI_CONFIG="$escape_config"
-run_terrapod_configure minimal "" "$default_env_home" "$default_env_xdg"
+run_terrapod_configure minimal "$default_env_home" "$default_env_xdg"
 unset TERRAPOD_CHEZMOI_CONFIG
 
 if [ ! -f "$default_env_config" ]; then
@@ -1118,7 +1141,7 @@ command = "nvim"
 TOML
 cp "$existing_config" "$tmp_dir/existing-before.toml"
 
-run_terrapod_configure development "y" "$existing_home" "$existing_xdg"
+run_terrapod_configure_yes development "$existing_home" "$existing_xdg"
 
 assert_contains "$existing_config" "branch = \"main\"" "existing update preserves unrelated sourceState values"
 assert_contains "$existing_config" "email = \"minu@example.com\"" "existing update preserves unrelated data values"
@@ -1155,7 +1178,7 @@ terrapodPreset = "minimal"
 branch = "main"
 TOML
 
-run_terrapod_configure development "y" "$quoted_table_home" "$quoted_table_xdg" macos-terminal
+run_terrapod_configure_yes development "$quoted_table_home" "$quoted_table_xdg" macos-terminal
 
 assert_contains "$quoted_table_config" "[\"data\"]" "quoted data table header is preserved"
 assert_not_contains "$quoted_table_config" "[data]" "quoted data table update does not append a duplicate bare data table"
@@ -1187,7 +1210,7 @@ terrapodPreset = "minimal"
 branch = "main"
 TOML
 
-run_terrapod_configure development "y" "$spaced_table_home" "$spaced_table_xdg" macos-terminal
+run_terrapod_configure_yes development "$spaced_table_home" "$spaced_table_xdg" macos-terminal
 
 assert_contains "$spaced_table_config" "[ data ]" "spaced data table header is preserved"
 assert_not_contains "$spaced_table_config" "[data]" "spaced data table update does not append a duplicate bare data table"
@@ -1220,7 +1243,7 @@ data.terrapodPreset = "minimal"
 branch = "main"
 TOML
 
-run_terrapod_configure development "y" "$dotted_home" "$dotted_xdg"
+run_terrapod_configure_yes development "$dotted_home" "$dotted_xdg"
 
 assert_not_contains "$dotted_config" "[data]" "dotted data update does not append a duplicate data table"
 assert_contains "$dotted_config" "data.email = \"minu@example.com\"" "dotted data update preserves unrelated data values"
@@ -1258,7 +1281,7 @@ cat >"$quoted_config" <<'TOML'
 keepLiteral = "preserve"
 TOML
 
-run_terrapod_configure development "y" "$quoted_home" "$quoted_xdg" macos-terminal
+run_terrapod_configure_yes development "$quoted_home" "$quoted_xdg" macos-terminal
 
 assert_data_key_once_with_value "$quoted_config" "enableEditorStack" "true" "quoted managed key update writes one Editor Stack value in data"
 assert_data_key_once_with_value "$quoted_config" "enableAiCliTools" "true" "quoted managed key update writes one AI Tool Stack value in data"
@@ -1294,7 +1317,7 @@ enableEditorStack = "do-not-touch"
 TOML
 chmod 600 "$array_config"
 
-run_terrapod_configure development "y" "$array_home" "$array_xdg" macos-terminal
+run_terrapod_configure_yes development "$array_home" "$array_xdg" macos-terminal
 
 assert_contains "$array_config" "keepMe = \"yes\"" "array-table update preserves unrelated data values"
 assert_data_key_once_with_value "$array_config" "enableEditorStack" "true" "array-table update writes Editor Stack only in data"
@@ -1338,7 +1361,7 @@ enableAiCliTools = false
 branch = "main"
 TOML
 
-run_terrapod_configure development "y" "$custom_array_home" "$custom_array_xdg" macos-terminal
+run_terrapod_configure_yes development "$custom_array_home" "$custom_array_xdg" macos-terminal
 
 assert_contains "$custom_array_config" "customValues = [" "custom array update preserves array header"
 assert_contains "$custom_array_config" "preserve-me" "custom array update preserves array value"
@@ -1418,8 +1441,8 @@ exit 2
 SH
 chmod +x "$fake_stat_bin/stat"
 
-if ! printf '%s\n' "y" |
-  PATH="$fake_stat_bin:$PATH" HOME="$fake_stat_home" XDG_CONFIG_HOME="$fake_stat_xdg" sh "$terrapod" configure development >"$tmp_dir/fake-stat.out" 2>"$tmp_dir/fake-stat.err"; then
+if ! PATH="$fake_stat_bin:$PATH" HOME="$fake_stat_home" XDG_CONFIG_HOME="$fake_stat_xdg" \
+  sh "$terrapod" configure --yes development >"$tmp_dir/fake-stat.out" 2>"$tmp_dir/fake-stat.err" </dev/null; then
   printf '%s\n' "stdout:" >&2
   sed 's/^/  /' "$tmp_dir/fake-stat.out" >&2
   printf '%s\n' "stderr:" >&2
@@ -1583,7 +1606,7 @@ keepMe = "yes"
 TOML
 cp "$decline_config" "$tmp_dir/decline-before.toml"
 
-if run_terrapod_configure development "n" "$decline_home" "$decline_xdg" >"$tmp_dir/decline.out" 2>"$tmp_dir/decline.err"; then
+if run_terrapod_configure_in_pty development "n" "$decline_home" "$decline_xdg" >"$tmp_dir/decline.out" 2>&1; then
   fail "existing config update can be declined"
 fi
 pass "existing config update can be declined"
@@ -1593,8 +1616,127 @@ if ! cmp -s "$decline_config" "$tmp_dir/decline-before.toml"; then
 fi
 pass "declined config update leaves existing config unchanged"
 
-assert_contains "$tmp_dir/decline.err" "Update Terrapod-managed data keys" "existing config update asks before writing"
+assert_contains "$tmp_dir/decline.out" "Update Terrapod-managed data keys" "existing config update asks before writing"
+assert_contains "$tmp_dir/decline.out" "config update cancelled" "declined config update explains the cancellation"
 assert_backup_count "$decline_config" 0 "declined config update does not create a backup"
+
+accept_home="$tmp_dir/accept-home"
+accept_xdg="$tmp_dir/accept-xdg"
+accept_config="$accept_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$accept_home" "$(dirname "$accept_config")"
+
+cat >"$accept_config" <<'TOML'
+[data]
+enableEditorStack = false
+keepMe = "yes"
+TOML
+
+run_terrapod_configure_in_pty development "y" "$accept_home" "$accept_xdg" >"$tmp_dir/accept.out" 2>&1
+
+assert_contains "$tmp_dir/accept.out" "Update Terrapod-managed data keys" "accepted config update asks before writing"
+assert_data_key_once_with_value "$accept_config" "enableEditorStack" "true" "accepted config update writes the Preset settings"
+assert_contains "$accept_config" "keepMe = \"yes\"" "accepted config update preserves unrelated data values"
+
+no_tty_home="$tmp_dir/no-tty-home"
+no_tty_xdg="$tmp_dir/no-tty-xdg"
+no_tty_config="$no_tty_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$no_tty_home" "$(dirname "$no_tty_config")"
+
+cat >"$no_tty_config" <<'TOML'
+[data]
+enableEditorStack = false
+keepMe = "yes"
+TOML
+cp "$no_tty_config" "$tmp_dir/no-tty-before.toml"
+
+if run_terrapod_configure development "$no_tty_home" "$no_tty_xdg" >"$tmp_dir/no-tty.out" 2>"$tmp_dir/no-tty.err"; then
+  fail "configure without a terminal refuses to overwrite an existing config"
+fi
+pass "configure without a terminal refuses to overwrite an existing config"
+
+if ! cmp -s "$no_tty_config" "$tmp_dir/no-tty-before.toml"; then
+  fail "refused config update leaves existing config unchanged"
+fi
+pass "refused config update leaves existing config unchanged"
+
+assert_not_contains "$tmp_dir/no-tty.err" "Update Terrapod-managed data keys" "configure without a terminal does not print an unanswerable prompt"
+assert_contains "$tmp_dir/no-tty.err" "tpod configure --yes" "configure without a terminal names the flag that allows the overwrite"
+assert_contains "$tmp_dir/no-tty.err" "TERRAPOD_ASSUME_YES=1" "configure without a terminal names the environment variable that allows the overwrite"
+assert_not_contains "$tmp_dir/no-tty.out" "Configured Terrapod Preset" "configure without a terminal does not report success"
+assert_backup_count "$no_tty_config" 0 "refused config update does not create a backup"
+assert_no_terrapod_temp_files "$no_tty_config" "refused config update leaves no Terrapod temp files"
+
+piped_answer_home="$tmp_dir/piped-answer-home"
+piped_answer_xdg="$tmp_dir/piped-answer-xdg"
+piped_answer_config="$piped_answer_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$piped_answer_home" "$(dirname "$piped_answer_config")"
+
+cat >"$piped_answer_config" <<'TOML'
+[data]
+enableEditorStack = false
+keepMe = "yes"
+TOML
+cp "$piped_answer_config" "$tmp_dir/piped-answer-before.toml"
+
+if printf '%s\n' "y" |
+  TERRAPOD_PROFILE=vps-shell TERRAPOD_CHEZMOI_CONFIG= HOME="$piped_answer_home" XDG_CONFIG_HOME="$piped_answer_xdg" \
+    sh "$terrapod" configure development >"$tmp_dir/piped-answer.out" 2>"$tmp_dir/piped-answer.err"; then
+  fail "a piped confirmation answer does not stand in for the overwrite flag"
+fi
+pass "a piped confirmation answer does not stand in for the overwrite flag"
+
+if ! cmp -s "$piped_answer_config" "$tmp_dir/piped-answer-before.toml"; then
+  fail "a piped confirmation answer leaves the existing config unchanged"
+fi
+pass "a piped confirmation answer leaves the existing config unchanged"
+
+assume_yes_home="$tmp_dir/assume-yes-home"
+assume_yes_xdg="$tmp_dir/assume-yes-xdg"
+assume_yes_config="$assume_yes_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$assume_yes_home" "$(dirname "$assume_yes_config")"
+
+cat >"$assume_yes_config" <<'TOML'
+[data]
+enableEditorStack = false
+keepMe = "yes"
+TOML
+cp "$assume_yes_config" "$tmp_dir/assume-yes-before.toml"
+
+TERRAPOD_ASSUME_YES=1 TERRAPOD_PROFILE=vps-shell TERRAPOD_CHEZMOI_CONFIG= \
+  HOME="$assume_yes_home" XDG_CONFIG_HOME="$assume_yes_xdg" \
+  sh "$terrapod" configure development >"$tmp_dir/assume-yes.out" 2>&1 </dev/null
+
+assert_contains "$tmp_dir/assume-yes.out" "Configured Terrapod Preset 'development'" "TERRAPOD_ASSUME_YES=1 lets configure overwrite an existing config"
+assert_not_contains "$tmp_dir/assume-yes.out" "Update Terrapod-managed data keys" "TERRAPOD_ASSUME_YES=1 skips the confirmation prompt"
+assert_data_key_once_with_value "$assume_yes_config" "enableEditorStack" "true" "TERRAPOD_ASSUME_YES=1 writes the Preset settings"
+assert_contains "$assume_yes_config" "keepMe = \"yes\"" "TERRAPOD_ASSUME_YES=1 preserves unrelated data values"
+assert_single_backup_matches "$assume_yes_config" "$tmp_dir/assume-yes-before.toml" "TERRAPOD_ASSUME_YES=1 still backs up the config before changing managed keys"
+
+flag_new_home="$tmp_dir/flag-new-home"
+flag_new_xdg="$tmp_dir/flag-new-xdg"
+flag_new_config="$flag_new_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$flag_new_home"
+
+run_terrapod_configure_yes minimal "$flag_new_home" "$flag_new_xdg" >"$tmp_dir/flag-new.out"
+
+assert_contains "$tmp_dir/flag-new.out" "Configured Terrapod Preset 'minimal' in $flag_new_config" "--yes writes a new config the same way as a bare configure"
+assert_backup_count "$flag_new_config" 0 "--yes new config creation does not create a backup"
+
+if TERRAPOD_PROFILE=vps-shell TERRAPOD_CHEZMOI_CONFIG= HOME="$tmp_dir/unknown-option-home" XDG_CONFIG_HOME="$tmp_dir/unknown-option-xdg" \
+  sh "$terrapod" configure --force minimal >"$tmp_dir/unknown-option.out" 2>"$tmp_dir/unknown-option.err" </dev/null; then
+  fail "configure rejects an unknown option"
+fi
+pass "configure rejects an unknown option"
+
+assert_contains "$tmp_dir/unknown-option.err" "unknown configure option: --force" "configure names the unknown option it rejected"
+
+if TERRAPOD_PROFILE=vps-shell TERRAPOD_CHEZMOI_CONFIG= HOME="$tmp_dir/flag-only-home" XDG_CONFIG_HOME="$tmp_dir/flag-only-xdg" \
+  sh "$terrapod" configure --yes >"$tmp_dir/flag-only.out" 2>"$tmp_dir/flag-only.err" </dev/null; then
+  fail "configure still requires a Preset when only the overwrite flag is given"
+fi
+pass "configure still requires a Preset when only the overwrite flag is given"
+
+assert_contains "$tmp_dir/flag-only.err" "Preset is required" "configure with only the overwrite flag reports the missing Preset"
 
 directory_home="$tmp_dir/directory-home"
 directory_xdg="$tmp_dir/directory-xdg"


### PR DESCRIPTION
Closes #160

## Problem

`confirm_existing_config_update` prompted on stdin unconditionally whenever the chezmoi config already held Terrapod-managed data keys. Without a terminal, `read` hits EOF, `answer` stays empty, the `*)` branch runs, and the command exits 1 with "config update cancelled". `terrapod configure <Preset>` is documented in both READMEs and CONTEXT.md as the script-friendly command, so scripted and CI runs against an already configured machine always failed.

## Change

- `configure` now takes a `--yes` flag, and `TERRAPOD_ASSUME_YES=1` does the same thing. Either one skips the confirmation.
- Without either, and with stdin not a tty, `configure` fails with an error naming both escapes rather than printing a prompt nobody can answer. It does not silently overwrite.
- On a tty the prompt is unchanged: `y`/`Y`/`yes`/`YES` proceeds, anything else cancels.
- A piped answer no longer counts as confirmation, so a script cannot overwrite managed keys by accident.
- `run_configure` parses arguments in a loop, so `--yes` works before or after the Preset, and an unknown option is rejected by name.
- Documented in `show_help` (a new `Options:` section, a `tpod configure --yes development` example, and the `[--yes]` usage line), in both READMEs next to the script-friendly claim, and in the CONTEXT.md rule that previously said configure "may overwrite existing managed setup settings non-interactively".

## Note on the issue text

The issue points at `dot_local/bin/executable_terrapod:1941-1960`; on the current `main` the function lives at 2006-2025. The behavior is exactly as described.

## Tests

New regression coverage in `tests/terrapod_config_test.sh`:

- non-interactive `configure` against an existing config fails, prints no prompt, names `tpod configure --yes` and `TERRAPOD_ASSUME_YES=1`, leaves the config unchanged, creates no backup, and leaves no temp files
- a piped `y` is not accepted as confirmation
- `TERRAPOD_ASSUME_YES=1` overwrites, skips the prompt, preserves unrelated data values, and still writes the backup
- `--yes` on a fresh config behaves like a bare `configure` and creates no backup
- an unknown option and a `--yes`-only invocation both fail with the expected usage error
- the interactive decline and accept paths now run in a pty (`run_terrapod_configure_in_pty`), so the prompt itself stays covered

Existing overwrite tests moved from a piped `y` to `run_terrapod_configure_yes`, and the now-unused `input` parameter was dropped from `run_terrapod_configure`. `tests/terrapod_command_test.sh` asserts the new help text.

```
$ sh tests/terrapod_config_test.sh              -> 418 ok, exit 0
$ sh tests/terrapod_command_test.sh             -> 511 ok, exit 0
$ sh tests/readme_korean_test.sh                -> 52 ok, exit 0
$ sh tests/readme_optional_stack_profiles_test.sh -> 111 ok, exit 0
$ sh tests/terrapod_installer_test.sh           -> 390 ok, exit 0
```

The command suite needs a real `python3` on `PATH` for its Jetendard assertions; a mise shim that cannot resolve fails them independently of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKu7yrNkZj6rtDDuF1kzVF