### PR TITLE
Rebuild the completion table after zinit extends fpath

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -43,8 +43,17 @@ if [[ -r "$zinit_script" ]]; then
   # against the shorter fpath above. Rebuild the table so the new completion
   # directories actually register; sharing Oh My Zsh's dump keeps it to one
   # cache file.
+  #
+  # The security flag matches the one oh-my-zsh.sh just used, so the rebuilt
+  # table holds the same directories as the one it replaces. It also has to be
+  # there at all: bare `compinit` asks what to do about an insecure directory,
+  # and a shell that cannot answer aborts compinit and loses the whole table.
   autoload -Uz compinit
-  compinit -d "${ZSH_COMPDUMP:-${ZDOTDIR:-$HOME}/.zcompdump}"
+  if [[ "${ZSH_DISABLE_COMPFIX:-}" == true ]]; then
+    compinit -u -d "${ZSH_COMPDUMP:-${ZDOTDIR:-$HOME}/.zcompdump}"
+  else
+    compinit -i -d "${ZSH_COMPDUMP:-${ZDOTDIR:-$HOME}/.zcompdump}"
+  fi
 fi
 unset zinit_script
 

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -38,6 +38,13 @@ if [[ -r "$zinit_script" ]]; then
   zinit light zdharma-continuum/fast-syntax-highlighting
   zinit light zsh-users/zsh-autosuggestions
   zinit light zsh-users/zsh-completions
+
+  # zsh-completions only extends fpath, and oh-my-zsh.sh already ran compinit
+  # against the shorter fpath above. Rebuild the table so the new completion
+  # directories actually register; sharing Oh My Zsh's dump keeps it to one
+  # cache file.
+  autoload -Uz compinit
+  compinit -d "${ZSH_COMPDUMP:-${ZDOTDIR:-$HOME}/.zcompdump}"
 fi
 unset zinit_script
 

--- a/tests/zshrc_completions_test.zsh
+++ b/tests/zshrc_completions_test.zsh
@@ -31,17 +31,29 @@ render_zshrc() {
     >"$tmp_dir/home/.zshrc"
 }
 
+# Every scenario sources .zshrc in its own subshell, so each one has to start
+# from a shell that has never run compinit: no dump on disk, no table in memory.
+reset_dumps() {
+  rm -f "$tmp_dir"/home/.zcompdump*(N)
+}
+
 mkdir -p \
   "$tmp_dir/home/.oh-my-zsh" \
   "$tmp_dir/home/.local/share/zinit/zinit.git" \
-  "$tmp_dir/completions"
+  "$tmp_dir/completions" \
+  "$tmp_dir/insecure"
 
 # Oh My Zsh runs compinit itself against its own dump; that snapshot is what a
-# late fpath addition misses.
+# late fpath addition misses. It picks its security flag the way the real
+# oh-my-zsh.sh does, so it never stops to ask about an insecure directory.
 cat >"$tmp_dir/home/.oh-my-zsh/oh-my-zsh.sh" <<'STUB'
 ZSH_COMPDUMP="${ZDOTDIR:-$HOME}/.zcompdump-oh-my-zsh"
 autoload -Uz compinit
-compinit -u -d "$ZSH_COMPDUMP"
+if [[ "${ZSH_DISABLE_COMPFIX:-}" == true ]]; then
+  compinit -u -d "$ZSH_COMPDUMP"
+else
+  compinit -i -d "$ZSH_COMPDUMP"
+fi
 STUB
 
 # zsh-completions contributes nothing but fpath entries, so the stub does only that.
@@ -58,6 +70,15 @@ cat >"$tmp_dir/completions/_terrapod-completions-probe" <<'STUB'
 _message 'terrapod completions probe'
 STUB
 
+# A completion directory compaudit refuses to vouch for. Machines grow these:
+# a group-writable Homebrew site-functions directory is the everyday case, and
+# the GitHub Actions Ubuntu runner carries one in its default fpath.
+cat >"$tmp_dir/insecure/_terrapod-insecure-probe" <<'STUB'
+#compdef terrapod-insecure-probe
+_message 'terrapod insecure probe'
+STUB
+chmod 777 "$tmp_dir/insecure"
+
 chezmoi_bin="$(command -v chezmoi)" || fail "chezmoi is required to render templates"
 
 export HOME="$tmp_dir/home"
@@ -69,27 +90,69 @@ export CLAUDECODE=1
 : >"$tmp_dir/chezmoi.toml"
 render_zshrc '{"chezmoi":{"os":"linux","osRelease":{"id":"ubuntu","versionID":"24.04"}}}'
 
