### PR TITLE
Guide recovery from a failed update and follow the running tpod

### DIFF
--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -1876,6 +1876,31 @@ run_update_preflight() {
   fi
 }
 
+# The refreshed command normally sits beside the running one, so a tpod
+# installed outside the default location hands off to itself; the default
+# install location stays the fallback for a tpod run straight from a checkout.
+resolve_refreshed_tpod() {
+  refreshed_tpod="$command_dir/tpod"
+  fallback_tpod="$HOME/.local/bin/tpod"
+
+  if [ "$fallback_tpod" = "$refreshed_tpod" ]; then
+    refreshed_tpod_locations="$refreshed_tpod"
+  else
+    refreshed_tpod_locations="$refreshed_tpod or $fallback_tpod"
+  fi
+
+  if [ -x "$refreshed_tpod" ]; then
+    return 0
+  fi
+
+  if [ -x "$fallback_tpod" ]; then
+    refreshed_tpod="$fallback_tpod"
+    return 0
+  fi
+
+  return 1
+}
+
 run_update() {
   if [ "$#" -ne 0 ]; then
     fail_usage "update accepts no arguments"
@@ -1884,13 +1909,17 @@ run_update() {
   config_file="$(chezmoi_config_file)"
   show_update_context
   run_update_preflight "$config_file"
-  run_chezmoi_command update --exclude scripts
 
-  installed_tpod="$HOME/.local/bin/tpod"
-  if [ ! -x "$installed_tpod" ]; then
-    fatal "refreshed tpod command is missing: $installed_tpod"
+  if ! run_chezmoi_command update --exclude scripts; then
+    printf '%s\n' "terrapod: chezmoi update failed; fix the error above, then rerun 'tpod update'." >&2
+    return 1
   fi
-  exec "$installed_tpod" apply
+
+  if ! resolve_refreshed_tpod; then
+    fatal "refreshed tpod command is missing: $refreshed_tpod_locations"
+  fi
+
+  exec "$refreshed_tpod" apply
 }
 
 render_settings_data() {

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -3010,6 +3010,107 @@ fi
 
 pass "Terrapod update rejects extra arguments before broad upgrade flows"
 
+update_sibling_bin="$tmp_dir/update-sibling-bin"
+mkdir -p "$update_sibling_bin"
+cp "$terrapod" "$update_sibling_bin/terrapod"
+chmod +x "$update_sibling_bin/terrapod"
+update_sibling_handoff_file="$tmp_dir/update-sibling-handoff.args"
+write_stub "$update_sibling_bin/tpod" \
+  'printf "%s\n" "$*" >"'"$update_sibling_handoff_file"'"' \
+  'exit 0'
+
+: >"$update_handoff_file"
+rm -f "$CHEZMOI_CALL_FILE" "$CHEZMOI_INVOKED_FILE"
+
+if ! HOME="$update_home" XDG_CONFIG_HOME="$update_xdg" PATH="$tmp_dir/bin:/usr/bin:/bin" \
+  sh "$update_sibling_bin/terrapod" update >"$tmp_dir/update-sibling.out" 2>"$tmp_dir/update-sibling.err"; then
+  printf '%s\n' "sibling update stdout:" >&2
+  sed 's/^/  /' "$tmp_dir/update-sibling.out" >&2
+  printf '%s\n' "sibling update stderr:" >&2
+  sed 's/^/  /' "$tmp_dir/update-sibling.err" >&2
+  fail "Terrapod update runs successfully from a non-default install location"
+fi
+
+assert_line "$(cat "$update_sibling_handoff_file")" "apply" "Terrapod update hands off to the tpod beside the running command"
+
+if [ -s "$update_handoff_file" ]; then
+  fail "Terrapod update does not hand off to the default install location when a sibling tpod exists"
+fi
+
+pass "Terrapod update does not hand off to the default install location when a sibling tpod exists"
+
+update_missing_home="$tmp_dir/update-missing-home"
+update_missing_xdg="$tmp_dir/update-missing-xdg"
+update_missing_config="$update_missing_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$update_missing_home" "$(dirname "$update_missing_config")"
+cp "$update_config" "$update_missing_config"
+
+rm -f "$CHEZMOI_CALL_FILE" "$CHEZMOI_INVOKED_FILE"
+
+if HOME="$update_missing_home" XDG_CONFIG_HOME="$update_missing_xdg" PATH="$tmp_dir/bin:/usr/bin:/bin" \
+  sh "$terrapod" update >"$tmp_dir/update-missing.out" 2>"$tmp_dir/update-missing.err"; then
+  fail "Terrapod update fails when no refreshed tpod command exists"
+fi
+
+pass "Terrapod update fails when no refreshed tpod command exists"
+
+update_missing_error="$(cat "$tmp_dir/update-missing.err")"
+
+assert_contains \
+  "$update_missing_error" \
+  "refreshed tpod command is missing: $(dirname "$terrapod")/tpod or $update_missing_home/.local/bin/tpod" \
+  "Terrapod update names both places it looked for the refreshed tpod command"
+
+update_fail_home="$tmp_dir/update-fail-home"
+update_fail_xdg="$tmp_dir/update-fail-xdg"
+update_fail_config="$update_fail_xdg/chezmoi/chezmoi.toml"
+mkdir -p "$update_fail_home/.local/bin" "$(dirname "$update_fail_config")"
+cp "$update_config" "$update_fail_config"
+update_fail_handoff_file="$tmp_dir/update-fail-handoff.args"
+write_stub "$update_fail_home/.local/bin/tpod" \
+  'printf "%s\n" "$*" >"'"$update_fail_handoff_file"'"' \
+  'exit 0'
+
+rm -f "$CHEZMOI_CALL_FILE" "$CHEZMOI_INVOKED_FILE"
+
+write_stub "$tmp_dir/bin/chezmoi" \
+  'printf "%s\n" invoked >"$CHEZMOI_INVOKED_FILE"' \
+  'printf "%s\n" "chezmoi: source state update failed" >&2' \
+  'exit 1'
+
+if HOME="$update_fail_home" XDG_CONFIG_HOME="$update_fail_xdg" PATH="$tmp_dir/bin:/usr/bin:/bin" \
+  sh "$terrapod" update >"$tmp_dir/update-failed.out" 2>"$tmp_dir/update-failed.err"; then
+  fail "Terrapod update fails when chezmoi update fails"
+fi
+
+pass "Terrapod update fails when chezmoi update fails"
+
+update_failed_error="$(cat "$tmp_dir/update-failed.err")"
+
+assert_contains \
+  "$update_failed_error" \
+  "chezmoi: source state update failed" \
+  "Terrapod update keeps the chezmoi error visible"
+
+assert_contains \
+  "$update_failed_error" \
+  "terrapod: chezmoi update failed; fix the error above, then rerun 'tpod update'." \
+  "Terrapod update guides recovery after a failed source update"
+
+if [ -e "$update_fail_handoff_file" ]; then
+  fail "Terrapod update does not hand off to apply after a failed source update"
+fi
+
+pass "Terrapod update does not hand off to apply after a failed source update"
+
+write_stub "$tmp_dir/bin/chezmoi" \
+  'printf "%s\n" invoked >"$CHEZMOI_INVOKED_FILE"' \
+  ': >"$CHEZMOI_CALL_FILE"' \
+  'for arg do' \
+  '  printf "%s\n" "$arg" >>"$CHEZMOI_CALL_FILE"' \
+  'done' \
+  'exit 0'
+
 export CHEZMOI_CALL_FILE="$tmp_dir/chezmoi-diff.args"
 export CHEZMOI_INVOKED_FILE="$tmp_dir/chezmoi-diff.invoked"
 


### PR DESCRIPTION
Closes #161

Stacked on #196 (`juty9026/issue-160-configure-assume-yes`).

## Problem

Two things in `run_update`:

1. `run_chezmoi_command update --exclude scripts` ran bare. Under `set -e` a failure ended the command with only chezmoi's raw output, while `run_apply` prints `chezmoi apply failed; fix the error above, then rerun 'tpod apply'.` for the same class of failure.
2. `installed_tpod="$HOME/.local/bin/tpod"` ignored `$command_dir`. A tpod installed anywhere else refreshed its source and then fataled with "refreshed tpod command is missing" instead of re-execing itself.

## Change

- The source update now reports `terrapod: chezmoi update failed; fix the error above, then rerun 'tpod update'.` and returns 1, matching the apply pattern. chezmoi's own error stays visible above it, and no handoff happens.
- `resolve_refreshed_tpod` looks for `$command_dir/tpod` first and falls back to `$HOME/.local/bin/tpod`, so a tpod installed outside the default location hands off to itself and one run straight from a checkout still finds the installed command.
- When neither exists, the failure names both places it looked (and just the one when they are the same path).

## Note on the issue text

The issue points at `dot_local/bin/executable_terrapod:1811-1826`; on `main` `run_update` is at 1879-1894 and the apply guidance it cites (`:1527-1531`) is at 1580-1584. The behavior matches the description.

## Tests

New coverage in `tests/terrapod_command_test.sh`:

- update run from a non-default install location hands off to the sibling `tpod`, and does not touch the one under `$HOME/.local/bin`
- update with no `tpod` in either place fails and names both paths
- update with a failing `chezmoi` keeps chezmoi's error, adds the rerun guidance, and does not hand off to apply

```
$ sh tests/terrapod_command_test.sh   -> 519 ok, exit 0
$ sh tests/terrapod_config_test.sh    -> 418 ok, exit 0
```

The command suite needs a real `python3` on `PATH` for its Jetendard assertions; a mise shim that cannot resolve fails them independently of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKu7yrNkZj6rtDDuF1kzVF