### PR TITLE
Probe both Homebrew prefixes and skip the probe once one is set

### DIFF
--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -6,17 +6,22 @@ if [[ -d "$HOME/.local/bin" ]]; then
   path=("$HOME/.local/bin" $path)
 fi
 
+# Every zsh process reads this file, non-interactive `zsh -c` included, so the
+# probe short-circuits once the environment already carries a Homebrew prefix.
 {{ if eq .chezmoi.os "linux" -}}
-if [[ -x /home/linuxbrew/.linuxbrew/bin/brew ]]; then
+if [[ -z "${HOMEBREW_PREFIX:-}" && -x /home/linuxbrew/.linuxbrew/bin/brew ]]; then
   eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 fi
 {{ else if eq .chezmoi.os "darwin" -}}
-if [[ "$(uname -m)" == arm64 || "$(sysctl -in sysctl.proc_translated 2>/dev/null)" == 1 ]]; then
+# Both prefixes are probed regardless of the reported architecture: a translated
+# shell on a machine that only carries an Intel Homebrew still needs it on PATH.
+# Apple Silicon wins when both are installed.
+if [[ -z "${HOMEBREW_PREFIX:-}" ]]; then
   if [[ -x /opt/homebrew/bin/brew ]]; then
     eval "$(/opt/homebrew/bin/brew shellenv)"
+  elif [[ -x /usr/local/bin/brew ]]; then
+    eval "$(/usr/local/bin/brew shellenv)"
   fi
-elif [[ -x /usr/local/bin/brew ]]; then
-  eval "$(/usr/local/bin/brew shellenv)"
 fi
 {{ end -}}
 

--- a/tests/zshenv_local_bin_test.sh
+++ b/tests/zshenv_local_bin_test.sh
@@ -26,6 +26,16 @@ assert_contains() {
   pass "$message"
 }
 