-source "$tmp_dir/home/.zshrc"
+reset_dumps
+(
+  source "$tmp_dir/home/.zshrc"
 
-if (( ! ${+_comps} )); then
-  fail "sourcing .zshrc should leave a completion table behind"
-fi
+  if (( ! ${+_comps} )); then
+    fail "sourcing .zshrc should leave a completion table behind"
+  fi
 
-pass "sourcing .zshrc leaves a completion table behind"
+  pass "sourcing .zshrc leaves a completion table behind"
 
-if (( ! ${+_comps[terrapod-completions-probe]} )); then
-  fail "completions contributed by zsh-completions should be registered; \
+  if (( ! ${+_comps[terrapod-completions-probe]} )); then
+    fail "completions contributed by zsh-completions should be registered; \
 compinit ran before the zinit block added them to fpath"
-fi
+  fi
 
-pass "completions contributed by zsh-completions are registered"
+  pass "completions contributed by zsh-completions are registered"
 
-if [[ ! -f "$tmp_dir/home/.zcompdump-oh-my-zsh" ]]; then
-  fail "the rebuilt completion table should reuse Oh My Zsh's dump file"
-fi
+  if [[ ! -f "$tmp_dir/home/.zcompdump-oh-my-zsh" ]]; then
+    fail "the rebuilt completion table should reuse Oh My Zsh's dump file"
+  fi
 
-if [[ -e "$tmp_dir/home/.zcompdump" ]]; then
-  fail "the rebuilt completion table should not add a second dump file"
-fi
+  if [[ -e "$tmp_dir/home/.zcompdump" ]]; then
+    fail "the rebuilt completion table should not add a second dump file"
+  fi
 
-pass "the rebuilt completion table reuses Oh My Zsh's dump file"
+  pass "the rebuilt completion table reuses Oh My Zsh's dump file"
+) || exit 1
+
+# The directory zinit contributes is the one only the rebuild ever sees, so the
+# rebuild alone decides what to do about its security. compinit stops to ask
+# unless it is told, and a shell with nothing to ask — every non-interactive
+# one — aborts and keeps no table at all.
+reset_dumps
+(
+  export COMPLETIONS_TEST_DIR="$tmp_dir/insecure"
+
+  source "$tmp_dir/home/.zshrc"
+
+  if (( ! ${+_comps} )); then
+    fail "an insecure directory arriving late should not cost the table"
+  fi
+
+  if (( ${+_comps[terrapod-insecure-probe]} )); then
+    fail "the rebuild should skip an insecure completion directory, \
+the way oh-my-zsh.sh does"
+  fi
+
+  pass "the rebuild skips an insecure completion directory"
+) || exit 1
+
+# ZSH_DISABLE_COMPFIX is how a user tells Oh My Zsh to load insecure
+# directories anyway. The rebuild has to make the same call, or it drops the
+# completions that flag was set to keep.
+reset_dumps
+(
+  export COMPLETIONS_TEST_DIR="$tmp_dir/insecure"
+  export ZSH_DISABLE_COMPFIX=true
+
+  source "$tmp_dir/home/.zshrc"
+
+  if (( ! ${+_comps} )) || (( ! ${+_comps[terrapod-insecure-probe]} )); then
+    fail "ZSH_DISABLE_COMPFIX should keep insecure directories in the rebuilt table"
+  fi
+
+  pass "ZSH_DISABLE_COMPFIX keeps insecure directories in the rebuilt table"
+) || exit 1

