### PR TITLE
Reclaim abandoned install warning staging files

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -236,6 +236,7 @@ _Avoid_: separate Korean introduction, independent README, self-labeled translat
 - Terrapod install warning marker `updated_at` values use UTC ISO 8601 timestamps such as `2026-06-02T03:12:45Z`.
 - Terrapod install warning marker writes should be atomic at the category file level, and `terrapod_install_warning_clear()` removes only the matching category file.
 - The Terrapod install warning directory is Terrapod-owned; its only valid filenames are current categories, the legacy aliases Terrapod still reads, and in-flight staging files.
+- An install warning staging file is in flight only between the `mktemp` that creates it and the rename that publishes it; one that outlives that window is abandoned, and `tpod apply` reclaims abandoned staging files once they are older than a day.
 - `tpod apply` removes install warning marker files whose names are not valid and prints one line per removal; `tpod status` and `tpod doctor` stay read-only.
 - Install warning marker prune failures print a warning and do not change the exit status of `tpod apply`.
 - Terrapod install warnings do not include a retained installer log; recovery guidance should direct users to rerun the relevant apply path for fresh command output.

--- a/docs/adr/0018-reclaim-abandoned-install-warning-staging-files.md
+++ b/docs/adr/0018-reclaim-abandoned-install-warning-staging-files.md
@@ -1,0 +1,51 @@
+# Reclaim abandoned install warning staging files on apply
+
+`terrapod_install_warning_prune` reclaims dot-prefixed `mktemp` staging files in
+the install warning directory once their modification time is older than one day.
+Staging files younger than that are still left alone, and every other rule from
+ADR 0014 is unchanged.
+
+This narrows ADR 0014's consequence that "dot-prefixed staging files survive
+because the prune iterates a POSIX glob". That rule protected in-flight writes
+and, by the same token, made an abandoned staging file permanently unreachable:
+`terrapod_install_warning_write` stages `.<category>.XXXXXX` and renames it over
+the category file, so a process killed between the two leaves a file that nothing
+in Terrapod could ever remove. These writes run inside installers users interrupt,
+so the window is reached in practice.
+
+Age is what separates the two cases. Terrapod owns the directory, and the only
+legitimate reason a staging file exists is a `mv` that has not happened yet.
+A `mktemp` and its `mv` are separated by four `printf`s, so a staging file that
+has survived a day has no live writer waiting on it. One day is far past any real
+write and far short of any interval at which a machine applies, so no in-flight
+write can be pruned out from under itself.
+
+## Considered Options
+
+- `trap`-remove the staging file inside `terrapod_install_warning_write`:
+  rejected because `trap` in POSIX shell is process-global, and the function is
+  called from scripts that already install their own `EXIT` traps for downloaded
+  files - `run_before_60-install-ai-cli-tools.sh.tmpl` among them. Setting a trap
+  there would silently discard the caller's. It also would not cover `SIGKILL` or
+  power loss, so the prune reclaim would still be needed.
+- Stage under a deterministic `.<category>.staging` name so the next write
+  truncates it: rejected because it drops the uniqueness `mktemp` provides
+  between concurrent writers, and a category that never fails again still leaks
+  the file forever.
+- Reclaim every dot-prefixed file regardless of age: rejected because it makes
+  a concurrent `tpod apply` able to delete a live write's staging file between
+  its `mktemp` and its `mv`, turning an unrelated prune into a lost warning.
+
+## Consequences
+
+- ADR 0014's rule that an implementation switching to `find` or `ls -a` must
+  reintroduce the dot-prefix exclusion still holds for the unrecognized-marker
+  loop, which keeps iterating `"$marker_dir"/*`. The reclaim is a second,
+  separately guarded loop over `"$marker_dir"/.*.??????`.
+- Reclaimed staging files are reported through the same channel as retired
+  markers, so `tpod apply` prints one line per reclaimed file.
+- A failed reclaim sets the prune exit status like any other failed removal, so
+  it prints a warning and does not change the exit status of `tpod apply`.
+- The staging file lifecycle is stated in the contract comment at the top of
+  `dot_local/lib/terrapod/install-warnings.sh`, which is what ADR 0014 left
+  unwritten.

--- a/dot_local/lib/terrapod/install-warnings.sh
+++ b/dot_local/lib/terrapod/install-warnings.sh
@@ -1,6 +1,35 @@
 #!/bin/sh
 
