### PR TITLE
Clean up the marker snapshot and report an unreadable warning state

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1004,28 +1004,47 @@ snapshot_install_warnings_from_source() {
   done
 }
 
-install_warning_markers_changed_since_snapshot() {
+# Reports 0 when no marker changed, 1 when at least one did, and 2 when the
+# answer could not be determined: the marker library is not loaded, or a
+# marker exists but cannot be read. Reporting either of those as "nothing
+# changed" would hide fresh warnings behind a clean completion message.
+install_warning_marker_change_status() {
   source_dir="$1"
   snapshot_dir="$2"
   changed=false
 
+  if [ "${TERRAPOD_INSTALL_WARNINGS_LOADED:-}" != "1" ]; then
+    return 2
+  fi
+
   for category in $(terrapod_install_warning_categories); do
+    marker_path="$(terrapod_install_warning_existing_path "$category" 2>/dev/null || true)"
+    if [ -z "$marker_path" ]; then
+      continue
+    fi
+
     current_file="$snapshot_dir/current-$category"
-    if terrapod_install_warning_read "$category" >"$current_file" 2>/dev/null; then
-      marker_path="$(terrapod_install_warning_existing_path "$category" 2>/dev/null || true)"
-      if [ ! -f "$snapshot_dir/$category" ] ||
-        ! cmp -s "$snapshot_dir/$category" "$current_file" ||
-        {
-          [ -f "$snapshot_dir/$category.identity" ] &&
-            [ ! "$snapshot_dir/$category.identity" -ef "$marker_path" ]
-        }; then
-        changed=true
-      fi
+    if ! terrapod_install_warning_read "$category" >"$current_file" 2>/dev/null; then
+      rm -f "$current_file"
+      return 2
+    fi
+
+    if [ ! -f "$snapshot_dir/$category" ] ||
+      ! cmp -s "$snapshot_dir/$category" "$current_file" ||
+      {
+        [ -f "$snapshot_dir/$category.identity" ] &&
+          [ ! "$snapshot_dir/$category.identity" -ef "$marker_path" ]
+      }; then
+      changed=true
     fi
     rm -f "$current_file"
   done
 
-  [ "$changed" = "true" ]
+  if [ "$changed" = "true" ]; then
+    return 1
+  fi
+
+  return 0
 }
 
 run_terrapod_setup() {
@@ -1218,6 +1237,8 @@ apply_recovery_core_shell_startup_files() {
   fi
 }
 
+# Returns 0 for a clean apply, 2 when install warning markers changed, and 3
+# when the marker state could not be read.
 run_initial_apply() {
   profile="$1"
   source_dir="$2"
@@ -1225,22 +1246,34 @@ run_initial_apply() {
   tpod_bin="$local_bin_dir/tpod"
   marker_snapshot_dir="$(mktemp -d)" ||
     fatal "failed to create install-warning snapshot directory"
+  trap 'rm -rf "$marker_snapshot_dir"' EXIT
+  trap 'rm -rf "$marker_snapshot_dir"; exit 1' INT TERM
 
   snapshot_install_warnings_from_source "$source_dir" "$marker_snapshot_dir" ||
     fatal "failed to snapshot install warning markers"
 
   if ! TERRAPOD_PROFILE="$profile" TERRAPOD_FIRST_RUN_APPLY=1 "$tpod_bin" apply; then
-    rm -rf "$marker_snapshot_dir"
     fatal "installed tpod apply failed"
   fi
 
-  if install_warning_markers_changed_since_snapshot "$source_dir" "$marker_snapshot_dir"; then
-    rm -rf "$marker_snapshot_dir"
-    return 2
-  fi
+  marker_change_status=0
+  install_warning_marker_change_status "$source_dir" "$marker_snapshot_dir" ||
+    marker_change_status="$?"
 
   rm -rf "$marker_snapshot_dir"
-  return 0
+  trap - EXIT INT TERM
+
+  case "$marker_change_status" in
+    0)
+      return 0
+      ;;
+    1)
+      return 2
+      ;;
+    *)
+      return 3
+      ;;
+  esac
 }
 
 show_first_run_help() {
@@ -1277,6 +1310,18 @@ print_first_run_warning_completion() {
   printf '%s\n' "Terrapod first-run apply completed with warnings."
   printf '%s\n' "Warning:"
   printf '%s\n' "  Terrapod installed and the recovery core is valid, but machine profile readiness needs attention."
+  printf '%s\n' "  Review the full apply output above, then run:"
+  printf '%s\n' "  $local_bin_dir/tpod doctor"
+}
+
+print_first_run_unknown_marker_completion() {
+  local_bin_dir="$1"
+
+  printf '\n'
+  printf '%s\n' "Terrapod first-run apply completed with an unknown warning state."
+  printf '%s\n' "Warning:"
+  printf '%s\n' "  Terrapod installed and the recovery core is valid, but install warning markers could not be read,"
+  printf '%s\n' "  so new machine profile readiness warnings could not be detected."
   printf '%s\n' "  Review the full apply output above, then run:"
   printf '%s\n' "  $local_bin_dir/tpod doctor"
 }
@@ -1338,6 +1383,9 @@ main() {
       ;;
     2)
       print_first_run_warning_completion "$local_bin_dir"
+      ;;
+    3)
+      print_first_run_unknown_marker_completion "$local_bin_dir"
       ;;
     *)
       fatal "unexpected initial apply status: $initial_apply_status"