--- a/tests/zshrc_completions_test.zsh
+++ b/tests/zshrc_completions_test.zsh
@@ -1,0 +1,95 @@
+#!/usr/bin/env zsh
+
+set -u
+
+repo_root="${0:A:h:h}"
+tmp_dir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT INT TERM
+
+fail() {
+  print -u2 -- "not ok - $1"
+  exit 1
+}
+
+pass() {
+  print -- "ok - $1"
+}
+
+render_zshrc() {
+  local data="$1"
+
+  "$chezmoi_bin" \
+    --config "$tmp_dir/chezmoi.toml" \
+    --destination "$tmp_dir/home" \
+    --source "$repo_root" \
+    --override-data "$data" \
+    cat "$tmp_dir/home/.zshrc" \
+    >"$tmp_dir/home/.zshrc"
+}
+
+mkdir -p \
+  "$tmp_dir/home/.oh-my-zsh" \
+  "$tmp_dir/home/.local/share/zinit/zinit.git" \
+  "$tmp_dir/completions"
+
+# Oh My Zsh runs compinit itself against its own dump; that snapshot is what a
+# late fpath addition misses.
+cat >"$tmp_dir/home/.oh-my-zsh/oh-my-zsh.sh" <<'STUB'
+ZSH_COMPDUMP="${ZDOTDIR:-$HOME}/.zcompdump-oh-my-zsh"
+autoload -Uz compinit
+compinit -u -d "$ZSH_COMPDUMP"
+STUB
+
+# zsh-completions contributes nothing but fpath entries, so the stub does only that.
+cat >"$tmp_dir/home/.local/share/zinit/zinit.git/zinit.zsh" <<'STUB'
+function zinit() {
+  if [[ "${1:-}" == light && "${2:-}" == zsh-users/zsh-completions ]]; then
+    fpath=("$COMPLETIONS_TEST_DIR" $fpath)
+  fi
+}
+STUB
+
+cat >"$tmp_dir/completions/_terrapod-completions-probe" <<'STUB'
+#compdef terrapod-completions-probe
+_message 'terrapod completions probe'
+STUB
+
+chezmoi_bin="$(command -v chezmoi)" || fail "chezmoi is required to render templates"
+
+export HOME="$tmp_dir/home"
+export PATH="/usr/bin:/bin:/usr/sbin:/sbin"
+export COMPLETIONS_TEST_DIR="$tmp_dir/completions"
+# SCM Breeze is unrelated here and pulls in a repository it does not have.
+export CLAUDECODE=1
+
+: >"$tmp_dir/chezmoi.toml"
+render_zshrc '{"chezmoi":{"os":"linux","osRelease":{"id":"ubuntu","versionID":"24.04"}}}'
+
+source "$tmp_dir/home/.zshrc"
+
+if (( ! ${+_comps} )); then
+  fail "sourcing .zshrc should leave a completion table behind"
+fi
+
+pass "sourcing .zshrc leaves a completion table behind"
+
+if (( ! ${+_comps[terrapod-completions-probe]} )); then
+  fail "completions contributed by zsh-completions should be registered; \
+compinit ran before the zinit block added them to fpath"
+fi
+
+pass "completions contributed by zsh-completions are registered"
+
+if [[ ! -f "$tmp_dir/home/.zcompdump-oh-my-zsh" ]]; then
+  fail "the rebuilt completion table should reuse Oh My Zsh's dump file"
+fi
+
+if [[ -e "$tmp_dir/home/.zcompdump" ]]; then
+  fail "the rebuilt completion table should not add a second dump file"
+fi
+
+pass "the rebuilt completion table reuses Oh My Zsh's dump file"


### PR DESCRIPTION
Closes #167

## Problem

`source "$ZSH/oh-my-zsh.sh"` (`dot_zshrc.tmpl:19-21`) runs `compinit`, which snapshots `fpath` into `$ZSH_COMPDUMP`. The zinit block twenty lines later (`dot_zshrc.tmpl:40`) loads `zsh-users/zsh-completions`, and that plugin does nothing but prepend its completion directory to `fpath` — after the snapshot.

The plugin is installed (`run_onchange_before_30-install-shell-integrations.sh.tmpl:85-97`), so users pay the clone and the startup cost and get no completions in return.

## Approach

Re-run `compinit` at the end of the zinit block, against Oh My Zsh's own dump:

```zsh
  zinit light zsh-users/zsh-completions

  autoload -Uz compinit
  if [[ "${ZSH_DISABLE_COMPFIX:-}" == true ]]; then
    compinit -u -d "${ZSH_COMPDUMP:-${ZDOTDIR:-$HOME}/.zcompdump}"
  else
    compinit -i -d "${ZSH_COMPDUMP:-${ZDOTDIR:-$HOME}/.zcompdump}"
  fi
```

The security flag is not decoration. `compinit` with neither `-i` nor `-u` **stops and asks** when `compaudit` finds an insecure directory in `fpath`, and a shell with no terminal to ask on aborts:

```
not interactive and can't open terminal
compinit: initialization aborted
```

An aborted `compinit` leaves no `$_comps` at all — the shell ends up with fewer completions than before this change. `oh-my-zsh.sh` never leaves the question open (`compinit -i` normally, `compinit -u` when `ZSH_DISABLE_COMPFIX` is true), so the rebuild makes the same call: it decides the same way about the same directories, and under `ZSH_DISABLE_COMPFIX` it keeps the insecure directories that flag exists to keep.

It sits *inside* `if [[ -r "$zinit_script" ]]` because that is exactly where `fpath` grows. A machine without zinit keeps Oh My Zsh's single `compinit` and behaves as before.

Reusing `$ZSH_COMPDUMP` rather than letting `compinit` default to `~/.zcompdump` keeps one cache file. A second dump would double the on-disk cache and leave Oh My Zsh's daily regeneration logic managing only half of it. `${ZDOTDIR:-$HOME}/.zcompdump` is the fallback for the case where Oh My Zsh is absent but zinit is present.