+# Terrapod install warning markers.
+#
+# The install warning directory is Terrapod-owned. Its only valid contents are
+# one regular file per current category, the legacy aliases Terrapod still
+# reads, and the staging files described below. Everything else is reclaimed by
+# `terrapod_install_warning_prune`.
+#
+# Staging file lifecycle:
+#
+#   1. `terrapod_install_warning_write` creates `.<category>.XXXXXX` with
+#      `mktemp`, fills it, and renames it over `<category>`. That rename is what
+#      makes a marker write atomic at the category file level.
+#   2. Between the `mktemp` and the `mv` the staging file is *in flight*. The
+#      prune glob `"$marker_dir"/*` cannot match a leading dot, so a concurrent
+#      prune leaves it alone.
+#   3. A write that dies inside that window - the installers this runs inside
+#      are routinely interrupted - leaves the staging file behind with no owner.
+#      `terrapod_install_warning_prune` reclaims dot-prefixed staging files that
+#      no `mv` can still be waiting on, meaning a modification time older than
+#      `TERRAPOD_INSTALL_WARNING_STAGING_MAX_AGE_DAYS` day. Younger ones stay,
+#      because a live write may still own them.
+#
+# No staging file therefore outlives the day it was created, and no in-flight
+# write can be pruned out from under itself.
+
 TERRAPOD_INSTALL_WARNINGS_LOADED=1
