### PR TITLE
Drop the .chezmoiignore entry for a script that does not exist

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -33,7 +33,6 @@ tests/**
 
 {{ if ne .chezmoi.os "darwin" }}
 # macOS Terminal Profile entries are not part of the VPS Shell Profile.
-.chezmoiscripts/13-retry-homebrew-desktop-apps.sh
 .chezmoiscripts/02-retry-jetendard-font.sh
 .chezmoiscripts/50-open-karabiner-if-needed.sh
 .chezmoiscripts/65-install-jetendard-font.sh

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -235,6 +235,50 @@ do
 done
 pass "Ubuntu manages cross-profile Homebrew core state"
 
+# .chezmoiignore names target paths, so an entry only means anything if some
+# source script actually renders to it. A dead entry rots into false safety: the
+# list looks complete while a macOS-only script that is genuinely missing from it
+# goes unnoticed.
+chezmoiscript_target_name() {
+  script_target_name="${1##*/}"
+  script_target_name="${script_target_name%.tmpl}"
+
+  case "$script_target_name" in
+    run_onchange_before_*) script_target_name="${script_target_name#run_onchange_before_}" ;;
+    run_onchange_after_*) script_target_name="${script_target_name#run_onchange_after_}" ;;
+    run_onchange_*) script_target_name="${script_target_name#run_onchange_}" ;;
+    run_before_*) script_target_name="${script_target_name#run_before_}" ;;
+    run_after_*) script_target_name="${script_target_name#run_after_}" ;;
+    run_*) script_target_name="${script_target_name#run_}" ;;
+  esac
+
+  printf '%s\n' "$script_target_name"
+}
+
+chezmoiscript_target_names=""
+for script_source in "$repo_root"/.chezmoiscripts/*; do
+  chezmoiscript_target_names="$chezmoiscript_target_names$(chezmoiscript_target_name "$script_source")
+"
+done
+
+ignored_chezmoiscripts="$(grep -E '^\.chezmoiscripts/' "$repo_root/.chezmoiignore" || true)"
+
+if [ -z "$ignored_chezmoiscripts" ]; then
+  fail ".chezmoiignore still names chezmoi scripts to check"
+fi
+pass ".chezmoiignore still names chezmoi scripts to check"
+
+for ignored_chezmoiscript in $ignored_chezmoiscripts; do
+  ignored_chezmoiscript_name="${ignored_chezmoiscript#.chezmoiscripts/}"
+
+  if ! printf '%s' "$chezmoiscript_target_names" | grep -Fx -- "$ignored_chezmoiscript_name" >/dev/null; then
+    printf '%s\n' "known .chezmoiscripts target names:" >&2
+    printf '%s' "$chezmoiscript_target_names" | sed 's/^/  /' >&2
+    fail ".chezmoiignore entry resolves to a source script: $ignored_chezmoiscript"
+  fi
+  pass ".chezmoiignore entry resolves to a source script: $ignored_chezmoiscript"
+done
+
 macos_only_entries="
 .chezmoiscripts/run_before_02-retry-jetendard-font.sh.tmpl
 .chezmoiscripts/run_onchange_after_50-open-karabiner-if-needed.sh.tmpl


### PR DESCRIPTION
Closes #179

> Stacked on #203 (issue #180) → #201 (issue #165) → #197 (issue #164). Base is `juty9026/issue-180-checksum-comments`.

## Problem

`.chezmoiignore:36` listed `.chezmoiscripts/13-retry-homebrew-desktop-apps.sh` in the non-darwin block. `.chezmoiscripts/` contains no `13-*` script; the name survives only in `docs/superpowers/plans/2026-07-22-homebrew-unified-installation-source.md`.

The dead line itself is harmless. What it costs is the signal: `.chezmoiignore` names target paths, and nothing checked that those paths exist, so the list read as complete while an actually-missing macOS-only script would go unnoticed. A future macOS-only script under a different number would be applied on the **VPS Shell Profile** with no test to catch it.

## Approach

The line is deleted, and `tests/chezmoiignore_test.sh` now cross-checks the remaining entries.

The check has to bridge two namespaces: `.chezmoiignore` names targets (`.chezmoiscripts/02-retry-jetendard-font.sh`) while the repo holds sources (`.chezmoiscripts/run_before_02-retry-jetendard-font.sh.tmpl`). `chezmoiscript_target_name` reproduces chezmoi's mapping — strip the attribute prefix (`run_onchange_before_`, `run_onchange_after_`, `run_onchange_`, `run_before_`, `run_after_`, `run_`, longest first) and the `.tmpl` suffix — and every `.chezmoiscripts/` entry must resolve to one of the resulting names.

The loop is preceded by a non-empty assertion, so it cannot pass vacuously if the entries are ever restructured out of a plain `^.chezmoiscripts/` shape.

Scope is the `.chezmoiscripts/*` paths the issue names. The other target paths in the file (`.local/lib/terrapod/…`, `.config/ghostty`, …) are already covered by the existing `macos_only_entries` and `linux_only_entries` assertions, which compare against real `chezmoi managed` output per profile.

## Tests

`tests/chezmoiignore_test.sh`, 5 new cases:

- `.chezmoiignore still names chezmoi scripts to check`
- one `.chezmoiignore entry resolves to a source script: …` per remaining entry (`02-retry-jetendard-font.sh`, `50-open-karabiner-if-needed.sh`, `65-install-jetendard-font.sh`, `70-apply-jetendard-settings.sh`)

Red check: re-adding `.chezmoiscripts/13-retry-homebrew-desktop-apps.sh` fails with `.chezmoiignore entry resolves to a source script: .chezmoiscripts/13-retry-homebrew-desktop-apps.sh`, and the failure output lists the known target names.

Suite results on this branch:

| suite | ok | not ok |
| --- | --- | --- |
| `chezmoiignore_test.sh` | 349 | 0 |
| `terrapod_config_test.sh` | 393 | 0 |
| `terrapod_command_test.sh` | 226 | 1 (pre-existing) |

The one failure is `Terrapod status reports installed Jetendard font files`, which reproduces on a clean `origin/main` checkout on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKu7yrNkZj6rtDDuF1kzVF