### PR TITLE
Keep the App Group field non-empty in desktop app records

### DIFF
--- a/.chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl
+++ b/.chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl
@@ -57,7 +57,16 @@ desktop_app_package_records() {
       sub(/".*$/, "", token)
 
       if (token != "") {
-        printf "%s\t%s\t%s\n", group, token, declaration
+        # Tab is IFS whitespace, so an empty leading field would be swallowed by
+        # the reader and shift token and declaration left. Emit a placeholder
+        # instead; the reader maps it back to "no App Group". The declaration
+        # stays last so a tab inside it cannot shift anything either.
+        group_field = group
+        if (group_field == "") {
+          group_field = "-"
+        }
+
+        printf "%s\t%s\t%s\n", group_field, token, declaration
       }
     }
   ' "$brewfile"
@@ -109,6 +118,12 @@ run_desktop_app_bundle() {
   # Keep the record list on fd 3 so a cask post-install step that reads stdin
   # cannot consume the remaining packages and silently skip them.
   while IFS="$tab" read -r app_group token declaration <&3; do
+    # "-" is the placeholder desktop_app_package_records emits for a declaration
+    # that precedes every macOS App Group header.
+    if [ "$app_group" = "-" ]; then
+      app_group=
+    fi
+
     single_package_brewfile="$(mktemp "${TMPDIR:-/tmp}/terrapod-macos-desktop-package.XXXXXX")" || {
       cleanup_desktop_app_bundle_temps
       return 1

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -1238,6 +1238,25 @@ assert_text_equals \
   "$expected_package_records" \
   "desktop app package records carry group, token, and the verbatim declaration for casks and tap formulae"
 
+headerless_records_brewfile="$tmp_dir/package-records-headerless-brewfile"
+cat >"$headerless_records_brewfile" <<'PROBE_BREWFILE'
+# Rendered opt-in macOS Desktop App Stack.
+cask "ghostty"
+# launcher macOS App Group
+cask "raycast"
+PROBE_BREWFILE
+
+headerless_records_output="$(sh "$package_records_probe" "$headerless_records_brewfile")"
+
+expected_headerless_records="$(printf '%s\n' \
+  '-	ghostty	cask "ghostty"' \
+  'launcher	raycast	cask "raycast"')"
+
+assert_text_equals \
+  "$headerless_records_output" \
+  "$expected_headerless_records" \
+  "a declaration before the first macOS App Group header keeps a non-empty group field"
+
 assert_contains_text \
   "$macos_development_apps_bootstrap" \
   'read -r app_group token declaration' \
@@ -1493,6 +1512,58 @@ fallback_marker_text="$(cat "$fallback_state/terrapod/install-warnings/homebrew-
 assert_contains_text "$fallback_marker_text" "Review Homebrew desktop app bundle output" "desktop app marker falls back to bulk bundle guidance when casks are not reliable"
 assert_not_contains_text "$fallback_marker_text" "failed casks:" "desktop app fallback marker avoids invented cask detail"
 assert_not_contains_text "$fallback_marker_text" "App Groups:" "desktop app fallback marker avoids invented App Group detail"
+
+headerless_bootstrap_script="$tmp_dir/macos-desktop-headerless-bootstrap.sh"
+awk '
+  $0 == "BREWFILE" && in_brewfile == 1 {
+    print "# Rendered opt-in macOS Desktop App Stack."
+    print "cask \"ghostty\""
+    print "# launcher macOS App Group"
+    print "cask \"raycast\""
+    print "BREWFILE"
+    in_brewfile = 0
+    next
+  }
+  in_brewfile == 1 { next }
+  $0 == "cat >\"$desktop_brewfile\" <<'\''BREWFILE'\''" {
+    print
+    in_brewfile = 1
+    next
+  }
+  { print }
+' "$terminal_launcher_bootstrap_script" |
+  sed "s#$tmp_dir/terminal-launcher-bin/brew#$tmp_dir/headerless-bin/brew#g" >"$headerless_bootstrap_script"
+sh -n "$headerless_bootstrap_script" || fail "headerless desktop bootstrap script should be valid sh"
+pass "headerless desktop bootstrap script is valid sh"
+
+headerless_bin="$tmp_dir/headerless-bin"
+headerless_state="$tmp_dir/headerless-state"
+headerless_home="$tmp_dir/headerless-home"
+headerless_log="$tmp_dir/headerless-brew.log"
+mkdir -p "$headerless_bin" "$headerless_home"
+write_brew_bundle_stub "$headerless_bin/brew"
+
+# The stub fails a cask by grepping the single-package Brewfile it is handed, so
+# a collapsed record that writes an empty Brewfile makes the cask trivially
+# "succeed" and hides the failure entirely.
+if ! HOME="$headerless_home" XDG_STATE_HOME="$headerless_state" MACOS_BREW_LOG="$headerless_log" MACOS_BREW_FAIL_DESKTOP_BULK=1 MACOS_BREW_FAIL_CASKS="ghostty" PATH="$headerless_bin:/usr/bin:/bin" \
+  sh "$headerless_bootstrap_script" >"$tmp_dir/headerless.out" 2>"$tmp_dir/headerless.err"; then
+  fail "headerless desktop app bundle failure does not block bootstrap script"
+fi
+
+headerless_marker="$headerless_state/terrapod/install-warnings/homebrew-desktop-apps"
+if [ ! -f "$headerless_marker" ]; then
+  fail "headerless desktop app bundle failure records a homebrew-desktop-apps marker"
+fi
+pass "headerless desktop app bundle failure records a homebrew-desktop-apps marker"
+
+headerless_marker_text="$(cat "$headerless_marker")"
+assert_contains_text "$headerless_marker_text" "failed casks: ghostty" \
+  "a cask declared before the first macOS App Group header is still retried and attributed"
+assert_not_contains_text "$headerless_marker_text" "App Groups:" \
+  "a cask with no macOS App Group contributes no App Group detail"
+assert_not_contains_text "$headerless_marker_text" "raycast" \
+  "a grouped cask whose single-cask bundle succeeds stays out of the marker"
 
 terminal_only_bootstrap_script="$tmp_dir/macos-terminal-only-bootstrap.sh"
 printf '%s\n' "$macos_terminal_apps_bootstrap" | sed \


### PR DESCRIPTION
Closes #165

> Stacked on #197 (issue #164). Base is `juty9026/issue-164-prune-stale-staging-files`; rebase onto `main` after that merges.

## Problem

`desktop_app_package_records` emits `group\ttoken\tdeclaration` at `run_before_10-reconcile-homebrew.sh.tmpl:111`, and the per-package retry loop reads it at `:160` with `IFS="$tab" read -r app_group token declaration`.

Tab is IFS whitespace. POSIX `read` strips leading IFS whitespace and collapses runs of it into a single delimiter, so a record whose `group` is empty arrives as two fields, not three: `app_group` takes the token, `token` takes the declaration, and `declaration` ends up empty.

The loop then does `printf '%s\n' "$declaration" > "$single_package_brewfile"` and hands the empty file to `brew bundle`, which succeeds on it. The cask is never actually retried, `$token` (now a whole declaration string) is never appended to the failed list, and the marker falls back to the generic "Review Homebrew desktop app bundle output" guidance. A real install failure is reported as a bulk-output nudge.

`group` is empty for exactly one shape: a declaration emitted before the first `# … macOS App Group` header. `Brewfile.macos-desktop-apps.tmpl` puts every cask under a header today, so this is latent — and it breaks the moment a declaration is added above the first one.

## Approach

The issue offered a placeholder or a field reorder. This takes the placeholder.

Reordering so the possibly-empty field is last was rejected: `declaration` is last for a reason. It is the only field that can contain a tab — a Brewfile is free to write `cask\t"ghostty"`, and `awk` only trims leading and trailing whitespace — and `read`'s last variable absorbs the remainder including delimiters. Moving `declaration` into the middle would trade the empty-leading-field collapse for a tab-inside-declaration collapse.

So `awk` emits `-` when the group is absent, and the reader maps it back:

```sh
while IFS="$tab" read -r app_group token declaration <&3; do
  # "-" is the placeholder desktop_app_package_records emits for a declaration
  # that precedes every macOS App Group header.
  if [ "$app_group" = "-" ]; then
    app_group=
  fi
```

Downstream behavior is unchanged: `[ -n "$app_group" ]` already guards the failed-groups file, so an ungrouped cask contributes no App Group detail while still being named in `failed casks:`.

## Tests

Two cases in `tests/chezmoiignore_test.sh`, both red before the change:

- **Record level**, through the existing `desktop_app_package_records` probe: a Brewfile whose first `cask` precedes every header produces `-\tghostty\tcask "ghostty"`, and the grouped cask after it still produces `launcher\traycast\t…`. Against the pre-change code the record is `\tghostty\t…` — the empty leading field, directly.
- **End to end**, through a rendered bootstrap script whose embedded Brewfile is rewritten to put `cask "ghostty"` above the first header. This one is load-bearing because the `brew` stub reproduces the exact hiding mechanism: it fails a cask by grepping the single-package Brewfile it is handed, so an empty Brewfile makes the cask trivially succeed. With the fix the marker reads `failed casks: ghostty` with no `App Groups:` detail; without it, `a cask declared before the first macOS App Group header is still retried and attributed` fails.

Suite results on this branch:

| suite | ok | not ok |
| --- | --- | --- |
| `chezmoiignore_test.sh` | 334 | 0 |
| `terrapod_config_test.sh` | 393 | 0 |
| `terrapod_command_test.sh` | 226 | 1 (pre-existing) |
| `homebrew_manifests_test.sh` | 8 | 0 |

The one failure is `Terrapod status reports installed Jetendard font files`, which reproduces on a clean `origin/main` checkout on this machine and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKu7yrNkZj6rtDDuF1kzVF