### PR TITLE
Add a test runner and CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,50 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  run:
+    name: tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install zsh
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes zsh
+
+      - name: Install chezmoi
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "$HOME/.local/bin"
+          printf '%s\n' "$HOME/.local/bin" >>"$GITHUB_PATH"
+
+      - name: Report test dependencies
+        run: |
+          chezmoi --version
+          zsh --version
+          python3 --version
+          jq --version
+
+      # Terrapod Setup refuses to run whenever CI is set, and the setup tests
+      # drive it through a PTY. That guard is itself product behavior the same
+      # test file asserts, so the runner gets a CI-free environment rather than
+      # the tests learning which CI they are under.
+      - name: Run the test suite
+        run: env -u CI tests/run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,20 @@ Use the default five-label triage vocabulary. See `docs/agents/triage-labels.md`
 ### Domain docs
 
 This repo uses a single-context domain docs layout. See `docs/agents/domain.md`.
+
+## Tests
+
+Run the whole suite from the repo root with `tests/run`. It executes every
+`tests/*_test.sh` and `tests/*_test.zsh` file, prints each file's assertions,
+and exits non-zero when any file fails.
+
+The suite needs `chezmoi`, `zsh`, `python3`, and `jq` on `PATH`.
+
+`python3` has to be a real interpreter, not a mise shim. The tests that
+exercise the Jetendard helpers override `HOME`, and a shim resolving its
+tool versions under that empty `HOME` blocks on a download instead of
+running. Put the resolved interpreter's directory ahead of the shims for
+the run: `PATH="$(mise where python)/bin:$PATH" tests/run`.
+
+`tests/homebrew_ubuntu_smoke.sh` is not part of `tests/run` — it builds an
+Ubuntu container image and has to be invoked directly with Docker available.

--- a/tests/run
+++ b/tests/run
@@ -1,0 +1,85 @@
+#!/bin/sh
+# Runs every Terrapod test file and aggregates their exit statuses.
+#
+# tests/homebrew_ubuntu_smoke.sh is deliberately not part of the glob: it
+# builds a container image and is not named *_test.sh for that reason.
+set -u
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+work_dir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$work_dir"
+}
+trap cleanup EXIT INT TERM
+
+passed_files=0
+failed_files=""
+
+report_failure() {
+  failed_files="$failed_files
+$1"
+}
+
+run_test_file() {
+  interpreter="$1"
+  test_file="$2"
+  test_name="${test_file##*/}"
+
+  printf '\n=== %s ===\n' "$test_name"
+
+  # Output is streamed and copied at once: the copy is only read afterwards to
+  # tally skips, and a long file should not go quiet while it runs.
+  ( "$interpreter" "$test_file"; printf '%s\n' "$?" >"$work_dir/status" ) 2>&1 |
+    tee -a "$work_dir/output"
+
+  if [ "$(cat "$work_dir/status")" = 0 ]; then
+    passed_files=$((passed_files + 1))
+  else
+    exit_status="$(cat "$work_dir/status")"
+    printf 'not ok - %s exited %s\n' "$test_name" "$exit_status" >&2
+    report_failure "$test_name (exit $exit_status)"
+  fi
+}
+
+: >"$work_dir/output"
+
+for test_file in "$repo_root"/tests/*_test.sh; do
+  [ -f "$test_file" ] || continue
+  run_test_file sh "$test_file"
+done
+
+# zsh test files exercise interactive shell configuration that no POSIX shell
+# can source, so a missing zsh is a failure rather than a silent skip.
+zsh_bin="$(command -v zsh 2>/dev/null || true)"
+for test_file in "$repo_root"/tests/*_test.zsh; do
+  [ -f "$test_file" ] || continue
+  if [ -z "$zsh_bin" ]; then
+    test_name="${test_file##*/}"
+    printf '\n=== %s ===\n' "$test_name"
+    printf 'not ok - %s needs zsh, which is not on PATH\n' "$test_name" >&2
+    report_failure "$test_name (zsh not found)"
+    continue
+  fi
+  run_test_file "$zsh_bin" "$test_file"
+done
+
+# A case a test file reported as unreachable on this host. Counted so a green
+# run never reads as full coverage on a platform that skipped something.
+skipped_cases="$(grep -c '^skip - ' "$work_dir/output" || true)"
+
+printf '\n=== summary ===\n'
+if [ "$skipped_cases" -gt 0 ]; then
+  printf '%d cases skipped on this platform:\n' "$skipped_cases"
+  grep '^skip - ' "$work_dir/output" | sed 's/^skip - /  - /'
+fi
+
+if [ -z "$failed_files" ]; then
+  printf '%d test files passed\n' "$passed_files"
+  exit 0
+fi
+
+failed_count="$(printf '%s' "$failed_files" | grep -c .)"
+printf '%d test files passed, %d failed:\n' "$passed_files" "$failed_count"
+printf '%s\n' "$failed_files" | grep . | sed 's/^/  - /'
+exit 1

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -4,6 +4,10 @@ set -eu
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 tmp_dir="$(mktemp -d)"
 