--- a/tests/terrapod_installer_test.sh
+++ b/tests/terrapod_installer_test.sh
@@ -2878,3 +2878,151 @@ assert_failure "$installer_status" "installer fails when the checked-out source 
 assert_contains "$(cat "$missing_install_warnings_library_case/stderr")" \
   "failed to load the install warning library" \
   "missing install warning library failure is explicit"
+
+unreadable_marker_case="$(make_case_dir unreadable-marker)"
+prepare_resumable_macos_case "$unreadable_marker_case"
+write_complete_setup_config "$unreadable_marker_case/xdg-config/chezmoi/chezmoi.toml"
+HOME="$unreadable_marker_case/home" sh -c \
+  '. "$1"; terrapod_install_warning_write mise-tools "unreadable warning" "unreadable guidance"' \
+  sh "$install_warnings_lib_template"
+chmod 000 "$unreadable_marker_case/home/.local/state/terrapod/install-warnings/mise-tools"
+unreadable_marker_log="$unreadable_marker_case/command-calls"
+TERRAPOD_STUB_CALL_LOG="$unreadable_marker_log"
+export TERRAPOD_STUB_CALL_LOG
+run_installer_case "$unreadable_marker_case"
+unset TERRAPOD_STUB_CALL_LOG
+chmod 600 "$unreadable_marker_case/home/.local/state/terrapod/install-warnings/mise-tools"
+assert_status "$installer_status" 0 "an unreadable install warning marker does not fail the installer"
+unreadable_marker_stdout="$(cat "$unreadable_marker_case/stdout")"
+assert_not_contains "$unreadable_marker_stdout" "Terrapod first-run apply complete." "an unreadable install warning marker is not reported as a clean completion"
+assert_contains "$unreadable_marker_stdout" "Terrapod first-run apply completed with an unknown warning state." "an unreadable install warning marker is reported as an unknown warning state"
+assert_contains "$unreadable_marker_stdout" "install warning markers could not be read" "unknown warning state explains that markers could not be read"
+assert_contains "$unreadable_marker_stdout" "$unreadable_marker_case/home/.local/bin/tpod doctor" "unknown warning state prints the absolute doctor recovery command"
+
+marker_status_case="$(make_case_dir marker-change-status)"
+marker_status_functions="$marker_status_case/install-functions.sh"
+sed '$d' "$repo_root/install.sh" >"$marker_status_functions"
+marker_status_home="$marker_status_case/home"
+marker_status_snapshot="$marker_status_case/snapshot"
+mkdir -p "$marker_status_home" "$marker_status_snapshot"
+
+marker_status_result=0
+sh -c '. "$1"; install_warning_marker_change_status "$2" "$3"' \
+  sh "$marker_status_functions" "$marker_status_case" "$marker_status_snapshot" ||
+  marker_status_result="$?"
+assert_status "$marker_status_result" 2 "marker change status reports an unknown state when the warning library is not loaded"
+
+HOME="$marker_status_home" sh -c \
+  '. "$1"; terrapod_install_warning_write mise-tools "snapshot warning" "snapshot guidance"' \
+  sh "$install_warnings_lib_template"
+HOME="$marker_status_home" sh -c \
+  '. "$1"; . "$2"; snapshot_install_warnings_from_source "$3" "$4"' \
+  sh "$install_warnings_lib_template" "$marker_status_functions" \
+  "$marker_status_case" "$marker_status_snapshot"
+
+marker_status_result=0
+HOME="$marker_status_home" sh -c \
+  '. "$1"; . "$2"; install_warning_marker_change_status "$3" "$4"' \
+  sh "$install_warnings_lib_template" "$marker_status_functions" \
+  "$marker_status_case" "$marker_status_snapshot" ||
+  marker_status_result="$?"
+assert_status "$marker_status_result" 0 "marker change status reports no change when every marker still matches the snapshot"
+
+HOME="$marker_status_home" sh -c \
+  '. "$1"; terrapod_install_warning_write mise-tools "changed warning" "changed guidance"' \
+  sh "$install_warnings_lib_template"
+
+marker_status_result=0
+HOME="$marker_status_home" sh -c \
+  '. "$1"; . "$2"; install_warning_marker_change_status "$3" "$4"' \
+  sh "$install_warnings_lib_template" "$marker_status_functions" \
+  "$marker_status_case" "$marker_status_snapshot" ||
+  marker_status_result="$?"
+assert_status "$marker_status_result" 1 "marker change status reports a change when a marker was rewritten"
+
+chmod 000 "$marker_status_home/.local/state/terrapod/install-warnings/mise-tools"
+marker_status_result=0
+HOME="$marker_status_home" sh -c \
+  '. "$1"; . "$2"; install_warning_marker_change_status "$3" "$4"' \
+  sh "$install_warnings_lib_template" "$marker_status_functions" \
+  "$marker_status_case" "$marker_status_snapshot" ||
+  marker_status_result="$?"
+chmod 600 "$marker_status_home/.local/state/terrapod/install-warnings/mise-tools"
+assert_status "$marker_status_result" 2 "marker change status reports an unknown state when a marker exists but cannot be read"
+
+write_mktemp_dir_stub() {
+  stub="$1"
+  snapshot_root="$2"
+  real_mktemp="$(command -v mktemp)"
+
+  cat >"$stub" <<EOF
+#!/bin/sh
+set -eu
+
+if [ "\${1:-}" = "-d" ] && [ "\$#" -eq 1 ]; then
+  target="$snapshot_root/snapshot.\$\$"
+  mkdir -p "\$target"
+  printf '%s\n' "\$target"
+  exit 0
+fi
+
+exec "$real_mktemp" "\$@"
+EOF
+  chmod +x "$stub"
+}
+
+snapshot_trap_case="$(make_case_dir marker-snapshot-trap)"
+snapshot_trap_functions="$snapshot_trap_case/install-functions.sh"
+sed '$d' "$repo_root/install.sh" >"$snapshot_trap_functions"
+snapshot_trap_root="$snapshot_trap_case/snapshots"
+mkdir -p "$snapshot_trap_root" "$snapshot_trap_case/home/.local/bin"
+write_mktemp_dir_stub "$snapshot_trap_case/bin/mktemp" "$snapshot_trap_root"
+
+if PATH="$snapshot_trap_case/bin:$PATH" sh -c '
+. "$1"
+snapshot_install_warnings_from_source() {
+  return 1
+}
+run_initial_apply macos-terminal "$2" "$3"
+' sh "$snapshot_trap_functions" "$snapshot_trap_case" "$snapshot_trap_case/home/.local/bin" \
+  >"$snapshot_trap_case/stdout" 2>"$snapshot_trap_case/stderr"; then
+  fail "a failed marker snapshot stops the initial apply"
+fi
+pass "a failed marker snapshot stops the initial apply"
+
+assert_contains "$(cat "$snapshot_trap_case/stderr")" "failed to snapshot install warning markers" \
+  "a failed marker snapshot explains itself"
+
+if [ -n "$(find "$snapshot_trap_root" -mindepth 1 -print)" ]; then
+  printf '%s\n' "leftover snapshot temp entries:" >&2
+  find "$snapshot_trap_root" -mindepth 1 -print | sed 's/^/  /' >&2
+  fail "a failed marker snapshot removes the snapshot temp directory"
+fi
+pass "a failed marker snapshot removes the snapshot temp directory"
+
+signal_trap_case="$(make_case_dir marker-snapshot-signal)"
+signal_trap_functions="$signal_trap_case/install-functions.sh"
+sed '$d' "$repo_root/install.sh" >"$signal_trap_functions"
+signal_trap_root="$signal_trap_case/snapshots"
+mkdir -p "$signal_trap_root" "$signal_trap_case/home/.local/bin"
+write_mktemp_dir_stub "$signal_trap_case/bin/mktemp" "$signal_trap_root"
+
+if PATH="$signal_trap_case/bin:$PATH" sh -c '
+. "$1"
+snapshot_install_warnings_from_source() {
+  kill -TERM $$
+  sleep 5
+}
+run_initial_apply macos-terminal "$2" "$3"
+' sh "$signal_trap_functions" "$signal_trap_case" "$signal_trap_case/home/.local/bin" \
+  >"$signal_trap_case/stdout" 2>"$signal_trap_case/stderr"; then
+  fail "an interrupted initial apply stops instead of continuing"
+fi
+pass "an interrupted initial apply stops instead of continuing"
+
+if [ -n "$(find "$signal_trap_root" -mindepth 1 -print)" ]; then
+  printf '%s\n' "leftover snapshot temp entries:" >&2
+  find "$signal_trap_root" -mindepth 1 -print | sed 's/^/  /' >&2
+  fail "an interrupted initial apply removes the snapshot temp directory"
+fi
+pass "an interrupted initial apply removes the snapshot temp directory"