Moving the zinit block above `oh-my-zsh.sh` was the other option the issue offered. It would avoid the second `compinit` entirely, but `fast-syntax-highlighting` expects to be loaded late, so the block does not move as a unit — splitting it across two locations costs more clarity than the second `compinit` costs startup time. In steady state both `compinit` calls load a cached dump rather than rescanning `fpath`.

Code matched the issue description; no discrepancies.

## Tests

New `tests/zshrc_completions_test.zsh`. It renders `.zshrc` through chezmoi against:

- a stub `oh-my-zsh.sh` that sets its own `$ZSH_COMPDUMP` and picks its `compinit` security flag the way the real one does (`-i`, or `-u` under `ZSH_DISABLE_COMPFIX`);
- a stub `zinit` function that — like the real plugin — only prepends a directory to `fpath`, and only when asked for `zsh-users/zsh-completions`;
- a second completion directory at mode 0777, which `compaudit` refuses to vouch for.

Each scenario runs in its own subshell against its own dump file, so none of them inherits a table or a cache from the one before.

Every assertion is load-bearing, verified by breaking it:

- registration — red against the pre-change template (`not ok - completions contributed by zsh-completions should be registered`);
- dump sharing — red when `compinit -d` is pointed at `~/.zcompdump` instead of `$ZSH_COMPDUMP` (`not ok - the rebuilt completion table should not add a second dump file`);
- skipping the insecure directory — red under `compinit -u`, and red under bare `compinit`, which aborts with the runner's exact output;
- honouring `ZSH_DISABLE_COMPFIX` — red under `compinit -i`.

```
$ zsh tests/zshrc_completions_test.zsh
ok - sourcing .zshrc leaves a completion table behind
ok - completions contributed by zsh-completions are registered
ok - the rebuilt completion table reuses Oh My Zsh's dump file
ok - the rebuild skips an insecure completion directory
ok - ZSH_DISABLE_COMPFIX keeps insecure directories in the rebuilt table

$ zsh tests/zshrc_clear_test.zsh      # 13 assertions, rc=0
$ zsh tests/zshrc_zoxide_test.zsh     # 22 assertions, rc=0
```

`.sh` suites, all rc=0 — 1505 assertions:

```
bootstrap_ubuntu_test.sh (31)          chezmoiignore_test.sh (328)
executable_selection_test.sh (47)      ghostty_config_test.sh (2)
git_config_test.sh (21)                hammerspoon_config_test.sh (10)
helper_resolution_test.sh (4)          homebrew_manifests_test.sh (8)
karabiner_config_test.sh (9)           lazygit_pr_merge_test.sh (44)
readme_korean_test.sh (52)             readme_optional_stack_profiles_test.sh (111)
shell_integrations_test.sh (38)        terrapod_config_test.sh (393)
zshenv_local_bin_test.sh (17)          terrapod_installer_test.sh (390)
```

Not run to completion here: `homebrew_ubuntu_smoke.sh` (needs a container), and `jetendard_font_test.sh`, `jetendard_settings_test.sh`, `terrapod_command_test.sh` — all three drive a `mise` Python download that stalls in this sandbox. None of the three renders `.zshrc`.

## Follow-up: the Ubuntu CI failure

The first push of this branch was green on macOS and red on `ubuntu-latest`, on the test this PR adds:

```
not interactive and can't open terminal
compinit: initialization aborted
not ok - sourcing .zshrc should leave a completion table behind
```

**It was the template, not the test.** The GitHub Actions `ubuntu-24.04` image ships two directories in the default `fpath` at mode 0777:

```
drwxrwxrwx+ 7 root root /usr/share/zsh
drwxrwxrwx+ 2 root root /usr/share/zsh/vendor-completions
```

(measured on the runner itself with `zsh -f -c 'autoload -Uz compaudit; compaudit'`). So `compaudit` has something to report there and nothing to report on the macOS runner — which is the whole of the platform split. The prompt the bare `compinit` raised is not CI-specific: on any machine with one insecure completion directory, a non-interactive shell that sources `.zshrc` loses its completion table, and an interactive one gets a `[y/n]` question at every startup where Oh My Zsh alone gave none.

Reproduced in `ubuntu:24.04` with those two directories chmod'd to 0777, which gives byte-identical `compaudit` output to the runner: the pre-fix template fails there with the runner's message, the fixed one passes. A clean container reproduces neither, which is why this took a container rather than a re-run.

The test moved too, but only to stop hiding the defect: its `oh-my-zsh.sh` stub used to pass `-u` unconditionally. A stub that audits nothing cannot show what the rebuild's own audit does.

No `CONTEXT.md` or ADR change: no domain term moved and no architectural decision changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKu7yrNkZj6rtDDuF1kzVF