+assert_not_contains() {
+  haystack="$1"
+  needle="$2"
+  message="$3"
+  if printf '%s\n' "$haystack" | grep -F "$needle" >/dev/null; then
+    fail "$message"
+  fi
+  pass "$message"
+}
+
 assert_order() {
   haystack="$1"
   first="$2"
@@ -133,6 +143,83 @@ assert_linuxbrew_shellenv_rendering() {
   pass "$message"
 }
 
+# The Homebrew prefixes are absolute paths a test cannot create, so the rendered
+# file is redirected at stub prefixes before it is exercised.
+render_zshenv_with_stub_prefixes() {
+  data="$1"
+
+  render_zshenv "$data"
+  sed \
+    -e "s|/opt/homebrew/bin/brew|$tmp_dir/apple-silicon/bin/brew|g" \
+    -e "s|/usr/local/bin/brew|$tmp_dir/intel/bin/brew|g" \
+    -e "s|/home/linuxbrew/.linuxbrew/bin/brew|$tmp_dir/linuxbrew/bin/brew|g" \
+    "$tmp_dir/home/.zshenv" >"$tmp_dir/zshenv.stubbed"
+  mv "$tmp_dir/zshenv.stubbed" "$tmp_dir/home/.zshenv"
+}
+
+write_brew_stub() {
+  prefix="$1"
+
+  mkdir -p "$prefix/bin"
+  cat >"$prefix/bin/brew" <<STUB
+#!/bin/sh
+printf '%s\n' "$prefix" >>"\$BREW_STUB_LOG"
+printf '%s\n' 'export HOMEBREW_PREFIX="$prefix"'
+printf '%s\n' 'export PATH="$prefix/bin:\$PATH"'
+STUB
+  chmod +x "$prefix/bin/brew"
+}
+
+remove_brew_stub() {
+  rm -rf "$1"
+}
+
+# Runs a fresh zsh, which reads the rendered .zshenv. An empty first argument
+# leaves HOMEBREW_PREFIX unset.
+run_zshenv() {
+  inherited_prefix="$1"
+
+  : >"$tmp_dir/brew.log"
+
+  if [ -n "$inherited_prefix" ]; then
+    env -i \
+      HOME="$tmp_dir/home" \
+      PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+      BREW_STUB_LOG="$tmp_dir/brew.log" \
+      HOMEBREW_PREFIX="$inherited_prefix" \
+      zsh -c 'printf "%s\n" "$PATH"' >"$tmp_dir/zshenv.path"
+  else
+    env -i \
+      HOME="$tmp_dir/home" \
+      PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+      BREW_STUB_LOG="$tmp_dir/brew.log" \
+      zsh -c 'printf "%s\n" "$PATH"' >"$tmp_dir/zshenv.path"
+  fi
+}
+
+assert_path_contains() {
+  needle="$1"
+  message="$2"
+
+  if ! grep -F "$needle" "$tmp_dir/zshenv.path" >/dev/null; then
+    fail "$message; expected PATH to contain '$needle', got $(cat "$tmp_dir/zshenv.path")"
+  fi
+
+  pass "$message"
+}
+
+assert_brew_stub_log() {
+  expected="$1"
+  message="$2"
+
+  actual="$(cat "$tmp_dir/brew.log")"
+  if [ "$actual" != "$expected" ]; then
+    fail "$message; expected shellenv from '$expected', got '$actual'"
+  fi
+
+  pass "$message"
+}
+
 chezmoi_bin="$(command -v chezmoi)" || fail "chezmoi is required to render templates"
 
 mkdir -p "$tmp_dir/home/.local/bin"
@@ -202,3 +289,50 @@ if printf '%s\n' "$rendered_macos_zshenv" | grep -F 'export ANDROID_HOME="$HOME/
   fail "macOS zshenv omits the Android SDK block when the mobile-dev App Group is disabled"
 fi
 pass "macOS zshenv omits the Android SDK block when the mobile-dev App Group is disabled"
+
+# .zshenv runs for every zsh process, including the non-interactive ones scripts
+# and editors spawn, so the Homebrew probe has to be free once the environment
+# already carries a prefix — and it has to find whichever prefix is installed,
+# not the one the architecture predicts.
+assert_not_contains "$rendered_macos_zshenv" 'uname -m' \
+  "macOS zshenv does not spawn uname to choose a Homebrew prefix"
+assert_not_contains "$rendered_macos_zshenv" 'sysctl.proc_translated' \
+  "macOS zshenv does not spawn sysctl to detect Rosetta"
+assert_order "$rendered_macos_zshenv" '/opt/homebrew/bin/brew shellenv' '/usr/local/bin/brew shellenv' \
+  "macOS zshenv prefers the Apple Silicon prefix over the Intel one"
+
+render_zshenv_with_stub_prefixes '{"chezmoi":{"os":"darwin"}}'
+
+write_brew_stub "$tmp_dir/intel"
+run_zshenv ""
+assert_path_contains "$tmp_dir/intel/bin" \
+  "macOS zshenv finds an Intel-only Homebrew regardless of the reported architecture"
+assert_brew_stub_log "$tmp_dir/intel" \
+  "macOS zshenv evaluates the Intel shellenv once when it is the only prefix"
+
+write_brew_stub "$tmp_dir/apple-silicon"
+run_zshenv ""
+assert_path_contains "$tmp_dir/apple-silicon/bin" \
+  "macOS zshenv prefers the Apple Silicon prefix when both are installed"
+assert_brew_stub_log "$tmp_dir/apple-silicon" \
+  "macOS zshenv evaluates only one shellenv when both prefixes are installed"
+
+run_zshenv "$tmp_dir/apple-silicon"
+assert_brew_stub_log "" \
+  "macOS zshenv skips the Homebrew probe when the environment already carries a prefix"
+
+remove_brew_stub "$tmp_dir/intel"
+remove_brew_stub "$tmp_dir/apple-silicon"
+
+render_zshenv_with_stub_prefixes '{"chezmoi":{"os":"linux","osRelease":{"id":"ubuntu","versionID":"24.04"}}}'
+
+write_brew_stub "$tmp_dir/linuxbrew"
+run_zshenv ""
+assert_path_contains "$tmp_dir/linuxbrew/bin" \
+  "Ubuntu zshenv still puts Linuxbrew on PATH"
+assert_brew_stub_log "$tmp_dir/linuxbrew" \
+  "Ubuntu zshenv evaluates the Linuxbrew shellenv"
+
+run_zshenv "$tmp_dir/linuxbrew"
+assert_brew_stub_log "" \
+  "Ubuntu zshenv skips the Homebrew probe when the environment already carries a prefix"


### PR DESCRIPTION
Closes #168

Stacked on #207 (`juty9026/issue-170-fastfetch-first-shell`).

## Problem

Two defects in one block (`dot_zshenv.tmpl:14-20`):

```zsh
if [[ "$(uname -m)" == arm64 || "$(sysctl -in sysctl.proc_translated 2>/dev/null)" == 1 ]]; then
  if [[ -x /opt/homebrew/bin/brew ]]; then
    eval "$(/opt/homebrew/bin/brew shellenv)"
  fi
elif [[ -x /usr/local/bin/brew ]]; then
  eval "$(/usr/local/bin/brew shellenv)"
fi
```

**Cost.** `.zshenv` is read by every zsh process, the non-interactive `zsh -c` that scripts and editors spawn included. That is three subprocess spawns per invocation — `uname`, `sysctl`, `brew shellenv` — recomputing an answer the environment already carries.

**Correctness.** When `uname -m` reports `arm64`, or `sysctl.proc_translated` reports `1`, the `elif` for `/usr/local/bin/brew` is unreachable. A machine carrying only an Intel-prefix Homebrew, seen through a translated shell, gets no Homebrew on PATH at all.

## Approach

```zsh
if [[ -z "${HOMEBREW_PREFIX:-}" ]]; then
  if [[ -x /opt/homebrew/bin/brew ]]; then
    eval "$(/opt/homebrew/bin/brew shellenv)"
  elif [[ -x /usr/local/bin/brew ]]; then
    eval "$(/usr/local/bin/brew shellenv)"
  fi
fi
```

**The short-circuit is applied to Linux too.** The issue names only the darwin lines, but its reason — one fork per zsh invocation — holds identically for `/home/linuxbrew/.linuxbrew/bin/brew`, and the VPS Shell Profile pays it on every `zsh -c`.

**Probing `-x` on both prefixes in order replaces the arch test entirely.** Apple Silicon still wins when both are installed, which is the outcome the old branch produced on every machine where it was right. The Intel prefix is now reachable on every machine where it exists. `uname` and `sysctl` are gone from the file.

The nested `if`/`elif` was chosen over a loop deliberately: it keeps the literal `/opt/homebrew/bin/brew shellenv` and `/usr/local/bin/brew shellenv` strings that six existing assertions in `zshenv_local_bin_test.sh` match on, so the diff stays about the defect.

`dot_local/lib/terrapod/homebrew-prefix.sh` keeps its arch detection and is deliberately untouched. It answers a different question — which prefix Terrapod would *install* on this hardware — and an Apple Silicon Mac carrying only an Intel Homebrew remains a nonstandard prefix in its terms, which `CONTEXT.md:218` and ADR 0012 already keep advisory-only.

Code matched the issue description; no discrepancies.

## Tests

The Homebrew prefixes are absolute paths a test cannot create, so `tests/zshenv_local_bin_test.sh` gains `render_zshenv_with_stub_prefixes`: it renders the template, then rewrites the three absolute brew paths to stub prefixes under the test's temporary directory. Each stub logs its invocation and prints the `export` lines a real `brew shellenv` would, so the block is exercised end to end in a fresh `zsh -c` — no root, no real Homebrew, and it works on Linux CI as well as macOS.

```
$ sh tests/zshenv_local_bin_test.sh
... (17 pre-existing assertions) ...
ok - macOS zshenv does not spawn uname to choose a Homebrew prefix
ok - macOS zshenv does not spawn sysctl to detect Rosetta
ok - macOS zshenv prefers the Apple Silicon prefix over the Intel one
ok - macOS zshenv finds an Intel-only Homebrew regardless of the reported architecture
ok - macOS zshenv evaluates the Intel shellenv once when it is the only prefix
ok - macOS zshenv prefers the Apple Silicon prefix when both are installed
ok - macOS zshenv evaluates only one shellenv when both prefixes are installed
ok - macOS zshenv skips the Homebrew probe when the environment already carries a prefix
ok - Ubuntu zshenv still puts Linuxbrew on PATH
ok - Ubuntu zshenv evaluates the Linuxbrew shellenv
ok - Ubuntu zshenv skips the Homebrew probe when the environment already carries a prefix
```

Both behavioural fixes are load-bearing, verified by restoring the old shape one at a time:

- reinstating the `arm64` arch gate →
  `not ok - macOS zshenv finds an Intel-only Homebrew regardless of the reported architecture; expected PATH to contain '…/intel/bin'`
- dropping the `-z "${HOMEBREW_PREFIX:-}"` guard →
  `not ok - macOS zshenv skips the Homebrew probe when the environment already carries a prefix; expected shellenv from '', got '…/apple-silicon'`

Other suites that render `.zshenv` or resolve prefixes, all rc=0:

```
sh tests/chezmoiignore_test.sh          (328)
sh tests/terrapod_config_test.sh        (393)
sh tests/terrapod_installer_test.sh     (390)
sh tests/executable_selection_test.sh   (47)
sh tests/shell_integrations_test.sh     (38)
sh tests/bootstrap_ubuntu_test.sh       (31)
```

No `CONTEXT.md` or ADR change: no domain term moved, and the standard-prefix decision this file now diverges from is already recorded as advisory-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKu7yrNkZj6rtDDuF1kzVF