### PR DESCRIPTION
Closes #162

Stacked on #198 (`juty9026/issue-161-update-guidance`).

## Problem

1. `run_initial_apply` created `marker_snapshot_dir` with `mktemp -d` and no trap, then removed it at three separate exit points. Any path that did not reach one of those three — an interrupt, or the `fatal` on a failed snapshot — left the directory behind. Verified against `main`: forcing either path leaves a `snapshot.*` directory in place.
2. `install_warning_markers_changed_since_snapshot` answered a plain yes/no. A marker that exists but cannot be read (`terrapod_install_warning_read` fails) was skipped and counted as "nothing changed", so the run finished with "Terrapod first-run apply complete." and hid the warning.

## Change

- `run_initial_apply` sets `trap 'rm -rf "$marker_snapshot_dir"' EXIT` and `trap 'rm -rf "$marker_snapshot_dir"; exit 1' INT TERM`, and the three duplicate `rm -rf` calls collapse into one before `trap - EXIT INT TERM`. The split follows the existing convention in `dot_local/bin/executable_terrapod:2339-2340`, where the signal trap exits rather than resuming — the issue's single-`trap` sketch would have let an interrupted apply continue.
- `install_warning_markers_changed_since_snapshot` becomes `install_warning_marker_change_status`, returning 0 for no change, 1 for a change, and 2 when the answer cannot be determined: the warning library is not loaded, or a marker exists but cannot be read.
- `run_initial_apply` maps that third status to a new return code 3, and `main` prints `print_first_run_unknown_marker_completion` for it — same doctor guidance as the warning completion, but an honest headline instead of a clean one.

