### PR TITLE
Delete source checksums from always-run chezmoi scripts

### DIFF
--- a/.chezmoiscripts/run_after_20-install-mise-tools.sh.tmpl
+++ b/.chezmoiscripts/run_after_20-install-mise-tools.sh.tmpl
@@ -1,6 +1,5 @@
 {{- if or (eq .chezmoi.os "darwin") (eq .chezmoi.os "linux") -}}
 #!/bin/sh
-# mise-config-sha256={{ includeTemplate "dot_config/mise/config.toml.tmpl" . | sha256sum }}
 set -eu
 
 {{ include "dot_local/lib/terrapod/homebrew-prefix.sh" }}

--- a/.chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl
+++ b/.chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl
@@ -20,22 +20,6 @@ set -eu
 
 {{ include "dot_local/lib/terrapod/homebrew-core-bundle.sh" }}
 
-join_lines_with_commas() {
-  awk '
-    NF {
-      if (joined == "") {
-        joined = $0
-      } else {
-        joined = joined ", " $0
-      }
-    }
-
-    END {
-      print joined
-    }
-  ' "$1"
-}
-
 desktop_app_package_records() {
   brewfile="$1"
 
@@ -151,11 +135,11 @@ run_desktop_app_bundle() {
   done 3<"$records_file"
 
   if [ -s "$failed_casks_file" ]; then
-    if ! failed_casks="$(join_lines_with_commas "$failed_casks_file")"; then
+    if ! failed_casks="$(terrapod_homebrew_core_join_lines_with_commas "$failed_casks_file")"; then
       cleanup_desktop_app_bundle_temps
       return 1
     fi
-    if ! failed_groups="$(join_lines_with_commas "$failed_groups_file")"; then
+    if ! failed_groups="$(terrapod_homebrew_core_join_lines_with_commas "$failed_groups_file")"; then
       cleanup_desktop_app_bundle_temps
       return 1
     fi
@@ -266,7 +250,6 @@ fi
 
 core_brewfile="{{ .chezmoi.sourceDir }}/Brewfile"
 
-# Core Brewfile checksum: {{ include "Brewfile" | sha256sum }}
 if [ -f "$core_brewfile" ]; then
   if terrapod_homebrew_core_run_bundle "$core_brewfile"; then
     clear_install_warning homebrew-core
@@ -289,7 +272,6 @@ cleanup_desktop_brewfile() {
 }
 trap cleanup_desktop_brewfile EXIT HUP INT TERM
 
-# macOS Desktop App Stack App Groups checksum: {{ include "Brewfile.macos-desktop-apps.tmpl" | sha256sum }}
 cat >"$desktop_brewfile" <<'BREWFILE'
 {{ includeTemplate "Brewfile.macos-desktop-apps.tmpl" . -}}
 BREWFILE

--- a/.chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl
+++ b/.chezmoiscripts/run_before_60-install-ai-cli-tools.sh.tmpl
@@ -98,7 +98,6 @@ install_claude_code() {
   [ -x "$CLAUDE_CODE_CANONICAL_EXECUTABLE" ]
 }
 
-# Optional AI Tool Stack Brewfile checksum: {{ includeTemplate "Brewfile.ai-cli-tools.tmpl" . | sha256sum }}
 install_ai_cli_bundle || append_failed_ai_cli_tool "Homebrew bundle"
 install_claude_code || append_failed_ai_cli_tool "Claude Code"
 

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -1873,12 +1873,14 @@ assert_contains_text "$mise_tools_installer" 'mise_bin="$(standard_mise_path || 
 assert_contains_text "$mise_tools_installer" '"$mise_bin" install --yes -C "$HOME"' "Ubuntu runtime install invokes the resolved Homebrew mise"
 assert_not_contains_text "$mise_tools_installer" '/usr/bin/mise' "Ubuntu runtime install never falls back to APT mise"
 
-if ! printf '%s\n' "$mise_tools_installer" |
+# run_after_20 is not a run_onchange_ script, so a source checksum in it gates
+# nothing and only reads as if the script were change-tracked.
+if printf '%s\n' "$mise_tools_installer" |
   grep -E '^# mise-config-sha256=[0-9a-f]{64}$' >/dev/null; then
-  fail "mise tool installer tracks rendered mise config changes"
+  fail "mise tool installer carries no vestigial rendered-config checksum"
 fi
 
-pass "mise tool installer tracks rendered mise config changes"
+pass "mise tool installer carries no vestigial rendered-config checksum"
 
 mise_tools_installer_script="$tmp_dir/mise-tools-installer.sh"
 printf '%s\n' "$mise_tools_installer" |
@@ -2501,6 +2503,41 @@ warning_script_data() {
       ;;
   esac
 }
+
+# A `sha256sum` over a source file only does anything in a run_onchange_ script,
+# where chezmoi hashes the rendered content to decide whether to run. Anywhere
+# else it reads as change-gating that does not exist. And where it is
+# load-bearing it has to hash what the user actually gets: `include` of a
+# template returns the raw source, which does not change when a setting toggles
+# an App Group on, so a checksum over a `.tmpl` source must use
+# `includeTemplate … .`.
+for checksum_script_template in "$repo_root"/.chezmoiscripts/*.tmpl; do
+  checksum_script_name="${checksum_script_template##*/}"
+
+  case "$checksum_script_name" in
+    run_onchange_*)
+      raw_template_checksums="$(
+        grep -n 'sha256sum' "$checksum_script_template" |
+          grep -E '(^|[^A-Za-z])include[[:space:]]+"[^"]*\.tmpl"' || true
+      )"
+
+      if [ -n "$raw_template_checksums" ]; then
+        printf '%s\n' "$raw_template_checksums" | sed 's/^/  /' >&2
+        fail "run_onchange checksum over a template source uses includeTemplate: $checksum_script_name"
+      fi
+      pass "run_onchange checksum over a template source uses includeTemplate: $checksum_script_name"
+      ;;
+    *)
+      vestigial_checksums="$(grep -n 'sha256sum' "$checksum_script_template" || true)"
+
+      if [ -n "$vestigial_checksums" ]; then
+        printf '%s\n' "$vestigial_checksums" | sed 's/^/  /' >&2
+        fail "always-run chezmoi script carries no vestigial checksum: $checksum_script_name"
+      fi
+      pass "always-run chezmoi script carries no vestigial checksum: $checksum_script_name"
+      ;;
+  esac
+done
 
 for warning_script in $inlined_warning_scripts; do
   rendered_warning_script="$(render_template "$(warning_script_data "$warning_script")" "$warning_script")"