+
+# `find -mtime +N` selects modification times older than N + 1 days, so the
+# threshold below is expressed as the exclusive day count the reclaim uses.
+TERRAPOD_INSTALL_WARNING_STAGING_MAX_AGE_DAYS=1
 
 terrapod_install_warning_categories() {
   printf '%s\n' \
@@ -164,6 +193,12 @@ terrapod_install_warning_known_names() {
   done
 }
 
+terrapod_install_warning_staging_is_abandoned() {
+  staging_path="$1"
+
+  [ -n "$(find "$staging_path" -mtime "+$((TERRAPOD_INSTALL_WARNING_STAGING_MAX_AGE_DAYS - 1))" 2>/dev/null)" ]
+}
+
 terrapod_install_warning_prune() {
   marker_dir="$(terrapod_install_warning_dir)"
   [ -d "$marker_dir" ] || return 0
@@ -181,6 +216,18 @@ terrapod_install_warning_prune() {
 
     if rm -f "$marker_path"; then
       printf '%s\n' "$marker_name"
+    else
+      prune_status=1
+    fi
+  done
+
+  for staging_path in "$marker_dir"/.*.??????; do
+    [ -f "$staging_path" ] || continue
+    terrapod_install_warning_staging_is_abandoned "$staging_path" || continue
+
+    staging_name="${staging_path##*/}"
+    if rm -f "$staging_path"; then
+      printf '%s\n' "$staging_name"
     else
       prune_status=1
     fi

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -1230,6 +1230,43 @@ if [ "$prune_remaining_list" != "$expected_prune_remaining_list" ]; then
 fi
 pass "install warning marker prune leaves current and legacy categories readable"
 
+staging_prune_home="$tmp_dir/staging-prune-home"
+staging_prune_state="$tmp_dir/staging-prune-state"
+staging_prune_dir="$staging_prune_state/terrapod/install-warnings"
+mkdir -p "$staging_prune_home" "$staging_prune_dir"
+
+printf '%s\n' "category='homebrew-core'" >"$staging_prune_dir/homebrew-core"
+printf '%s\n' "category='homebrew-core'" >"$staging_prune_dir/.homebrew-core.fresh1"
+printf '%s\n' "category='mise-tools'" >"$staging_prune_dir/.mise-tools.aB3xY9"
+touch -t 202001010000 "$staging_prune_dir/.mise-tools.aB3xY9"
+
+staging_prune_removed="$(
+  HOME="$staging_prune_home" XDG_STATE_HOME="$staging_prune_state" sh -c '. "$1"; terrapod_install_warning_prune' sh "$install_warnings_lib"
+)"
+
+if [ "$staging_prune_removed" != ".mise-tools.aB3xY9" ]; then
+  printf '%s\n' "expected pruned names: .mise-tools.aB3xY9" >&2
+  printf '%s\n' "actual pruned names:" >&2
+  printf '%s\n' "$staging_prune_removed" | sed 's/^/  /' >&2
+  fail "install warning marker prune reports reclaimed staging files"
+fi
+pass "install warning marker prune reports reclaimed staging files"
+
+if [ -e "$staging_prune_dir/.mise-tools.aB3xY9" ]; then
+  fail "install warning marker prune reclaims abandoned mktemp staging files"
+fi
+pass "install warning marker prune reclaims abandoned mktemp staging files"
+
+if [ ! -f "$staging_prune_dir/.homebrew-core.fresh1" ]; then
+  fail "install warning marker prune keeps staging files a live write may still own"
+fi
+pass "install warning marker prune keeps staging files a live write may still own"
+
+if [ ! -f "$staging_prune_dir/homebrew-core" ]; then
+  fail "install warning marker prune keeps category marker files while reclaiming staging files"
+fi
+pass "install warning marker prune keeps category marker files while reclaiming staging files"
+
 prune_missing_state="$tmp_dir/prune-missing-state"
 if ! HOME="$prune_marker_home" XDG_STATE_HOME="$prune_missing_state" \
   sh -c '. "$1"; terrapod_install_warning_prune' sh "$install_warnings_lib" >"$tmp_dir/prune-missing.out"; then


### PR DESCRIPTION
Closes #164

## Problem

`terrapod_install_warning_write` stages `.<category>.XXXXXX` with `mktemp` and renames it over the category file. That rename is what makes a marker write atomic, but the process can die between the two — and these writes run inside installers users interrupt.

The leftover staging file is then unreachable. `terrapod_install_warning_prune` iterates `"$marker_dir"/*`, and a POSIX glob never expands `*` to a leading dot, so no code path in Terrapod could ever remove it. ADR 0014 recorded that exclusion deliberately, to protect in-flight writes, and the contract in `CONTEXT.md` names "in-flight staging files" as valid directory contents without saying when they stop being in flight.

The code matches the issue: `install-warnings.sh:126` stages, `:174` globs.

## Approach

The issue offered two directions. This takes the prune one.

`trap`-removing the temp inside `write` was rejected: `trap` in POSIX shell is process-global, and `terrapod_install_warning_write` is called from scripts that already install their own `EXIT` traps for downloaded files — `run_before_60-install-ai-cli-tools.sh.tmpl` among them. Setting a trap there would silently discard the caller's. It also would not cover `SIGKILL` or power loss, so the prune reclaim would still be needed on top of it.

Prune gains a second loop over `"$marker_dir"/.*.??????`, removing staging files older than a day:

```sh
terrapod_install_warning_staging_is_abandoned() {
  staging_path="$1"

  [ -n "$(find "$staging_path" -mtime "+$((TERRAPOD_INSTALL_WARNING_STAGING_MAX_AGE_DAYS - 1))" 2>/dev/null)" ]
}
```

Age is the whole discriminator. A `mktemp` and its `mv` are separated by four `printf`s, so a staging file that has survived a day has no live writer waiting on it. Younger files are still left alone, which is what stops a concurrent `tpod apply` from deleting a live write's staging file between its `mktemp` and its `mv`. The glob is a separate loop, so the unrecognized-marker loop keeps its `"$marker_dir"/*` form and ADR 0014's dot-prefix exclusion still holds there.

Reclaimed files are reported through the existing prune output channel, so `tpod apply` prints one line per reclaimed file and a failed reclaim sets the same non-zero prune status as any other failed removal.

The staging file lifecycle is now stated in a contract comment at the top of the library, and `CONTEXT.md` gains the vocabulary distinction between an in-flight and an abandoned staging file. ADR 0018 records the narrowing of ADR 0014's "dot-prefixed staging files survive" consequence.

## Tests

Four cases in `tests/terrapod_command_test.sh`, next to the existing prune scenario:

- prune reports the reclaimed staging file by name
- prune deletes a staging file backdated with `touch -t 202001010000`
- prune keeps a freshly written staging file, which a live write may still own
- prune leaves the category marker files alone while reclaiming

Red before the change, green after — reverting only `install-warnings.sh` fails `install warning marker prune reports reclaimed staging files`. The pre-existing `prune keeps in-flight mktemp staging files` case still passes, since its staging file is created fresh.

Suite results on this branch:

| suite | ok | not ok |
| --- | --- | --- |
| `terrapod_command_test.sh` | 226 | 1 (pre-existing) |
| `chezmoiignore_test.sh` | 328 | 0 |
| `terrapod_installer_test.sh` | 390 | 0 |
| `shell_integrations_test.sh` | 38 | 0 |
| `bootstrap_ubuntu_test.sh` | 31 | 0 |
| `terrapod_config_test.sh` | 393 | 0 |
| `readme_optional_stack_profiles_test.sh` | 111 | 0 |
| `readme_korean_test.sh` | 52 | 0 |
| `lazygit_pr_merge_test.sh` | 44 | 0 |
| remaining `*_test.sh` / `*_test.zsh` | all green | 0 |

Two failures are pre-existing and unrelated — both reproduce on a clean `origin/main` checkout on this machine:

- `terrapod_command_test.sh` — `Terrapod status reports installed Jetendard font files`
- `helper_resolution_test.sh` — `tpod status resolves the Jetendard font helper from the source checkout`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKu7yrNkZj6rtDDuF1kzVF