### PR TITLE
Drive macOS App Group and optional stack state from one table

### DIFF
--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -941,31 +941,22 @@ config_bool_state_label() {
   bool_state_label "$(config_data_bool "$1" "$2")"
 }
 
-effective_optional_stack_state_label() {
+# The Optional Development Workspace turns on the optional stacks it bundles,
+# so every optional stack answers the same "own key or the workspace key" rule.
+effective_optional_stack_enabled() {
   config_file="$1"
   key="$2"
 
   if [ "$(config_data_bool "$config_file" "$key")" = "true" ] ||
     [ "$(config_data_bool "$config_file" enableDevelopmentWorkspace)" = "true" ]; then
-    bool_state_label true
+    printf '%s\n' "true"
   else
-    bool_state_label false
+    printf '%s\n' "false"
   fi
 }
 
 is_enabled() {
   [ "$1" = "true" ]
-}
-
-effective_editor_stack_enabled() {
-  config_file="$1"
-
-  if [ "$(config_data_bool "$config_file" enableEditorStack)" = "true" ] ||
-    [ "$(config_data_bool "$config_file" enableDevelopmentWorkspace)" = "true" ]; then
-    printf '%s\n' "true"
-  else
-    printf '%s\n' "false"
-  fi
 }
 
 ai_cli_tools_supported_profile() {
@@ -981,12 +972,7 @@ effective_ai_cli_tools_enabled() {
     return
   fi
 
-  if [ "$(config_data_bool "$config_file" enableAiCliTools)" = "true" ] ||
-    [ "$(config_data_bool "$config_file" enableDevelopmentWorkspace)" = "true" ]; then
-    printf '%s\n' "true"
-  else
-    printf '%s\n' "false"
-  fi
+  effective_optional_stack_enabled "$config_file" enableAiCliTools
 }
 
 executable_selection_helper_available() {
@@ -1118,6 +1104,18 @@ print_optional_setting_status() {
   fi
 }
 
+# One row per macOS App Group as 'key|label|apps', read by every command that
+# reports App Group state so the list is edited in one place.
+macos_app_group_table() {
+  printf '%s\n' \
+    'enableMacosAppGroupTerminalApps|terminal-apps|Ghostty' \
+    'enableMacosAppGroupAutomation|automation|Hammerspoon, Karabiner-Elements, and Scroll Reverser' \
+    'enableMacosAppGroupLauncher|launcher|Raycast and 1Password CLI' \
+    'enableMacosAppGroupMonitoring|monitoring|iStat Menus' \
+    'enableMacosAppGroupDevelopmentApps|development-apps|Zed, Orca ADE, and OrbStack' \
+    'enableMacosAppGroupMobileDev|mobile-dev|Android Studio and Maestro'
+}
+
 print_macos_app_group_status() {
   config_file="$1"
   profile="$2"
@@ -1128,36 +1126,12 @@ print_macos_app_group_status() {
   fi
 
   print_section "macOS App Groups:"
-  if is_enabled "$(config_data_bool "$config_file" enableMacosAppGroupTerminalApps)"; then
-    print_indented_colon_state_line "terminal-apps" "enabled" "(Ghostty)"
-  else
-    print_indented_colon_state_line "terminal-apps" "disabled"
-  fi
-  if is_enabled "$(config_data_bool "$config_file" enableMacosAppGroupAutomation)"; then
-    print_indented_colon_state_line "automation" "enabled" "(Hammerspoon, Karabiner-Elements, and Scroll Reverser)"
-  else
-    print_indented_colon_state_line "automation" "disabled"
-  fi
-  if is_enabled "$(config_data_bool "$config_file" enableMacosAppGroupLauncher)"; then
-    print_indented_colon_state_line "launcher" "enabled" "(Raycast and 1Password CLI)"
-  else
-    print_indented_colon_state_line "launcher" "disabled"
-  fi
-  if is_enabled "$(config_data_bool "$config_file" enableMacosAppGroupMonitoring)"; then
-    print_indented_colon_state_line "monitoring" "enabled" "(iStat Menus)"
-  else
-    print_indented_colon_state_line "monitoring" "disabled"
-  fi
-  if is_enabled "$(config_data_bool "$config_file" enableMacosAppGroupDevelopmentApps)"; then
-    print_indented_colon_state_line "development-apps" "enabled" "(Zed, Orca ADE, and OrbStack)"
-  else
-    print_indented_colon_state_line "development-apps" "disabled"
-  fi
-  if is_enabled "$(config_data_bool "$config_file" enableMacosAppGroupMobileDev)"; then
-    print_indented_colon_state_line "mobile-dev" "enabled" "(Android Studio and Maestro)"
-  else
-    print_indented_colon_state_line "mobile-dev" "disabled"
-  fi
+  macos_app_group_table | while IFS='|' read -r group_key group_label group_apps; do
+    print_optional_setting_status \
+      "$group_label" \
+      "$(config_data_bool "$config_file" "$group_key")" \
+      "$group_apps"
+  done
 }
 
 print_key_tool_status() {
@@ -1316,7 +1290,7 @@ run_status() {
     print_warning_line "executable selection helper failed"
   fi
   print_section "Optional stacks:"
-  print_optional_setting_status "Optional Editor Stack" "$(effective_editor_stack_enabled "$config_file")" "rich Neovim configuration"
+  print_optional_setting_status "Optional Editor Stack" "$(effective_optional_stack_enabled "$config_file" enableEditorStack)" "rich Neovim configuration"
   if ai_cli_tools_supported_profile "$profile"; then
     print_stack_status "Optional AI Tool Stack" "$(effective_ai_cli_tools_enabled "$config_file" "$profile")" agy claude codex
   else
@@ -1379,11 +1353,11 @@ show_stack_context() {
   profile="$2"
 
   print_section "Optional stacks:"
-  editor_state="$(effective_optional_stack_state_label "$config_file" enableEditorStack)"
+  editor_state="$(bool_state_label "$(effective_optional_stack_enabled "$config_file" enableEditorStack)")"
   workspace_state="$(config_bool_state_label "$config_file" enableDevelopmentWorkspace)"
   print_named_state_line "Optional Editor Stack" "$editor_state"
   if ai_cli_tools_supported_profile "$profile"; then
-    ai_state="$(effective_optional_stack_state_label "$config_file" enableAiCliTools)"
+    ai_state="$(bool_state_label "$(effective_ai_cli_tools_enabled "$config_file" "$profile")")"
     print_named_state_line "Optional AI Tool Stack" "$ai_state"
   else
     print_colon_state_line "Optional AI Tool Stack" "not applicable" "($(profile_context_label))"
@@ -1396,18 +1370,9 @@ show_stack_context() {
   fi
 
   print_section "macOS App Groups:"
-  terminal_apps_state="$(config_bool_state_label "$config_file" enableMacosAppGroupTerminalApps)"
-  automation_state="$(config_bool_state_label "$config_file" enableMacosAppGroupAutomation)"
-  launcher_state="$(config_bool_state_label "$config_file" enableMacosAppGroupLauncher)"
-  monitoring_state="$(config_bool_state_label "$config_file" enableMacosAppGroupMonitoring)"
-  development_apps_state="$(config_bool_state_label "$config_file" enableMacosAppGroupDevelopmentApps)"
-  mobile_dev_state="$(config_bool_state_label "$config_file" enableMacosAppGroupMobileDev)"
-  print_named_state_line "terminal-apps" "$terminal_apps_state"
-  print_named_state_line "automation" "$automation_state"
-  print_named_state_line "launcher" "$launcher_state"
-  print_named_state_line "monitoring" "$monitoring_state"
-  print_named_state_line "development-apps" "$development_apps_state"
-  print_named_state_line "mobile-dev" "$mobile_dev_state"
+  macos_app_group_table | while IFS='|' read -r group_key group_label group_apps; do
+    print_named_state_line "$group_label" "$(config_bool_state_label "$config_file" "$group_key")"
+  done
 }
 
 render_chezmoi_command() {
@@ -1800,7 +1765,7 @@ run_doctor() {
 
   doctor_check_optional_setting \
     "Optional Editor Stack" \
-    "$(effective_editor_stack_enabled "$config_file")" \
+    "$(effective_optional_stack_enabled "$config_file" enableEditorStack)" \
     "rich Neovim configuration"
 
   if ai_cli_tools_supported_profile "$profile"; then

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -424,6 +424,26 @@ assert_line() {
   pass "$message"
 }
 
+macos_app_group_labels() {
+  printf '%s\n' "$1" |
+    awk '
+      /^ *macOS App Groups:/ {
+        in_group = 1
+        next
+      }
+
+      in_group {
+        line = $0
+        sub(/^ +/, "", line)
+        if (line !~ /^[A-Za-z][A-Za-z0-9-]* +: /) {
+          exit
+        }
+        sub(/ +:.*$/, "", line)
+        print line
+      }
+    '
+}
+
 assert_first_occurrence_before() {
   haystack="$1"
   earlier="$2"
@@ -3225,6 +3245,32 @@ assert_contains \
   "$diff_output" \
   "development-apps              : enabled" \
   "Terrapod diff prints enabled development-apps macOS App Group state"
+
+expected_macos_app_group_labels="terminal-apps
+automation
+launcher
+monitoring
+development-apps
+mobile-dev"
+
+status_macos_app_group_labels="$(macos_app_group_labels "$macos_status_output")"
+diff_macos_app_group_labels="$(macos_app_group_labels "$diff_output")"
+
+if [ "$status_macos_app_group_labels" != "$expected_macos_app_group_labels" ]; then
+  printf '%s\n' "Terrapod status macOS App Group labels:" >&2
+  printf '%s\n' "$status_macos_app_group_labels" | sed 's/^/  /' >&2
+  fail "Terrapod status reports every macOS App Group in table order"
+fi
+pass "Terrapod status reports every macOS App Group in table order"
+
+if [ "$diff_macos_app_group_labels" != "$status_macos_app_group_labels" ]; then
+  printf '%s\n' "Terrapod diff macOS App Group labels:" >&2
+  printf '%s\n' "$diff_macos_app_group_labels" | sed 's/^/  /' >&2
+  printf '%s\n' "Terrapod status macOS App Group labels:" >&2
+  printf '%s\n' "$status_macos_app_group_labels" | sed 's/^/  /' >&2
+  fail "Terrapod diff reports the same macOS App Groups as status"
+fi
+pass "Terrapod diff reports the same macOS App Groups as status"
 
 assert_contains \
   "$diff_output" \


### PR DESCRIPTION
Closes #173

Stacked on #204 (`juty9026/issue-162-marker-snapshot-trap`).

## Problem

`print_macos_app_group_status` (used by `status`) and `show_stack_context` (used by `diff`/`apply`/`update`) each hardcoded the same six App Group keys, labels, and enable checks in different shapes — one as six `if`/`else` blocks with tool detail, the other as six `*_state` variables plus six print calls. Adding, renaming, or reordering a group meant editing both lists, and nothing caught a drift.

The same duplication existed for optional stacks: `effective_optional_stack_state_label`, `effective_editor_stack_enabled`, and `effective_ai_cli_tools_enabled` were three spellings of one rule — "the stack's own key, or `enableDevelopmentWorkspace`".

## Change

- `macos_app_group_table` emits one `key|label|apps` row per group. Both reporting paths loop over it, so the list is edited in one place. It uses `printf` rather than a heredoc because `tpod` runs under a PATH that need not contain `cat`.
- `print_macos_app_group_status` now goes through the existing `print_optional_setting_status`, which already prints exactly the enabled-with-detail / disabled shapes the six blocks spelled out.
- `effective_optional_stack_enabled <config> <key>` holds the shared rule. `effective_optional_stack_state_label` and `effective_editor_stack_enabled` are gone; their four call sites use the shared helper (wrapped in `bool_state_label` where a label was wanted).
- `effective_ai_cli_tools_enabled` stays, because the profile gate is a real extra rule rather than a copy, and it now delegates the shared part.

Output is byte-identical: every existing `status`, `diff`, `apply`, and `doctor` assertion about stack and App Group lines passes unchanged.

## Note on the issue text

The issue cites `:1077-1117`, `:1327-1357`, `:896`, `:912`, `:923`; on `main` those are `:1121-1160`, `:1377-1414`, `:944`, `:960`, `:975`. Same functions, same duplication.

## Tests

`tests/terrapod_command_test.sh` gains a drift guard: a `macos_app_group_labels` extractor pulls the App Group labels out of a command's output, and the test asserts `status` lists exactly the six groups in table order and that `diff` lists the same ones. Before this change the two lists could diverge without any test noticing.

```
$ sh tests/terrapod_command_test.sh    -> 521 ok, exit 0
$ sh tests/terrapod_config_test.sh     -> 418 ok, exit 0
$ sh tests/terrapod_installer_test.sh  -> 404 ok, exit 0
$ sh tests/homebrew_manifests_test.sh  -> 8 ok, exit 0
$ sh tests/helper_resolution_test.sh   -> 4 ok, exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKu7yrNkZj6rtDDuF1kzVF