### PR TITLE
Greet with fastfetch only in the first shell of a session

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -8,7 +8,10 @@ if command -v mise &>/dev/null; then
 fi
 
 # Fastfetch
-if command -v fastfetch &>/dev/null; then
+# The greeting belongs to the first shell of a session. Zellij panes and nested
+# shells run this file too, and the dev layout opens five panes at once; `c`
+# reprints it on demand.
+if [[ -z "${ZELLIJ:-}" && "${SHLVL:-1}" -le 1 ]] && command -v fastfetch &>/dev/null; then
   fastfetch
 fi
 

--- a/tests/zshrc_clear_test.zsh
+++ b/tests/zshrc_clear_test.zsh
@@ -30,6 +30,24 @@ assert_log_contains() {
   pass "$message"
 }
 
+assert_startup_fastfetch() {
+  local expected="$1"
+  local message="$2"
+
+  : >"$CLEAR_TEST_LOG"
+  source "$tmp_dir/home/.zshrc"
+
+  if command grep -F "fastfetch" "$CLEAR_TEST_LOG" >/dev/null 2>&1; then
+    if [[ "$expected" != ran ]]; then
+      fail "$message; fastfetch should not have run at startup"
+    fi
+  elif [[ "$expected" != skipped ]]; then
+    fail "$message; expected fastfetch to run at startup"
+  fi
+
+  pass "$message"
+}
+
 render_zshrc() {
   local data="$1"
 
@@ -139,3 +157,24 @@ if ! whence -w git_index >/dev/null 2>&1; then
 fi
 
 pass "SCM Breeze keeps its repo index under its full command name"
+
+# The greeting belongs to the first shell of a session. Zellij panes and nested
+# shells inherit .zshrc too, and the dev layout opens five panes at once.
+original_shlvl="$SHLVL"
+
+SHLVL=1
+unset ZELLIJ
+assert_startup_fastfetch ran "the first shell greets with system information"
+
+export ZELLIJ="0"
+assert_startup_fastfetch skipped "a Zellij pane does not repeat the greeting"
+
+: >"$CLEAR_TEST_LOG"
+c
+assert_log_contains "fastfetch" "c still prints system information inside a Zellij pane"
+
+unset ZELLIJ
+SHLVL=2
+assert_startup_fastfetch skipped "a nested shell does not repeat the greeting"
+
+SHLVL="$original_shlvl"


### PR DESCRIPTION
Closes #170

Stacked on #202 (`juty9026/issue-167-zsh-completions-compinit`) — same file.

## Problem

`dot_zshrc.tmpl:11-13` ran `fastfetch` unconditionally on every interactive shell:

```zsh
if command -v fastfetch &>/dev/null; then
  fastfetch
fi
```

Every new Zellij pane, split, and tab therefore pays a full system-info scan before the prompt. The repo ships a dev layout that opens five panes at once (`zd`, gated on `enableDevelopmentWorkspace`), plus `zja`/`zdac` helpers that encourage more, and every nested shell repeats it again.

## Approach

The decided direction: gate the startup call on being the outermost shell of a session.

```zsh
if [[ -z "${ZELLIJ:-}" && "${SHLVL:-1}" -le 1 ]] && command -v fastfetch &>/dev/null; then
  fastfetch
fi
```

Both halves earn their place:

- `$ZELLIJ` covers panes opened inside a running session, where `SHLVL` is simply whatever the session was launched with and carries no information about nesting.
- `$SHLVL` covers plain nesting outside Zellij — a subshell, a `zsh` inside `zsh`, a shell an editor spawns.

The `${ZELLIJ:-}` / `${SHLVL:-1}` defaults keep the file sourceable under `set -u`, which the zsh test suites run with.

`c()` (`dot_zshrc.tmpl:72-77`) is deliberately untouched. It still clears and reprints on demand, inside a pane as much as anywhere else, so the greeting stays one keystroke away.

Code matched the issue description; no discrepancies.

## Tests

Four cases added to `tests/zshrc_clear_test.zsh`, which already stubs `fastfetch` into a log file. A new `assert_startup_fastfetch` helper re-sources the rendered `.zshrc` under a chosen environment and asserts whether the stub ran.

```
$ zsh tests/zshrc_clear_test.zsh
... (13 pre-existing assertions) ...
ok - the first shell greets with system information
ok - a Zellij pane does not repeat the greeting
ok - c still prints system information inside a Zellij pane
ok - a nested shell does not repeat the greeting
```

Each gate clause is load-bearing, verified by deleting it:

- dropping the `SHLVL` term → `not ok - a nested shell does not repeat the greeting`
- dropping the `ZELLIJ` term → `not ok - a Zellij pane does not repeat the greeting`

The pre-existing `c` assertions (issue #170 names `tests/zshrc_clear_test.zsh:98`) all still pass, including the on-demand `fastfetch` one.

Other suites, all rc=0:

```
zsh tests/zshrc_completions_test.zsh    (3)
zsh tests/zshrc_zoxide_test.zsh         (22)
sh  tests/chezmoiignore_test.sh         (328)
sh  tests/terrapod_config_test.sh       (393)
sh  tests/terrapod_installer_test.sh    (390)
```

Those three `.sh` suites are the ones that render `.zshrc`; the rest of the suite is unaffected by this file.

No `CONTEXT.md` or ADR change: no domain term moved and no architectural decision changed. Neither README documents the startup greeting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKu7yrNkZj6rtDDuF1kzVF
