### PR TITLE
Authenticate, retry, and categorize the Jetendard release fetch

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -39,6 +39,7 @@ tests/**
 .chezmoiscripts/65-install-jetendard-font.sh
 .chezmoiscripts/70-apply-jetendard-settings.sh
 .local/lib/terrapod/jetendard-font
+.local/lib/terrapod/jetendard-font-status.sh
 .local/lib/terrapod/jetendard-settings
 .config/ghostty
 .config/ghostty/**

--- a/.chezmoiscripts/run_before_02-retry-jetendard-font.sh.tmpl
+++ b/.chezmoiscripts/run_before_02-retry-jetendard-font.sh.tmpl
@@ -4,20 +4,29 @@ set -eu
 
 {{ include "dot_local/lib/terrapod/install-warnings.sh" }}
 
+{{ include "dot_local/lib/terrapod/jetendard-font-status.sh" }}
+
 font_helper="{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/executable_jetendard-font"
 
 if ! terrapod_install_warning_existing_path jetendard-font >/dev/null 2>&1; then
   exit 0
 fi
 
-if command -v python3 >/dev/null 2>&1 && python3 "$font_helper" install; then
-  terrapod_install_warning_clear jetendard-font || exit 1
-  exit 0
+if command -v python3 >/dev/null 2>&1; then
+  if python3 "$font_helper" install; then
+    terrapod_install_warning_clear jetendard-font || exit 1
+    exit 0
+  else
+    # The helper's exit status names the failure; anything else is generic.
+    font_status=$?
+  fi
+else
+  font_status=127
 fi
 
 terrapod_install_warning_write \
   jetendard-font \
   "Jetendard font install needs attention" \
-  "Restore Python and GitHub access, then rerun tpod apply." || exit 1
+  "$(terrapod_jetendard_font_guidance "$font_status")" || exit 1
 exit 0
 {{- end }}

--- a/.chezmoiscripts/run_onchange_after_65-install-jetendard-font.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_65-install-jetendard-font.sh.tmpl
@@ -2,22 +2,31 @@
 #!/bin/sh
 set -eu
 
-# Sourced by path rather than inlined: inlining would put this library into the
-# run_onchange_ content hash, re-downloading the font on every library edit.
+# Sourced by path rather than inlined: inlining would put these libraries into
+# the run_onchange_ content hash, re-downloading the font on every library edit.
 warnings_lib="{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/install-warnings.sh"
+status_lib="{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/jetendard-font-status.sh"
 font_helper="{{ .chezmoi.sourceDir }}/dot_local/lib/terrapod/executable_jetendard-font"
 # Jetendard font helper checksum: {{ include "dot_local/lib/terrapod/executable_jetendard-font" | sha256sum }}
 . "$warnings_lib"
+. "$status_lib"
 
-if command -v python3 >/dev/null 2>&1 && python3 "$font_helper" install; then
-  terrapod_install_warning_clear jetendard-font || exit 1
-  printf '%s\n' "Jetendard is ready. Restart Ghostty or Zed if an existing window still uses a cached font."
-  exit 0
+if command -v python3 >/dev/null 2>&1; then
+  if python3 "$font_helper" install; then
+    terrapod_install_warning_clear jetendard-font || exit 1
+    printf '%s\n' "Jetendard is ready. Restart Ghostty or Zed if an existing window still uses a cached font."
+    exit 0
+  else
+    # The helper's exit status names the failure; anything else is generic.
+    font_status=$?
+  fi
+else
+  font_status=127
 fi
 
 terrapod_install_warning_write \
   jetendard-font \
   "Jetendard font install needs attention" \
-  "Restore Python and GitHub access, then rerun tpod apply." || exit 1
+  "$(terrapod_jetendard_font_guidance "$font_status")" || exit 1
 exit 0
 {{- end }}

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -300,6 +300,8 @@ _Avoid_: separate Korean introduction, independent README, self-labeled translat
 - The **macOS Terminal Profile** installs every TTF from the latest stable `kuskhan/jetendard` GitHub release and verifies the asset digest published by GitHub instead of using a Homebrew font cask.
 - The Jetendard installer queries GitHub only when its managed source changes or a failed installation is retried; ordinary `tpod status` and `tpod doctor` checks remain offline, and an upstream release alone does not trigger an upgrade.
 - Jetendard installation records its tag, digest, and owned font files in a user-scoped manifest, and cleanup removes only obsolete files named by that manifest after a successful replacement.
+- The Jetendard release lookup sends `Authorization: Bearer $GITHUB_TOKEN` when that variable is set and retries transient failures up to three times with exponential backoff; a GitHub API rate limit is reported rather than retried.
+- A failed Jetendard install distinguishes a GitHub API rate limit, an unreachable GitHub, and an unusable release from every other failure, and its install warning marker carries guidance specific to that category — the rate-limit guidance names `GITHUB_TOKEN`, matching the mise/aqua guidance.
 - Jetendard app-setting management changes only font-family keys for Ghostty, Zed buffers and terminals, and initialized Orca terminal profiles; other app settings remain outside Terrapod ownership.
 - Jetendard settings for Orca are deferred while Orca is running and require quitting Orca before rerunning `tpod apply`.
 - The **VPS Shell Profile** excludes the Jetendard installer, app-setting adapter, status, and doctor checks.

--- a/dot_local/lib/terrapod/executable_jetendard-font
+++ b/dot_local/lib/terrapod/executable_jetendard-font
@@ -9,13 +9,53 @@ import re
 import secrets
 import shutil
 import stat
+import sys
 import tempfile
+import time
+import urllib.error
 import urllib.request
 import zipfile
 
 RELEASE_API_URL = "https://api.github.com/repos/kuskhan/jetendard/releases/latest"
 ASSET_NAME = "Jetendard-TTF.zip"
 FONT_NAME = re.compile(r"Jetendard-[A-Za-z0-9]+\.ttf\Z")
+USER_AGENT = "terrapod-jetendard"
+RETRY_ATTEMPTS = 3
+RETRY_BACKOFF_SECONDS = 2.0
+
+# Exit codes the shell wrappers branch on to pick failure-specific guidance.
+EXIT_FAILURE = 1
+EXIT_RATE_LIMIT = 2
+EXIT_NETWORK = 3
+EXIT_INVALID_RELEASE = 4
+
+
+class HelperError(Exception):
+    """A failure whose category the caller can act on.
+
+    ``marker`` is printed in brackets on the single stderr line and
+    ``exit_code`` is returned by ``main``; the shell wrapper reads either one.
+    """
+
+    marker = ""
+    exit_code = EXIT_FAILURE
+
+
+class RateLimitError(HelperError):
+    marker = "rate-limit"
+    exit_code = EXIT_RATE_LIMIT
+
+
+class NetworkError(HelperError):
+    marker = "network"
+    exit_code = EXIT_NETWORK
+
+
+# Also a ValueError: the release-shape checks below raised ValueError before
+# they were categorized, and callers still catch that.
+class InvalidReleaseError(HelperError, ValueError):
+    marker = "invalid-release"
+    exit_code = EXIT_INVALID_RELEASE
 
 
 class ArgumentParser(argparse.ArgumentParser):
@@ -36,32 +76,72 @@ def manifest_path(home: Path, state_home: str | None = None) -> Path:
     return state_root(home, state_home) / "manifest.json"
 
 
+def is_rate_limited(error: urllib.error.HTTPError) -> bool:
+    if error.code == 429:
+        return True
+    if error.code != 403:
+        return False
+    headers = getattr(error, "headers", None)
+    remaining = headers.get("X-RateLimit-Remaining") if headers is not None else None
+    return isinstance(remaining, str) and remaining.strip() == "0"
+
+
+def open_url(url: str, headers: dict[str, str], timeout: int):
+    """Open ``url``, retrying transient failures with exponential backoff.
+
+    A rate limit is never retried: the quota resets on GitHub's clock, not
+    within the seconds an apply can wait.
+    """
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            return urllib.request.urlopen(urllib.request.Request(url, headers=headers), timeout=timeout)
+        except urllib.error.HTTPError as error:
+            if is_rate_limited(error):
+                raise RateLimitError(f"GitHub API rate limit reached for {url} (HTTP {error.code})") from error
+            if error.code < 500 or attempt >= RETRY_ATTEMPTS:
+                raise NetworkError(f"GitHub returned HTTP {error.code} for {url}") from error
+        except (urllib.error.URLError, TimeoutError, OSError) as error:
+            if attempt >= RETRY_ATTEMPTS:
+                raise NetworkError(f"could not reach {url} in {attempt} attempts: {error}") from error
+        time.sleep(RETRY_BACKOFF_SECONDS * (2 ** (attempt - 1)))
+
+
 def load_json_url(url: str) -> dict:
-    request = urllib.request.Request(url, headers={"Accept": "application/vnd.github+json", "User-Agent": "terrapod-jetendard"})
-    with urllib.request.urlopen(request, timeout=30) as response:
-        return json.load(response)
+    headers = {"Accept": "application/vnd.github+json", "User-Agent": USER_AGENT}
+    # Only the release lookup is authenticated. browser_download_url redirects
+    # to an asset CDN, and urllib replays request headers across the redirect,
+    # so a token attached to the download would leave GitHub.
+    token = os.environ.get("GITHUB_TOKEN", "").strip()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    with open_url(url, headers, 30) as response:
+        try:
+            return json.load(response)
+        except ValueError as error:
+            raise InvalidReleaseError(f"GitHub release response is not valid JSON: {error}") from error
 
 
 def select_asset(release: dict) -> tuple[str, str, str]:
     if release.get("draft") or release.get("prerelease"):
-        raise ValueError("latest GitHub release is not a stable published release")
+        raise InvalidReleaseError("latest GitHub release is not a stable published release")
     tag = release.get("tag_name")
     assets = [asset for asset in release.get("assets", []) if asset.get("name") == ASSET_NAME and asset.get("state") == "uploaded"]
     if not isinstance(tag, str) or not tag or len(assets) != 1:
-        raise ValueError("latest GitHub release must contain one uploaded Jetendard-TTF.zip asset")
+        raise InvalidReleaseError("latest GitHub release must contain one uploaded Jetendard-TTF.zip asset")
     asset = assets[0]
     digest = asset.get("digest")
     url = asset.get("browser_download_url")
     if not isinstance(digest, str) or not re.fullmatch(r"sha256:[0-9a-fA-F]{64}", digest):
-        raise ValueError("Jetendard-TTF.zip does not publish a SHA-256 digest")
+        raise InvalidReleaseError("Jetendard-TTF.zip does not publish a SHA-256 digest")
     if not isinstance(url, str) or not url:
-        raise ValueError("Jetendard-TTF.zip does not publish a download URL")
+        raise InvalidReleaseError("Jetendard-TTF.zip does not publish a download URL")
     return tag, digest.lower(), url
 
 
 def download(url: str, destination: Path) -> None:
-    request = urllib.request.Request(url, headers={"User-Agent": "terrapod-jetendard"})
-    with urllib.request.urlopen(request, timeout=60) as response, destination.open("wb") as output:
+    with open_url(url, {"User-Agent": USER_AGENT}, 60) as response, destination.open("wb") as output:
         shutil.copyfileobj(response, output)
 
 
@@ -83,10 +163,10 @@ def font_entries(archive: zipfile.ZipFile) -> dict[str, zipfile.ZipInfo]:
         if not FONT_NAME.fullmatch(basename):
             continue
         if basename in selected:
-            raise ValueError(f"release archive contains duplicate font: {basename}")
+            raise InvalidReleaseError(f"release archive contains duplicate font: {basename}")
         selected[basename] = info
     if not selected:
-        raise ValueError("release archive contains no Jetendard TTF files")
+        raise InvalidReleaseError("release archive contains no Jetendard TTF files")
     return selected
 
 
@@ -240,16 +320,19 @@ def install(home: Path) -> None:
         download(asset_url, archive_path)
         actual_digest = sha256(archive_path)
         if actual_digest != digest:
-            raise ValueError(f"Jetendard archive digest mismatch: expected {digest}, got {actual_digest}")
-        with zipfile.ZipFile(archive_path) as archive:
-            entries = font_entries(archive)
-            staged = Path(temporary) / "fonts"
-            staged.mkdir()
-            for basename, info in entries.items():
-                destination = staged / basename
-                with archive.open(info) as source, destination.open("wb") as output:
-                    shutil.copyfileobj(source, output)
-                destination.chmod(0o644)
+            raise InvalidReleaseError(f"Jetendard archive digest mismatch: expected {digest}, got {actual_digest}")
+        try:
+            with zipfile.ZipFile(archive_path) as archive:
+                entries = font_entries(archive)
+                staged = Path(temporary) / "fonts"
+                staged.mkdir()
+                for basename, info in entries.items():
+                    destination = staged / basename
+                    with archive.open(info) as source, destination.open("wb") as output:
+                        shutil.copyfileobj(source, output)
+                    destination.chmod(0o644)
+        except zipfile.BadZipFile as error:
+            raise InvalidReleaseError(f"Jetendard release archive is not a readable zip: {error}") from error
         new_files = sorted(entries)
         old_files = list(old.get("files", []))
         touched = sorted(set(old_files) | set(new_files))
@@ -335,8 +418,10 @@ def main() -> int:
         else:
             check(Path(args.home or os.environ.get("HOME", str(Path.home()))), args.state_home)
     except Exception as error:
-        print(f"Jetendard font: {error}", file=__import__("sys").stderr)
-        return 1
+        marker = getattr(error, "marker", "")
+        label = f"[{marker}] " if marker else ""
+        print(f"Jetendard font: {label}{error}", file=sys.stderr)
+        return getattr(error, "exit_code", EXIT_FAILURE)
     return 0
 
 

--- a/dot_local/lib/terrapod/jetendard-font-status.sh
+++ b/dot_local/lib/terrapod/jetendard-font-status.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# Maps an executable_jetendard-font exit status to install warning guidance.
+# The helper exits 2 for a GitHub API rate limit, 3 for an unreachable GitHub,
+# and 4 for a release it cannot use; every other non-zero status keeps the
+# generic guidance. Both the install and the retry wrapper read this, so the
+# two markers cannot drift apart.
+
+terrapod_jetendard_font_guidance() {
+  case "$1" in
+    2)
+      printf '%s\n' "GitHub API rate limit reached while resolving the Jetendard release. Export a temporary GITHUB_TOKEN or run gh auth login, then rerun tpod apply."
+      ;;
+    3)
+      printf '%s\n' "GitHub was unreachable while resolving the Jetendard release. Restore network access, then rerun tpod apply."
+      ;;
+    4)
+      printf '%s\n' "The latest Jetendard GitHub release is not installable. Wait for a corrected upstream release, then rerun tpod apply."
+      ;;
+    *)
+      printf '%s\n' "Restore Python and GitHub access, then rerun tpod apply."
+      ;;
+  esac
+}

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -241,6 +241,7 @@ macos_only_entries="
 .chezmoiscripts/run_onchange_after_65-install-jetendard-font.sh.tmpl
 dot_local/lib/terrapod/executable_jetendard-font
 dot_local/lib/terrapod/executable_jetendard-settings
+dot_local/lib/terrapod/jetendard-font-status.sh
 dot_config/ghostty
 dot_config/private_karabiner
 dot_hammerspoon
@@ -406,6 +407,7 @@ terrapod_install_warning_clear() {
 }
 terrapod_install_warning_write() {
   printf '%s\n' write >>"$JETENDARD_ADAPTER_LOG"
+  printf '%s\n' "$3" >"$JETENDARD_ADAPTER_LOG.guidance"
   return 0
 }
 SH
@@ -414,6 +416,7 @@ import os
 from pathlib import Path
 with Path(os.environ["JETENDARD_ADAPTER_LOG"]).open("a") as stream:
     stream.write("helper\n")
+raise SystemExit(int(os.environ.get("JETENDARD_HELPER_EXIT", "0")))
 PY
 
 # The adapters inline install-warnings.sh, so the stub is appended after the
@@ -457,6 +460,44 @@ assert_text_equals "$(cat "$jetendard_adapter_log")" 'marker-check
 helper
 clear' \
   "Jetendard retry checks the marker before install and clear"
+
+# The helper exit status, not its message, is what the wrappers branch on:
+# 2 rate limit, 3 unreachable GitHub, 4 unusable release, anything else generic.
+assert_jetendard_guidance() {
+  adapter="$1"
+  helper_exit="$2"
+  expected="$3"
+  label="$4"
+
+  : >"$jetendard_adapter_log"
+  rm -f "$jetendard_adapter_log.guidance"
+  JETENDARD_ADAPTER_LOG="$jetendard_adapter_log" \
+    JETENDARD_MARKER_EXISTS=1 \
+    JETENDARD_CLEAR_FAIL=0 \
+    JETENDARD_HELPER_EXIT="$helper_exit" \
+    sh "$adapter" >/dev/null 2>&1 ||
+    fail "$label (adapter exited non-zero)"
+
+  assert_text_equals "$(cat "$jetendard_adapter_log.guidance")" "$expected" "$label"
+}
+
+for adapter in "$jetendard_installer_fixture" "$jetendard_retry_fixture"; do
+  assert_jetendard_guidance "$adapter" 2 \
+    "GitHub API rate limit reached while resolving the Jetendard release. Export a temporary GITHUB_TOKEN or run gh auth login, then rerun tpod apply." \
+    "Jetendard adapter offers GITHUB_TOKEN guidance on a rate limit: $adapter"
+
+  assert_jetendard_guidance "$adapter" 3 \
+    "GitHub was unreachable while resolving the Jetendard release. Restore network access, then rerun tpod apply." \
+    "Jetendard adapter offers network guidance on an unreachable GitHub: $adapter"
+
+  assert_jetendard_guidance "$adapter" 4 \
+    "The latest Jetendard GitHub release is not installable. Wait for a corrected upstream release, then rerun tpod apply." \
+    "Jetendard adapter offers release guidance on an unusable release: $adapter"
+
+  assert_jetendard_guidance "$adapter" 1 \
+    "Restore Python and GitHub access, then rerun tpod apply." \
+    "Jetendard adapter keeps the generic guidance for an uncategorized failure: $adapter"
+done
 
 jetendard_no_python_bin="$tmp_dir/jetendard-no-python-bin"
 mkdir -p "$jetendard_no_python_bin"

--- a/tests/jetendard_font_test.sh
+++ b/tests/jetendard_font_test.sh
@@ -602,3 +602,167 @@ assert_snapshot(home, state, before)
 PY
 pass "installer rolls back failures and preserves backups when restore fails"
 pass "recovery cleanup failures never change the reported install outcome"
+
+python3 - "$helper" "$tmp_dir" <<'FETCH'
+import contextlib
+import email.message
+import importlib.machinery
+import importlib.util
+import io
+import json
+import os
+from pathlib import Path
+import sys
+import urllib.error
+
+helper_path, temp_arg = sys.argv[1:]
+loader = importlib.machinery.SourceFileLoader("jetendard_font_fetch", helper_path)
+spec = importlib.util.spec_from_loader(loader.name, loader)
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+temp = Path(temp_arg)
+
+API_URL = "https://api.github.com/repos/kuskhan/jetendard/releases/latest"
+RELEASE = json.dumps({
+    "tag_name": "v1.2.3",
+    "draft": False,
+    "prerelease": False,
+    "assets": [],
+}).encode("utf-8")
+
+requests = []
+sleeps = []
+module.time.sleep = lambda seconds: sleeps.append(seconds)
+
+
+class FakeResponse(io.BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *details):
+        return False
+
+
+def rate_limit_error(remaining):
+    headers = email.message.Message()
+    headers["X-RateLimit-Remaining"] = remaining
+    return urllib.error.HTTPError(API_URL, 403, "rate limit exceeded", headers, None)
+
+
+def server_error():
+    return urllib.error.HTTPError(API_URL, 502, "bad gateway", email.message.Message(), None)
+
+
+def arrange(*items):
+    queue = list(items)
+    requests.clear()
+    sleeps.clear()
+
+    def fake_urlopen(request, timeout=None):
+        requests.append(request)
+        item = queue.pop(0)
+        if isinstance(item, BaseException):
+            raise item
+        return FakeResponse(item)
+
+    module.urllib.request.urlopen = fake_urlopen
+
+
+os.environ["GITHUB_TOKEN"] = "secret-token"
+arrange(RELEASE)
+assert module.load_json_url(API_URL)["tag_name"] == "v1.2.3"
+assert requests[0].get_header("Authorization") == "Bearer secret-token"
+assert requests[0].get_header("User-agent") == "terrapod-jetendard"
+
+os.environ["GITHUB_TOKEN"] = "   "
+arrange(RELEASE)
+module.load_json_url(API_URL)
+assert requests[0].get_header("Authorization") is None
+
+os.environ.pop("GITHUB_TOKEN")
+arrange(RELEASE)
+module.load_json_url(API_URL)
+assert requests[0].get_header("Authorization") is None
+
+arrange(urllib.error.URLError("connection reset"), server_error(), RELEASE)
+assert module.load_json_url(API_URL)["tag_name"] == "v1.2.3"
+assert len(requests) == 3
+assert sleeps == [2.0, 4.0]
+
+arrange(*[urllib.error.URLError("connection reset")] * 3)
+try:
+    module.load_json_url(API_URL)
+except module.NetworkError as error:
+    assert error.marker == "network" and error.exit_code == 3
+else:
+    raise AssertionError("exhausted retries did not raise NetworkError")
+assert len(requests) == module.RETRY_ATTEMPTS == 3
+assert sleeps == [2.0, 4.0]
+
+arrange(rate_limit_error("0"))
+try:
+    module.load_json_url(API_URL)
+except module.RateLimitError as error:
+    assert error.marker == "rate-limit" and error.exit_code == 2
+else:
+    raise AssertionError("a rate limit did not raise RateLimitError")
+assert len(requests) == 1 and sleeps == []
+
+arrange(rate_limit_error("57"))
+try:
+    module.load_json_url(API_URL)
+except module.RateLimitError:
+    raise AssertionError("a 403 with quota left was reported as a rate limit")
+except module.NetworkError as error:
+    assert error.exit_code == 3
+assert len(requests) == 1 and sleeps == []
+
+arrange(b"<html>not json</html>")
+try:
+    module.load_json_url(API_URL)
+except module.InvalidReleaseError as error:
+    assert error.marker == "invalid-release" and error.exit_code == 4
+    assert isinstance(error, ValueError)
+else:
+    raise AssertionError("a non-JSON response did not raise InvalidReleaseError")
+
+
+def cli_install(items):
+    arrange(*items)
+    old_argv = sys.argv
+    old_home = os.environ.get("HOME")
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    sys.argv = [helper_path, "install"]
+    os.environ["HOME"] = str(temp / "fetch-home")
+    os.environ["TERRAPOD_JETENDARD_RELEASE_API_URL"] = API_URL
+    try:
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            result = module.main()
+    finally:
+        sys.argv = old_argv
+        if old_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = old_home
+    return result, stdout.getvalue(), stderr.getvalue()
+
+
+result, stdout, stderr = cli_install([rate_limit_error("0")])
+assert result == 2 and not stdout, (result, stdout)
+assert stderr.count("\n") == 1
+assert stderr.startswith("Jetendard font: [rate-limit] "), stderr
+
+result, stdout, stderr = cli_install([urllib.error.URLError("connection reset")] * 3)
+assert result == 3 and not stdout
+assert stderr.count("\n") == 1
+assert stderr.startswith("Jetendard font: [network] "), stderr
+
+prerelease = json.dumps({"tag_name": "v1.2.4", "draft": False, "prerelease": True, "assets": []}).encode("utf-8")
+result, stdout, stderr = cli_install([prerelease])
+assert result == 4 and not stdout
+assert stderr.count("\n") == 1
+assert stderr.startswith("Jetendard font: [invalid-release] "), stderr
+FETCH
+pass "release lookup authenticates, retries, and categorizes its failures"


### PR DESCRIPTION
Closes #163

## Problem

`load_json_url` built its request with only `Accept` and `User-Agent`, so
the Jetendard release lookup ran on GitHub's 60-request/hour
unauthenticated quota — deterministic failure behind a NAT or on CI.
There was no retry, and no failure was distinguishable from any other:
both wrappers wrote the same guidance,

```
Restore Python and GitHub access, then rerun tpod apply.
```

for a rate limit, an unreachable host, and a malformed release alike.
`run_after_20:61` already tells the user to export `GITHUB_TOKEN` for
the analogous mise/aqua case, so the vocabulary existed; the font
installer just had no way to reach it.

The code matched the issue's description.

## Approach

**The helper categorizes, the wrapper phrases.** `HelperError` carries a
`marker` and an `exit_code`; `RateLimitError` (2), `NetworkError` (3),
and `InvalidReleaseError` (4) subclass it, and `main` prints
`Jetendard font: [rate-limit] …` on the same single stderr line the
existing contract requires and returns the code. Everything uncategorized
keeps exit 1 and the unbracketed message, so the argparse contract case
is untouched.

`InvalidReleaseError` also subclasses `ValueError`: the release-shape
checks in `select_asset` and `font_entries` raised `ValueError` before
they were categorized, and the test suite catches that type.
`zipfile.BadZipFile` from a corrupt archive is wrapped into it too, so
"the published release cannot be used" is one category rather than
three.

**`open_url` is the single fetch path**, shared by `load_json_url` and
`download`. It retries up to `RETRY_ATTEMPTS` (3) on network errors and
5xx, sleeping `2s` then `4s`. A rate limit is *not* retried — the quota
resets on GitHub's clock, not within the seconds an apply can wait — and
neither is any other 4xx. `is_rate_limited` treats 429 as a rate limit
outright and 403 only when `X-RateLimit-Remaining` is `0`, so a 403 for
a private/deleted repository still reads as a network-class HTTP error.

**Only the release lookup is authenticated.** `browser_download_url`
redirects to an asset CDN and urllib replays request headers across
redirects, so a token attached to `download` would leave GitHub. A
whitespace-only `GITHUB_TOKEN` is treated as unset.

**Guidance lives in one place.** `dot_local/lib/terrapod/jetendard-font-status.sh`
maps the exit status to its warning line. `run_onchange_after_65` sources
it by path (same reason it already path-sources `install-warnings.sh`:
inlining would put it in the content hash and re-download the font on
every edit) and `run_before_02` inlines it with `{{ include }}`, matching
the three loading rules ADR 0016 set. One copy means the install and
retry markers cannot drift — the failure mode PR #194 was written to
remove. The file is macOS-only, so it joins the other Jetendard entries
in `.chezmoiignore` and in the `macos_only_entries` list.

Both wrappers now read the status in an `else` branch:

```sh
if python3 "$font_helper" install; then
  …
  exit 0
else
  font_status=$?
fi
```

and a missing `python3` maps to 127, which falls through to the generic
guidance — the behaviour it had before.

No ADR: ADR 0009's decisions (latest stable release, digest
verification, no continuous upgrade channel) are all unchanged. Two
CONTEXT.md invariants record the authenticated, bounded-retry lookup and
the per-category guidance.

## Tests

`tests/jetendard_font_test.sh` gains a block that stubs
`urllib.request.urlopen` and `time.sleep` so the fetch policy is
observable without a network:

- the `Authorization: Bearer` header is present with a token, absent
  without one, and absent for a whitespace-only token;
- a `URLError` then a 502 then success takes 3 requests and sleeps
  `[2.0, 4.0]`;
- three `URLError`s raise `NetworkError` after exactly
  `RETRY_ATTEMPTS` requests;
- a 403 with `X-RateLimit-Remaining: 0` raises `RateLimitError` with
  **one** request and no sleep, while a 403 with quota left is a
  `NetworkError`;
- a non-JSON body raises `InvalidReleaseError`, which is a `ValueError`;
- and end to end through `main`: exit 2/3/4 with
  `Jetendard font: [rate-limit|network|invalid-release] …` on one stderr
  line and no stdout.

Red-checked: deleting the two-line token block fails the first
assertion.

`tests/chezmoiignore_test.sh` extends the Jetendard adapter fixture. The
helper stub now exits with `$JETENDARD_HELPER_EXIT` and the warning stub
records the guidance argument, so eight new cases assert that both the
installer and the retry wrapper turn exit 2/3/4/1 into the four
guidance lines. The rate-limit line names `GITHUB_TOKEN`.

```
PASS tests/bootstrap_ubuntu_test.sh (31)
PASS tests/chezmoiignore_test.sh (336)
PASS tests/executable_selection_test.sh (47)
PASS tests/ghostty_config_test.sh (2)
PASS tests/git_config_test.sh (21)
PASS tests/hammerspoon_config_test.sh (10)
PASS tests/helper_resolution_test.sh (4)
PASS tests/homebrew_manifests_test.sh (8)
PASS tests/jetendard_font_test.sh (10)
PASS tests/jetendard_settings_test.sh (8)
PASS tests/karabiner_config_test.sh (9)
PASS tests/lazygit_pr_merge_test.sh (44)
PASS tests/readme_korean_test.sh (52)
PASS tests/readme_optional_stack_profiles_test.sh (111)
PASS tests/shell_integrations_test.sh (38)
PASS tests/terrapod_command_test.sh (508)
PASS tests/terrapod_config_test.sh (393)
PASS tests/terrapod_installer_test.sh (390)
PASS tests/zshenv_local_bin_test.sh (17)
PASS tests/zshrc_clear_test.zsh (10)
PASS tests/zshrc_zoxide_test.zsh (22)
TOTAL ok: 2071
```

`homebrew_ubuntu_smoke.sh` skipped (needs a container). The suite was run
with `/usr/bin` first on `PATH`, so `python3` is the 3.9.6 system
interpreter — the version the helper's first assertion targets.

## Follow-ups

- `download` retries the *connection* but not a mid-stream read failure;
  a truncated body still surfaces as a digest mismatch, which is now
  `invalid-release`. Distinguishing a truncated download from a bad
  release would need a separate category.
- The backoff is fixed at `2s`/`4s` with no jitter. Fine for a single
  interactive apply; worth revisiting if the helper ever runs in a fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKu7yrNkZj6rtDDuF1kzVF
