### PR TITLE
Assert the Hammerspoon launcher bindings positively

### DIFF
--- a/tests/hammerspoon_config_test.sh
+++ b/tests/hammerspoon_config_test.sh
@@ -3,6 +3,12 @@ set -eu
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 hammerspoon_config="$repo_root/dot_hammerspoon/init.lua"
+tmp_dir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT INT TERM
 
 fail() {
   printf '%s\n' "not ok - $1" >&2
@@ -13,64 +19,108 @@ pass() {
   printf '%s\n' "ok - $1"
 }
 
-assert_contains() {
-  needle="$1"
-  message="$2"
+# Reads the appBindings table out of init.lua as tab-separated
+# key/label/bundleID rows. Entries may name a top-level `local` string instead
+# of a literal, so those definitions are resolved first; an entry naming
+# anything else renders as UNRESOLVED(...) and fails the comparison below
+# rather than silently dropping out of the table.
+extract_bindings() {
+  awk '
+    function unquote(value) {
+      if (value ~ /^".*"$/) {
+        gsub(/^"|"$/, "", value)
+        return value
+      }
 
-  if ! grep -F "$needle" "$hammerspoon_config" >/dev/null; then
-    fail "$message"
-  fi
+      if (value in literals) {
+        return literals[value]
+      }
 
-  pass "$message"
+      return "UNRESOLVED(" value ")"
+    }
+
+    /^local [A-Za-z_][A-Za-z0-9_]* = ".*"$/ {
+      value = $0
+      sub(/^local [A-Za-z_][A-Za-z0-9_]* = "/, "", value)
+      sub(/"$/, "", value)
+      literals[$2] = value
+      next
+    }
+
+    /^local appBindings = \{$/ {
+      in_table = 1
+      next
+    }
+
+    in_table && /^\}$/ {
+      in_table = 0
+      next
+    }
+
+    in_table {
+      entry = $0
+      sub(/^[[:space:]]*\{[[:space:]]*/, "", entry)
+      sub(/[[:space:]]*\},?[[:space:]]*$/, "", entry)
+
+      key = ""
+      label = ""
+      bundle_id = ""
+
+      field_count = split(entry, fields, /,[[:space:]]*/)
+      for (field_index = 1; field_index <= field_count; field_index++) {
+        split(fields[field_index], pair, /[[:space:]]*=[[:space:]]*/)
+
+        if (pair[1] == "key") {
+          key = unquote(pair[2])
+        } else if (pair[1] == "label") {
+          label = unquote(pair[2])
+        } else if (pair[1] == "bundleID") {
+          bundle_id = unquote(pair[2])
+        }
+      }
+
+      printf "%s\t%s\t%s\n", key, label, bundle_id
+    }
+  ' "$hammerspoon_config"
 }
 
-assert_not_contains() {
-  needle="$1"
-  message="$2"
+extract_bindings >"$tmp_dir/actual"
 
-  if grep -F "$needle" "$hammerspoon_config" >/dev/null; then
-    fail "$message"
+[ -s "$tmp_dir/actual" ] || fail "Hammerspoon launcher declares an appBindings table"
+pass "Hammerspoon launcher declares an appBindings table"
+
+cat >"$tmp_dir/expected" <<'BINDINGS'
+t	Ghostty	com.mitchellh.ghostty
+s	Slack	com.tinyspeck.slackmacgap
+d	Discord	com.hnc.Discord
+n	Notion	notion.id
+b	Google Chrome	com.google.Chrome
+1	Orca	com.stablyai.orca
+2	Zed	dev.zed.Zed
+o	Obsidian	md.obsidian
+p	Postman	com.postmanlabs.mac
+f	Figma	com.figma.Desktop
+BINDINGS
+
+if ! diff -u "$tmp_dir/expected" "$tmp_dir/actual" >"$tmp_dir/bindings.diff"; then
+  cat "$tmp_dir/bindings.diff" >&2
+  fail "Hammerspoon launcher binds exactly the expected key, label and bundle ID for every app"
+fi
+pass "Hammerspoon launcher binds exactly the expected key, label and bundle ID for every app"
+
+duplicate_keys="$(cut -f1 "$tmp_dir/actual" | sort | uniq -d)"
+if [ -n "$duplicate_keys" ]; then
+  printf 'duplicate keys: %s\n' "$(printf '%s' "$duplicate_keys" | tr '\n' ' ')" >&2
+  fail "Hammerspoon launcher binds each key to a single app"
+fi
+pass "Hammerspoon launcher binds each key to a single app"
+
+# init.lua binds "/" to the help toast and "r" to a reload on both the hyper
+# chord and the leader modal. An app claiming either key would register a
+# second handler for it.
+for reserved_key in / r; do
+  if cut -f1 "$tmp_dir/actual" | grep -Fx "$reserved_key" >/dev/null; then
+    fail "Hammerspoon launcher leaves $reserved_key to the help and reload bindings"
   fi
-
-  pass "$message"
-}
-
-assert_contains \
-  '{ key = "1", label = "Orca", bundleID = "com.stablyai.orca" }' \
-  "Hammerspoon launcher binds Orca to 1"
-
-assert_contains \
-  '{ key = "2", label = "Zed", bundleID = "dev.zed.Zed" }' \
-  "Hammerspoon launcher binds Zed to 2"
-
-assert_not_contains \
-  'com.openai.codex' \
-  "Hammerspoon launcher no longer includes ChatGPT"
-
-assert_not_contains \
-  'com.anthropic.claudefordesktop' \
-  "Hammerspoon launcher no longer includes Claude Desktop"
-
-assert_not_contains \
-  '{ key = "4", label = "Orca", bundleID = "com.stablyai.orca" }' \
-  "Hammerspoon launcher no longer binds Orca to 4"
-
-assert_not_contains \
-  'com.google.antigravity' \
-  "Hammerspoon launcher no longer includes Antigravity desktop apps"
-
-assert_not_contains \
-  'ChatGPT Atlas' \
-  "Hammerspoon launcher no longer includes ChatGPT Atlas label"
-
-assert_not_contains \
-  'com.openai.atlas' \
-  "Hammerspoon launcher no longer includes ChatGPT Atlas bundle ID"
-
-assert_not_contains \
-  '{ key = "c", label = "Codex", bundleID = "com.openai.codex" }' \
-  "Hammerspoon launcher no longer binds Codex Desktop to c"
-
-assert_not_contains \
-  '{ key = "i", label = "Antigravity", bundleID = "com.google.antigravity" }' \
-  "Hammerspoon launcher no longer binds Antigravity 2.0 to i"
+done
+pass "Hammerspoon launcher leaves / and r to the help and reload bindings"


### PR DESCRIPTION
Stacked on #200 (issue #175). Review the last commit only.

## Problem

`tests/hammerspoon_config_test.sh` had 10 assertions, and 8 of them asserted
the absence of strings that were removed in earlier changes. Two pairs could
not fail independently: the file-wide `assert_not_contains 'com.openai.codex'`
already covers the later `{ key = "c", ... bundleID = "com.openai.codex" }`
assertion, and `com.google.antigravity` covers the `key = "i"` one the same way.

The two positive assertions covered `key = "1"` (Orca) and `key = "2"` (Zed) —
2 of the 10 entries in `appBindings`. The other 8 apps, every `label`, and any
duplicate `key` were untested. Renaming Slack's bundle ID, dropping Figma, or
binding two apps to the same key all left the suite green.

## Approach

The negative assertions are gone, replaced by one exhaustive comparison. An
`awk` pass extracts `appBindings` from `init.lua` as tab-separated
key/label/bundleID rows and diffs them against a literal expected table. That
subsumes every deleted negative assertion: a bundle ID that is not in the
expected list cannot be in the table, whether it is `com.openai.codex` or
something nobody has thought of yet. A mismatch prints the diff before failing.

Two entries name a `local` rather than a literal — `{ key = "t", label =
ghosttyAppName, bundleID = ghosttyBundleID }` — so the extractor first collects
top-level `local <name> = "<value>"` definitions and resolves through them. An
entry naming anything else renders as `UNRESOLVED(<name>)` and fails the
comparison, rather than dropping out of the table and shrinking the expected
list to whatever still parses.

The comparison keeps `label` alongside `key` and `bundleID`, though the issue's
fix direction only names key→bundleID. The deleted assertions did check labels
(`label = "Orca"`), and the label is what the leader-key help toast renders, so
dropping it would have traded one coverage gap for another.

Two checks follow the comparison:

- **Duplicate keys.** `cut | sort | uniq -d` over the extracted keys.
- **Reserved keys.** `init.lua` binds `/` to the help toast and `r` to a reload,
  on both the hyper chord and the leader modal. An app claiming either key would
  register a second handler for the same chord. This is the same defect class as
  a duplicate key, so it sits with it.

## Divergence from the issue text

The issue cites `tests/hammerspoon_config_test.sh:46-76`. In the code the
redundant block is lines 46-76 only if you count from `assert_not_contains
'com.openai.codex'` at line 45. Nothing else differs.

## Tests

Assertion count drops from 10 to 4, and coverage goes from 2 of 10 bindings to
all 10 plus their labels, plus two structural checks.

```
$ sh tests/hammerspoon_config_test.sh
ok - Hammerspoon launcher declares an appBindings table
ok - Hammerspoon launcher binds exactly the expected key, label and bundle ID for every app
ok - Hammerspoon launcher binds each key to a single app
ok - Hammerspoon launcher leaves / and r to the help and reload bindings
```

Each assertion was mutation-tested against a temporarily edited `init.lua`,
because a comparison test that cannot fail is exactly the problem this issue
describes:

| Mutation | Result |
| --- | --- |
| `com.stablyai.orca` → `com.example.impostor` | diff shows the changed row, fails |
| `label = "Zed"` → `label = "Zed Editor"` | diff shows the changed row, fails |
| added `{ key = "x", label = "Xcode", ... }` | diff shows the extra row, fails |
| added a second `key = "f"` entry | `duplicate keys: f`, fails |
| added `{ key = "r", ... }` | fails the reserved-key check |
| `bundleID = "md.obsidian"` → `bundleID = obsidianBundleID` | `UNRESOLVED(obsidianBundleID)`, fails |
| `local appBindings` renamed | fails on the empty-table guard |

`init.lua` was restored after each; the working tree is unchanged by this PR
outside the test file.

Full suite through the runner added in #200: **21 test files passed, 2056
assertions** (2062 before, minus the 6 net assertions this file drops).

## Follow-ups

The issue also notes that the leader-key modal and the Ghostty input-source
retry logic have no assertions. Both are runtime behavior inside Hammerspoon
rather than table structure, so neither fits this file's grep-the-config
approach; they are out of scope for the stated fix direction and still open.

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKu7yrNkZj6rtDDuF1kzVF