### PR DESCRIPTION
Closes #180

> Stacked on #201 (issue #165), which is itself stacked on #197 (issue #164). Base is `juty9026/issue-165-headerless-record-fields`.

## Problem

A `sha256sum` over a source file only does anything in a `run_onchange_` script, where chezmoi hashes the rendered script content to decide whether to run it. `run_before_10-reconcile-homebrew.sh.tmpl`, `run_after_20-install-mise-tools.sh.tmpl`, and `run_before_60-install-ai-cli-tools.sh.tmpl` always run. Their checksum lines gate nothing, and they read as change-tracking that is not there.

Separately, `run_before_10` hashed `{{ include "Brewfile.macos-desktop-apps.tmpl" | sha256sum }}` — the raw source. `run_onchange_after_50` hashes the same file with `{{ includeTemplate "Brewfile.macos-desktop-apps.tmpl" . | sha256sum }}` — the rendered output. Only the second changes when a user toggles an App Group setting, so the `run_before_10` form was both inert and the wrong thing to copy into a `run_onchange_` script.

### Where the code differs from the issue

- `run_after_20`'s line is `# mise-config-sha256={{ includeTemplate "dot_config/mise/config.toml.tmpl" . | sha256sum }}`, not the `# … checksum:` form. Same defect, different spelling.
- The `run_before_10` lines are at `:269` and `:292`, not `:303` and `:338`, and `run_before_60`'s is at `:101`, not `:89`. The file shifted under the issue.
- `run_before_10`'s duplicated `join_lines_with_commas` is at `:23-36`, not `:70-82`.

## Approach

All four checksum lines are deleted. After that, every surviving checksum is in a `run_onchange_` script, and the only one over a template source (`run_onchange_after_50:18`) already uses `includeTemplate … .`, so standardizing needs no further edit. The other three hash `Brewfile`, `ubuntu-bootstrap.sh`, and `executable_jetendard-font` — none is a chezmoi template, so `include` is the correct and only form for them.

What keeps that true is a new test over every `.chezmoiscripts/*.tmpl`:

- an always-run script contains no `sha256sum` at all
- a `run_onchange_` checksum whose source ends in `.tmpl` uses `includeTemplate`, not bare `include`

Both halves run per file and name the file, so a new script gets checked the day it lands.

**Bonus, per the issue:** `run_before_10` defined `join_lines_with_commas` byte-for-byte identically to `terrapod_homebrew_core_join_lines_with_commas` from `homebrew-core-bundle.sh`, which the same script inlines 46 lines earlier. The local copy is deleted and both call sites use the library function.

## Tests

`tests/chezmoiignore_test.sh`:

- 10 new cases from the guard loop — 7 always-run templates and 3 `run_onchange_` templates.
- The existing `mise tool installer tracks rendered mise config changes` case asserted the checksum line was present, on a premise that was never true. It is inverted to `mise tool installer carries no vestigial rendered-config checksum` rather than deleted, so the line cannot come back.

Red checks:

- Restoring `run_before_60`'s checksum line fails `always-run chezmoi script carries no vestigial checksum: run_before_60-install-ai-cli-tools.sh.tmpl`.
- Swapping `run_onchange_after_50`'s `includeTemplate … .` back to `include` fails the suite — though the pre-existing `Karabiner opener tracks different macOS Desktop App Group combinations` case trips first, which is itself the direct evidence that the raw form misses App Group toggles. The new assertion is a second, explicit line of defense; its grep was verified in isolation to match a raw `include "x.tmpl"` while ignoring `includeTemplate "x.tmpl" .` and `include "Brewfile"`.

The `join_lines_with_commas` removal is covered by the existing desktop-app attribution cases, which assert `failed casks: ghostty, raycast` and `App Groups: terminal-apps, launcher` — both produced by the joiner.

Suite results on this branch:

| suite | ok | not ok |
| --- | --- | --- |
| `chezmoiignore_test.sh` | 344 | 0 |
| `terrapod_config_test.sh` | 393 | 0 |
| `terrapod_command_test.sh` | 226 | 1 (pre-existing) |
| `bootstrap_ubuntu_test.sh` | 31 | 0 |
| `shell_integrations_test.sh` | 38 | 0 |
| `homebrew_manifests_test.sh` | 8 | 0 |

The one failure is `Terrapod status reports installed Jetendard font files`, which reproduces on a clean `origin/main` checkout on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKu7yrNkZj6rtDDuF1kzVF