+# PATH is later pointed at a stub bin directory whose uname always reports
+# Darwin, so the real host has to be recorded before that happens.
+host_os="$(uname -s)"
+
 cleanup() {
   rm -rf "$tmp_dir"
 }
@@ -16,6 +20,12 @@ fail() {
 
 pass() {
   printf '%s\n' "ok - $1"
+}
+
+# Reported instead of an assertion when a case cannot hold on this platform.
+# tests/run counts these lines, so a skip stays visible in a green CI log.
+skip() {
+  printf '%s\n' "skip - $1"
 }
 
 write_stub() {
@@ -551,6 +561,8 @@ copy_desktop_apply_source_fixture() {
   fixture_brew_bin="$2"
 
   # Keep this fixture minimal so real chezmoi apply only runs the Homebrew path under test.
+  # All three real Homebrew prefixes are redirected to the stub, because which one the
+  # rendered script reaches for depends on the host chezmoi is running on.
   mkdir -p \
     "$source_dir/.chezmoiscripts" \
     "$source_dir/dot_local/bin" \
@@ -561,6 +573,7 @@ copy_desktop_apply_source_fixture() {
   sed \
     -e "s#/opt/homebrew/bin/brew#$fixture_brew_bin#g" \
     -e "s#/usr/local/bin/brew#$fixture_brew_bin#g" \
+    -e "s#/home/linuxbrew/.linuxbrew/bin/brew#$fixture_brew_bin#g" \
     "$repo_root/.chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl" \
     >"$source_dir/.chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl"
   cp "$terrapod" "$source_dir/dot_local/bin/executable_terrapod"
@@ -569,6 +582,7 @@ copy_desktop_apply_source_fixture() {
   sed \
     -e "s#/opt/homebrew/bin/brew#$fixture_brew_bin#g" \
     -e "s#/usr/local/bin/brew#$fixture_brew_bin#g" \
+    -e "s#/home/linuxbrew/.linuxbrew/bin/brew#$fixture_brew_bin#g" \
     "$repo_root/dot_local/lib/terrapod/homebrew-prefix.sh" \
     >"$source_dir/dot_local/lib/terrapod/homebrew-prefix.sh"
   cp "$install_warnings_lib" "$source_dir/dot_local/lib/terrapod/install-warnings.sh"
@@ -3460,72 +3474,80 @@ if [ -z "$real_chezmoi" ]; then
   fail "desktop apply recalculation test requires chezmoi"
 fi
 
-desktop_apply_source="$tmp_dir/desktop-apply-source"
-desktop_apply_home="$tmp_dir/desktop-apply-home"
-desktop_apply_state="$tmp_dir/desktop-apply-state"
-desktop_apply_bin="$tmp_dir/desktop-apply-bin"
-desktop_apply_log="$tmp_dir/desktop-apply-brew.log"
-desktop_apply_config="$tmp_dir/desktop-apply.toml"
-mkdir -p "$desktop_apply_home" "$desktop_apply_bin"
-copy_desktop_apply_source_fixture "$desktop_apply_source" "$desktop_apply_bin/brew"
-ln -s "$real_chezmoi" "$desktop_apply_bin/chezmoi"
-write_brew_bundle_stub "$desktop_apply_bin/brew"
+# run_before_10-reconcile-homebrew.sh.tmpl gates its whole macOS App Group
+# section on `eq .chezmoi.os "darwin"`, so on any other OS the rendered script
+# never runs a desktop app bundle and no homebrew-desktop-apps marker can
+# exist. The scenario is unreachable rather than failing.
+if [ "$host_os" = "Darwin" ]; then
+  desktop_apply_source="$tmp_dir/desktop-apply-source"
+  desktop_apply_home="$tmp_dir/desktop-apply-home"
+  desktop_apply_state="$tmp_dir/desktop-apply-state"
+  desktop_apply_bin="$tmp_dir/desktop-apply-bin"
+  desktop_apply_log="$tmp_dir/desktop-apply-brew.log"
+  desktop_apply_config="$tmp_dir/desktop-apply.toml"
+  mkdir -p "$desktop_apply_home" "$desktop_apply_bin"
+  copy_desktop_apply_source_fixture "$desktop_apply_source" "$desktop_apply_bin/brew"
+  ln -s "$real_chezmoi" "$desktop_apply_bin/chezmoi"
+  write_brew_bundle_stub "$desktop_apply_bin/brew"
 
-write_desktop_apply_config "$desktop_apply_config" "$desktop_apply_source" "$desktop_apply_home" true true
+  write_desktop_apply_config "$desktop_apply_config" "$desktop_apply_source" "$desktop_apply_home" true true
 
-if ! HOME="$desktop_apply_home" XDG_STATE_HOME="$desktop_apply_state" TERRAPOD_CHEZMOI_CONFIG="$desktop_apply_config" MACOS_BREW_LOG="$desktop_apply_log" MACOS_BREW_FAIL_DESKTOP_BULK=1 MACOS_BREW_FAIL_CASKS="ghostty raycast" PATH="$desktop_apply_bin:/usr/bin:/bin" \
-  /bin/sh "$terrapod" apply >"$tmp_dir/desktop-apply-first.out" 2>"$tmp_dir/desktop-apply-first.err"; then
-  printf '%s\n' "desktop apply first stdout:" >&2
-  sed 's/^/  /' "$tmp_dir/desktop-apply-first.out" >&2
-  printf '%s\n' "desktop apply first stderr:" >&2
-  sed 's/^/  /' "$tmp_dir/desktop-apply-first.err" >&2
-  fail "Terrapod apply succeeds when desktop App Group casks fail with a marker"
+  if ! HOME="$desktop_apply_home" XDG_STATE_HOME="$desktop_apply_state" TERRAPOD_CHEZMOI_CONFIG="$desktop_apply_config" MACOS_BREW_LOG="$desktop_apply_log" MACOS_BREW_FAIL_DESKTOP_BULK=1 MACOS_BREW_FAIL_CASKS="ghostty raycast" PATH="$desktop_apply_bin:/usr/bin:/bin" \
+    /bin/sh "$terrapod" apply >"$tmp_dir/desktop-apply-first.out" 2>"$tmp_dir/desktop-apply-first.err"; then
+    printf '%s\n' "desktop apply first stdout:" >&2
+    sed 's/^/  /' "$tmp_dir/desktop-apply-first.out" >&2
+    printf '%s\n' "desktop apply first stderr:" >&2
+    sed 's/^/  /' "$tmp_dir/desktop-apply-first.err" >&2
+    fail "Terrapod apply succeeds when desktop App Group casks fail with a marker"
+  fi
+
+  desktop_apply_marker="$desktop_apply_state/terrapod/install-warnings/homebrew-desktop-apps"
+  desktop_apply_marker_text="$(cat "$desktop_apply_marker")"
+  assert_contains "$desktop_apply_marker_text" "failed casks: ghostty, raycast" "Terrapod apply records failed casks from enabled terminal and launcher groups"
+  assert_contains "$desktop_apply_marker_text" "App Groups: terminal-apps, launcher" "Terrapod apply records failed App Groups from enabled terminal and launcher groups"
+
+  if ! HOME="$desktop_apply_home" XDG_STATE_HOME="$desktop_apply_state" TERRAPOD_CHEZMOI_CONFIG="$desktop_apply_config" MACOS_BREW_LOG="$desktop_apply_log" PATH="$desktop_apply_bin:/usr/bin:/bin" \
+    /bin/sh "$terrapod" apply >"$tmp_dir/desktop-apply-retry-success.out" 2>"$tmp_dir/desktop-apply-retry-success.err"; then
+    printf '%s\n' "desktop apply retry success stdout:" >&2
+    sed 's/^/  /' "$tmp_dir/desktop-apply-retry-success.out" >&2
+    printf '%s\n' "desktop apply retry success stderr:" >&2
+    sed 's/^/  /' "$tmp_dir/desktop-apply-retry-success.err" >&2
+    fail "Terrapod apply retries desktop App Group failures with unchanged settings"
+  fi
+
+  if [ -e "$desktop_apply_marker" ]; then
+    fail "Terrapod apply clears a desktop App Group marker after unchanged-settings retry succeeds"
+  fi
+  pass "Terrapod apply clears a desktop App Group marker after unchanged-settings retry succeeds"
+
+  if ! HOME="$desktop_apply_home" XDG_STATE_HOME="$desktop_apply_state" TERRAPOD_CHEZMOI_CONFIG="$desktop_apply_config" MACOS_BREW_LOG="$desktop_apply_log" MACOS_BREW_FAIL_DESKTOP_BULK=1 MACOS_BREW_FAIL_CASKS="ghostty raycast" PATH="$desktop_apply_bin:/usr/bin:/bin" \
+    /bin/sh "$terrapod" apply >"$tmp_dir/desktop-apply-recreate.out" 2>"$tmp_dir/desktop-apply-recreate.err"; then
+    printf '%s\n' "desktop apply recreate stdout:" >&2
+    sed 's/^/  /' "$tmp_dir/desktop-apply-recreate.out" >&2
+    printf '%s\n' "desktop apply recreate stderr:" >&2
+    sed 's/^/  /' "$tmp_dir/desktop-apply-recreate.err" >&2
+    fail "Terrapod apply recreates desktop App Group marker before disabled-group recalculation"
+  fi
+
+  write_desktop_apply_config "$desktop_apply_config" "$desktop_apply_source" "$desktop_apply_home" true false
+
+  if ! HOME="$desktop_apply_home" XDG_STATE_HOME="$desktop_apply_state" TERRAPOD_CHEZMOI_CONFIG="$desktop_apply_config" MACOS_BREW_LOG="$desktop_apply_log" MACOS_BREW_FAIL_DESKTOP_BULK=1 MACOS_BREW_FAIL_CASKS="ghostty raycast" PATH="$desktop_apply_bin:/usr/bin:/bin" \
+    /bin/sh "$terrapod" apply >"$tmp_dir/desktop-apply-terminal-only.out" 2>"$tmp_dir/desktop-apply-terminal-only.err"; then
+    printf '%s\n' "desktop apply terminal-only stdout:" >&2
+    sed 's/^/  /' "$tmp_dir/desktop-apply-terminal-only.out" >&2
+    printf '%s\n' "desktop apply terminal-only stderr:" >&2
+    sed 's/^/  /' "$tmp_dir/desktop-apply-terminal-only.err" >&2
+    fail "Terrapod apply succeeds when disabled launcher failures are recalculated away"
+  fi
+
+  desktop_apply_marker_text="$(cat "$desktop_apply_marker")"
+  assert_contains "$desktop_apply_marker_text" "failed casks: ghostty" "Terrapod apply retains enabled terminal-apps failure after App Group settings change"
+  assert_contains "$desktop_apply_marker_text" "App Groups: terminal-apps" "Terrapod apply retains enabled terminal-apps group after App Group settings change"
+  assert_not_contains "$desktop_apply_marker_text" "raycast" "Terrapod apply removes disabled launcher cask from marker content"
+  assert_not_contains "$desktop_apply_marker_text" "launcher" "Terrapod apply removes disabled launcher group from marker content"
+else
+  skip "Terrapod apply desktop App Group marker recalculation (requires macOS)"
 fi
-
-desktop_apply_marker="$desktop_apply_state/terrapod/install-warnings/homebrew-desktop-apps"
-desktop_apply_marker_text="$(cat "$desktop_apply_marker")"
-assert_contains "$desktop_apply_marker_text" "failed casks: ghostty, raycast" "Terrapod apply records failed casks from enabled terminal and launcher groups"
-assert_contains "$desktop_apply_marker_text" "App Groups: terminal-apps, launcher" "Terrapod apply records failed App Groups from enabled terminal and launcher groups"
-
-if ! HOME="$desktop_apply_home" XDG_STATE_HOME="$desktop_apply_state" TERRAPOD_CHEZMOI_CONFIG="$desktop_apply_config" MACOS_BREW_LOG="$desktop_apply_log" PATH="$desktop_apply_bin:/usr/bin:/bin" \
-  /bin/sh "$terrapod" apply >"$tmp_dir/desktop-apply-retry-success.out" 2>"$tmp_dir/desktop-apply-retry-success.err"; then
-  printf '%s\n' "desktop apply retry success stdout:" >&2
-  sed 's/^/  /' "$tmp_dir/desktop-apply-retry-success.out" >&2
-  printf '%s\n' "desktop apply retry success stderr:" >&2
-  sed 's/^/  /' "$tmp_dir/desktop-apply-retry-success.err" >&2
-  fail "Terrapod apply retries desktop App Group failures with unchanged settings"
-fi
-
-if [ -e "$desktop_apply_marker" ]; then
-  fail "Terrapod apply clears a desktop App Group marker after unchanged-settings retry succeeds"
-fi
-pass "Terrapod apply clears a desktop App Group marker after unchanged-settings retry succeeds"
-
-if ! HOME="$desktop_apply_home" XDG_STATE_HOME="$desktop_apply_state" TERRAPOD_CHEZMOI_CONFIG="$desktop_apply_config" MACOS_BREW_LOG="$desktop_apply_log" MACOS_BREW_FAIL_DESKTOP_BULK=1 MACOS_BREW_FAIL_CASKS="ghostty raycast" PATH="$desktop_apply_bin:/usr/bin:/bin" \
-  /bin/sh "$terrapod" apply >"$tmp_dir/desktop-apply-recreate.out" 2>"$tmp_dir/desktop-apply-recreate.err"; then
-  printf '%s\n' "desktop apply recreate stdout:" >&2
-  sed 's/^/  /' "$tmp_dir/desktop-apply-recreate.out" >&2
-  printf '%s\n' "desktop apply recreate stderr:" >&2
-  sed 's/^/  /' "$tmp_dir/desktop-apply-recreate.err" >&2
-  fail "Terrapod apply recreates desktop App Group marker before disabled-group recalculation"
-fi
-
-write_desktop_apply_config "$desktop_apply_config" "$desktop_apply_source" "$desktop_apply_home" true false
-
-if ! HOME="$desktop_apply_home" XDG_STATE_HOME="$desktop_apply_state" TERRAPOD_CHEZMOI_CONFIG="$desktop_apply_config" MACOS_BREW_LOG="$desktop_apply_log" MACOS_BREW_FAIL_DESKTOP_BULK=1 MACOS_BREW_FAIL_CASKS="ghostty raycast" PATH="$desktop_apply_bin:/usr/bin:/bin" \
-  /bin/sh "$terrapod" apply >"$tmp_dir/desktop-apply-terminal-only.out" 2>"$tmp_dir/desktop-apply-terminal-only.err"; then
-  printf '%s\n' "desktop apply terminal-only stdout:" >&2
-  sed 's/^/  /' "$tmp_dir/desktop-apply-terminal-only.out" >&2
-  printf '%s\n' "desktop apply terminal-only stderr:" >&2
-  sed 's/^/  /' "$tmp_dir/desktop-apply-terminal-only.err" >&2
-  fail "Terrapod apply succeeds when disabled launcher failures are recalculated away"
-fi
-
-desktop_apply_marker_text="$(cat "$desktop_apply_marker")"
-assert_contains "$desktop_apply_marker_text" "failed casks: ghostty" "Terrapod apply retains enabled terminal-apps failure after App Group settings change"
-assert_contains "$desktop_apply_marker_text" "App Groups: terminal-apps" "Terrapod apply retains enabled terminal-apps group after App Group settings change"
-assert_not_contains "$desktop_apply_marker_text" "raycast" "Terrapod apply removes disabled launcher cask from marker content"
-assert_not_contains "$desktop_apply_marker_text" "launcher" "Terrapod apply removes disabled launcher group from marker content"
 
 core_apply_source="$tmp_dir/core-apply-source"
 core_apply_home="$tmp_dir/core-apply-home"


### PR DESCRIPTION
## Problem

`tests/` holds 21 executable test files and roughly 2,000 assertions, and
nothing in the repo runs them. There is no `tests/run-all`, no `Makefile`, and
no `.github/` directory — even though `.chezmoiignore` has ignored `.github/**`
since before any workflow existed. Neither `README.md` nor `AGENTS.md` says how
to execute the suite, so it has to be invoked file by file from memory. That is
how the resume-check bug (#148) and the stale `.chezmoiignore` entry survived.

## Approach

**`tests/run`** globs `tests/*_test.sh` and `tests/*_test.zsh`, runs each file
through the matching interpreter, and exits non-zero if any file failed. Each
file's own `ok -` / `not ok -` output passes through untouched, and a closing
summary names every failing file with its exit status, so a failure in the
middle of ~2,000 assertions does not have to be found by scrolling.

Test files are invoked as `sh <file>` / `zsh <file>` rather than executed
directly, because the mode bits in `tests/` are inconsistent — 5 files are
`755`, the other 16 are `644`. Reading the interpreter from the glob instead of
the executable bit keeps a newly added `644` test from being silently skipped.

`tests/homebrew_ubuntu_smoke.sh` is deliberately outside the glob. It is not
named `*_test.sh` precisely because it builds a container image, so the naming
convention already draws the line; the runner just follows it.

A missing `zsh` is treated as a failure of each `*_test.zsh` file, not a silent
skip. A runner that reports green while quietly not running two files is the
problem this issue is about.

**CI** is a `macos-latest` + `ubuntu-latest` matrix with `fail-fast: false`, so
one platform's failure does not hide the other's. `chezmoi` is installed from
`get.chezmoi.io` on both platforms rather than through Homebrew — Linuxbrew on
the Ubuntu runner is slow, and one install path for both keeps the job
symmetric. Ubuntu additionally installs `zsh`. `jq` and `python3` are already on
both runner images. A dependency-version step runs before the suite so a future
green-to-red flip can be attributed to a tool bump.

`.chezmoiignore:10` already lists `.github/**`, so the new workflow directory is
excluded from chezmoi management with no change needed — verified, not assumed.

## Divergences from the issue text

- The issue says 22 test files. The glob matches **21**; the 22nd file in
  `tests/` is `homebrew_ubuntu_smoke.sh`, which is not a test file by naming
  convention and needs Docker.
- The issue proposes the name `tests/run-all`; the fix direction in the same
  issue says `tests/run`. Went with `tests/run`.

## Tests

Full suite through the new runner:

```
$ PATH="$(mise where python)/bin:$PATH" tests/run
...
=== summary ===
21 test files passed
```

**macOS: 21 files, 2062 assertions, 0 failures, exit 0.**
**Ubuntu: 21 files, 1 case skipped, 0 failures** — see the platform section below.

The runner's own aggregation was verified against a synthetic tests directory
rather than by trusting the happy path:

- two passing and two failing files → both failures listed with their exit
  statuses (3 and 4), 2 counted as passed, runner exits 1
- `PATH` without `zsh` → `c_test.zsh (zsh not found)` listed as a failure,
  runner exits 1
- files emitting `skip -` lines → both listed under `2 cases skipped on this
  platform` in the summary, alongside the pass/fail tally

### The pre-existing failure CI surfaced

Ubuntu is the first platform this suite has ever run on, and it found one real
defect — in the test, not the product.

`terrapod_command_test.sh` builds a fixture source tree and runs a real
`chezmoi apply` against it. Two blocks in it assumed macOS:

**The desktop App Group marker block cannot hold on Linux at all.**
`run_before_10-reconcile-homebrew.sh.tmpl:2-3` gates its entire macOS App Group
section on `and (eq .chezmoi.os "darwin") (or …)`. `.chezmoi.os` comes from the
host, not from the fixture's `profile = "macos-terminal"` data key, so on Linux
the rendered script never runs a desktop app bundle and the
`homebrew-desktop-apps` marker the block reads can never exist. It is now
wrapped in a host guard that reports

```
skip - Terrapod apply desktop App Group marker recalculation (requires macOS)
```

and `tests/run` counts those lines, so a green Linux run states what it did not
cover instead of implying full coverage. The repo's existing idiom for a skipped
case is `pass "… is skipped when …"`, which is indistinguishable from an
assertion in any tally; `skip -` is new for that reason and the existing `pass`
skips are left alone.

The guard reads `host_os`, captured at the top of the file — **not** `uname` at
the point of use. `terrapod_command_test.sh:1835` exports a stub `PATH` and
`:2745` puts a `uname` on it that always prints `Darwin`. A guard written as
`[ "$(uname -s)" = Darwin ]` there passes on Linux and skips nothing; that was
caught by instrumenting the guard in a container, not by reading the code.

**The core Homebrew marker block was reachable and simply misconfigured.**
`copy_desktop_apply_source_fixture` rewrote `/opt/homebrew/bin/brew` and
`/usr/local/bin/brew` to the stub but not `/home/linuxbrew/.linuxbrew/bin/brew`,
so on Linux the rendered script found no Homebrew at all and wrote `Install
Homebrew from https://brew.sh` where the test expected `failed formulae: gum`.
Adding the third prefix to both `sed` calls makes the block run on Linux; it is
a no-op on macOS, where that path never appears in the render. This one is a
real coverage gain rather than a skip, so it is not guarded.

Both were verified in an `ubuntu:24.04` container before pushing, not by
watching CI: with the changes `terrapod_command_test.sh` is green on Linux with
501 assertions and 1 skip.

**On the 58-second gap** between the last `ok` and the failure: it is the four
real `chezmoi apply` runs inside the desktop block, not a retry loop. With the
block skipped, the file drops from 45s (macOS, block running) to 23s (Linux,
block skipped) — consistent with the block's own cost, and no retry behavior to
explain.

A sweep of the rest of the Ubuntu run found no other platform assumption; every
other file passed unmodified.

### A hang that is not a test failure

The first full macOS run appeared to hang: `jetendard_font_test.sh` and
`jetendard_settings_test.sh` sat idle for 90+ seconds, and
`terrapod_command_test.sh` failed on `Terrapod status reports installed
Jetendard font files`.

None of that is a test defect. `dot_config/mise/config.toml.tmpl` pins
`python = "3.13"`, so on a Terrapod machine `python3` resolves to a mise shim.
Those tests override `HOME`, the shim re-resolves its tool versions under the
now-empty `HOME`, and it blocks trying to fetch an interpreter. Sampling the
stuck process showed a `mise` call stack, not Python. With a real interpreter
ahead of the shims, both files pass in **1 second each** and
`terrapod_command_test.sh` passes too.

This will bite every contributor on a Terrapod-managed machine, so `AGENTS.md`
documents the cause and the one-line `PATH` prefix that avoids it.

## Follow-ups

- `tests/git_config_test.sh` needs git ≥ 2.46 — it uses the `git config get` /
  `git config set` subcommands. It passes on GitHub's `ubuntu-latest`, which
  ships a current git, and fails against stock Ubuntu 24.04's git 2.43 with a
  usage error. Not a CI failure today, but the suite is one runner-image change
  away from it.
- `tests/run` could detect a shimmed `python3` and fail fast with that message
  instead of leaving the caller to wait out a hang. Left out as beyond this
  issue; the documentation covers it for now.
- The `644`/`755` split across `tests/` is now cosmetic. Normalizing it is
  independent of this change.

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKu7yrNkZj6rtDDuF1kzVF