## Note on the issue text

The issue cites `install.sh:1044`, where `install_warning_markers_changed_since_snapshot` did `load_install_warnings_from_source || return 1`. That call is already gone: #194 moved the library load to `main`, which now `fatal`s if it fails. So the exact conflation the issue names no longer reaches that function. The same conflation still existed one level down — an existing-but-unreadable marker read as "no change" — so that is what the distinct status covers, plus a guard for an unloaded library so the function cannot silently regress if a future caller skips the load.

## Tests

New coverage in `tests/terrapod_installer_test.sh`:

- a full installer run with an unreadable marker finishes at status 0, does not print the clean completion, prints the unknown warning state and the absolute `tpod doctor` command
- `install_warning_marker_change_status` unit cases for all three statuses: no change, a rewritten marker, an unloaded library, and an existing-but-unreadable marker
- a failed snapshot stops the apply and leaves no snapshot directory
- a `TERM` during the snapshot stops the apply and leaves no snapshot directory

The two trap tests stub `mktemp` into a controlled directory, because macOS `mktemp -d` ignores `TMPDIR`. Both were confirmed to fail against `origin/main` (a leftover `snapshot.<pid>` directory in each case) and to pass here.

```
$ sh tests/terrapod_installer_test.sh   -> 404 ok, exit 0
$ sh tests/terrapod_command_test.sh     -> 519 ok, exit 0
$ sh tests/terrapod_config_test.sh      -> 418 ok, exit 0
$ sh tests/bootstrap_ubuntu_test.sh     -> 31 ok, exit 0
```

Every other suite under `tests/` was run too and passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKu7yrNkZj6rtDDuF1kzVF