### PR TITLE
Cover the zprofile render and wcd's worktree pipeline

### DIFF
--- a/tests/zprofile_orbstack_test.sh
+++ b/tests/zprofile_orbstack_test.sh
@@ -1,0 +1,142 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT INT TERM
+
+fail() {
+  printf '%s\n' "not ok - $1" >&2
+  exit 1
+}
+
+pass() {
+  printf '%s\n' "ok - $1"
+}
+
+render_zprofile() {
+  data="$1"
+
+  "$chezmoi_bin" \
+    --config "$tmp_dir/chezmoi.toml" \
+    --destination "$tmp_dir/home" \
+    --source "$repo_root" \
+    execute-template \
+    --override-data "$data" \
+    --file "$repo_root/dot_zprofile.tmpl" \
+    >"$tmp_dir/home/.zprofile"
+}
+
+# Sources the rendered .zprofile the way a zsh login shell would, from an
+# environment carrying nothing but HOME and a minimal PATH.
+source_zprofile() {
+  env -i \
+    HOME="$tmp_dir/home" \
+    PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
+    zsh -c '. "$HOME/.zprofile"' \
+    >"$tmp_dir/source.out" \
+    2>"$tmp_dir/source.err"
+}
+
+assert_orbstack_rendering() {
+  data="$1"
+  expected="$2"
+  message="$3"
+
+  render_zprofile "$data"
+
+  if [ "$expected" = present ]; then
+    if ! grep -F '. "$HOME/.orbstack/shell/init.zsh"' "$tmp_dir/home/.zprofile" >/dev/null; then
+      fail "$message; expected the OrbStack shell integration"
+    fi
+  elif grep -F '.orbstack' "$tmp_dir/home/.zprofile" >/dev/null; then
+    fail "$message; the OrbStack shell integration should be absent"
+  fi
+
+  pass "$message"
+}
+
+write_orbstack_init() {
+  mkdir -p "$tmp_dir/home/.orbstack/shell"
+  cat >"$tmp_dir/home/.orbstack/shell/init.zsh" <<'STUB'
+print -- "orbstack shell integration loaded"
+STUB
+}
+
+chezmoi_bin="$(command -v chezmoi)" || fail "chezmoi is required to render templates"
+command -v zsh >/dev/null || fail "zsh is required to source the rendered zprofile"
+
+mkdir -p "$tmp_dir/home"
+: >"$tmp_dir/chezmoi.toml"
+
+assert_orbstack_rendering \
+  '{"chezmoi":{"os":"darwin"}}' \
+  absent \
+  "macOS without the development-apps App Group keeps OrbStack out of zprofile"
+
+assert_orbstack_rendering \
+  '{"chezmoi":{"os":"darwin"},"enableMacosAppGroupDevelopmentApps":false}' \
+  absent \
+  "an explicitly disabled development-apps App Group keeps OrbStack out of zprofile"
+
+assert_orbstack_rendering \
+  '{"chezmoi":{"os":"darwin"},"enableMacosAppGroupMonitoring":true,"enableMacosAppGroupMobileDev":true}' \
+  absent \
+  "other macOS App Groups do not pull in the OrbStack shell integration"
+
+assert_orbstack_rendering \
+  '{"chezmoi":{"os":"darwin"},"enableMacosAppGroupDevelopmentApps":true}' \
+  present \
+  "the development-apps App Group renders the OrbStack shell integration"
+
+# The rendered file is a login-shell entry point, so every variant has to be
+# sourceable. Only the enabled variant can break, but a syntax error in the
+# disabled one would be just as fatal.
+render_zprofile '{"chezmoi":{"os":"darwin"}}'
+if ! source_zprofile; then
+  sed 's/^/  /' "$tmp_dir/source.err" >&2
+  fail "zprofile without the development-apps App Group is sourceable"
+fi
+pass "zprofile without the development-apps App Group is sourceable"
+
+render_zprofile '{"chezmoi":{"os":"darwin"},"enableMacosAppGroupDevelopmentApps":true}'
+rm -rf "$tmp_dir/home/.orbstack"
+
+if ! source_zprofile; then
+  sed 's/^/  /' "$tmp_dir/source.err" >&2
+  fail "the readability guard keeps the login shell working when OrbStack is missing"
+fi
+if [ -s "$tmp_dir/source.err" ]; then
+  sed 's/^/  /' "$tmp_dir/source.err" >&2
+  fail "a missing OrbStack install produces no login-shell diagnostics"
+fi
+pass "the readability guard keeps the login shell working when OrbStack is missing"
+pass "a missing OrbStack install produces no login-shell diagnostics"
+
+write_orbstack_init
+if ! source_zprofile; then
+  sed 's/^/  /' "$tmp_dir/source.err" >&2
+  fail "an installed OrbStack shell integration is sourced"
+fi
+if ! grep -F 'orbstack shell integration loaded' "$tmp_dir/source.out" >/dev/null; then
+  fail "an installed OrbStack shell integration is sourced"
+fi
+pass "an installed OrbStack shell integration is sourced"
+
+# An unreadable init.zsh is what the readability guard exists for: OrbStack can
+# leave the file behind with the cask removed.
+chmod 000 "$tmp_dir/home/.orbstack/shell/init.zsh"
+if ! source_zprofile; then
+  sed 's/^/  /' "$tmp_dir/source.err" >&2
+  fail "an unreadable OrbStack shell integration is skipped instead of failing the login shell"
+fi
+if [ -s "$tmp_dir/source.err" ]; then
+  sed 's/^/  /' "$tmp_dir/source.err" >&2
+  fail "an unreadable OrbStack shell integration is skipped instead of failing the login shell"
+fi
+chmod 644 "$tmp_dir/home/.orbstack/shell/init.zsh"
+pass "an unreadable OrbStack shell integration is skipped instead of failing the login shell"

--- a/tests/zshrc_zoxide_test.zsh
+++ b/tests/zshrc_zoxide_test.zsh
@@ -94,8 +94,13 @@ if [ "${1:-}" = "--zsh" ]; then
   exit 0
 fi
 
-if [ -n "${FZF_TEST_SELECTION:-}" ]; then
+if [ -n "${FZF_TEST_STDIN_LOG:-}" ]; then
+  cat >"$FZF_TEST_STDIN_LOG"
+else
   cat >/dev/null
+fi
+
+if [ -n "${FZF_TEST_SELECTION:-}" ]; then
   printf '%s\n' "$FZF_TEST_SELECTION"
   exit 0
 fi
@@ -291,7 +296,9 @@ git -C "$tmp_dir/worktree-main" config user.name "Test User"
 git -C "$tmp_dir/worktree-main" add file.txt
 git -C "$tmp_dir/worktree-main" commit -m "initial commit" >/dev/null
 git -C "$tmp_dir/worktree-main" branch feature/worktree
+git -C "$tmp_dir/worktree-main" branch feature/third
 git -C "$tmp_dir/worktree-main" worktree add "$tmp_dir/worktree selected" feature/worktree >/dev/null 2>&1
+git -C "$tmp_dir/worktree-main" worktree add "$tmp_dir/worktree third" feature/third >/dev/null 2>&1
 
 cd "$tmp_dir/worktree-main" || fail "could not enter worktree main directory"
 worktree_display="$(git -C "$tmp_dir/worktree-main" worktree list | command grep -F "$tmp_dir/worktree selected")"
@@ -299,6 +306,55 @@ export FZF_TEST_SELECTION="$tmp_dir/worktree selected"$'\t'"$worktree_display"
 wcd
 assert_pwd "$tmp_dir/worktree selected" "wcd should jump to the selected worktree path"
 pass "wcd changes directory to a selected worktree path containing spaces"
+
+# The fzf stub answers with FZF_TEST_SELECTION no matter what it is fed, so
+# nothing above this point can see the paste/awk half of wcd's pipeline. These
+# assertions read what wcd actually wrote to fzf's stdin.
+cd "$tmp_dir/worktree-main" || fail "could not reset to worktree main directory"
+export FZF_TEST_STDIN_LOG="$tmp_dir/wcd-fzf-stdin.log"
+export FZF_TEST_SELECTION="$tmp_dir/worktree selected"$'\t'"$worktree_display"
+wcd
+cd "$tmp_dir/worktree-main" || fail "could not reset to worktree main directory"
+
+typeset -a pipeline_lines
+# .zshrc aliases cat to bat, which is not on the stub PATH.
+pipeline_lines=("${(@f)$(command cat "$tmp_dir/wcd-fzf-stdin.log")}")
+
+if (( ${#pipeline_lines} != 3 )); then
+  fail "wcd should offer one row per worktree; got ${#pipeline_lines} for 3 worktrees"
+fi
+pass "wcd offers one row per worktree"
+
+typeset -a offered_paths
+offered_paths=()
+for pipeline_line in "${pipeline_lines[@]}"; do
+  worktree_path="${pipeline_line%%$'\t'*}"
+  worktree_row="${pipeline_line#*$'\t'}"
+
+  if [[ ! -d "$worktree_path" ]]; then
+    fail "wcd's first field should be a worktree directory; got '$worktree_path'"
+  fi
+
+  # git worktree list prints the path first, so a row whose display half does
+  # not start with the porcelain half means paste mispaired its two inputs.
+  if [[ "$worktree_row" != "$worktree_path"* ]]; then
+    fail "wcd should pair each porcelain path with its own listing row; '$worktree_path' got '$worktree_row'"
+  fi
+
+  offered_paths+=("$worktree_path")
+done
+pass "wcd's first field is the worktree directory cd receives"
+pass "wcd pairs each porcelain path with its own listing row"
+
+# git reports resolved paths, and mktemp -d hands out a symlinked one on macOS.
+typeset -a expected_paths
+expected_paths=("${tmp_dir:A}/worktree-main" "${tmp_dir:A}/worktree selected" "${tmp_dir:A}/worktree third")
+if [[ "${(j:\n:)${(o)offered_paths}}" != "${(j:\n:)${(o)expected_paths}}" ]]; then
+  fail "wcd should offer every worktree path verbatim; got ${(j:, :)offered_paths}"
+fi
+pass "wcd offers every worktree path verbatim, spaces included"
+
+unset FZF_TEST_STDIN_LOG
 
 cd "$tmp_dir/worktree-main" || fail "could not reset to worktree main directory"
 export FZF_TEST_SELECTION=""


### PR DESCRIPTION
Stacked on #205 (issue #177), which is stacked on #200 (issue #175). Review the last commit only.

## Problem

Two gaps, one of which turned out to be narrower than the issue describes.

**`dot_zprofile.tmpl` was never rendered by a test.** The only checks were
README string assertions in `readme_optional_stack_profiles_test.sh:155`, so
both the `enableMacosAppGroupDevelopmentApps` conditional and the `[ -r ... ]`
readability guard existed only as prose. The guard's stated purpose — "keeps
login shells working when the cask is missing" — is a claim about what a login
shell does, and nothing was executing one.

**`wcd`'s `paste`/`awk` half was untested**, though not for the reason given.

## Divergence from the issue text

The issue says the zshrc tests "cover `zj/zja/zd/zdac/zi/z/c` but not `wcd`".
`wcd` is tested — `tests/zshrc_zoxide_test.zsh:273-309` covers the non-git
message, the missing-fzf message, a selection whose path contains a space, and
cancellation. Those assertions predate the review baseline: `git show
c6fba0a:tests/zshrc_zoxide_test.zsh` mentions `wcd` 13 times. Trusting the code
over the issue, per the lane instructions.

The concern *underneath* the claim is real, and it is specifically the part the
issue names: the `paste`/`awk` pipeline and the `git worktree list --porcelain`
format it depends on. The fzf stub answered with `FZF_TEST_SELECTION` regardless
of its input and discarded stdin with `cat >/dev/null`, so the entire producing
half of the pipeline ran unobserved. Every existing `wcd` assertion checks what
comes *back* from fzf, which the test wrote itself.

The measurable consequence: changing `substr($0, 10)` to `substr($0, 11)` — an
off-by-one that strips the leading `/` and breaks `cd` for every worktree —
leaves `wcd changes directory to a selected worktree path containing spaces`
green on the old test.

## Approach

### `tests/zprofile_orbstack_test.sh` (new)

Mirrors `tests/zshenv_local_bin_test.sh`: renders the template through
`chezmoi execute-template --override-data`, then sources the result in a
`env -i` zsh with nothing but `HOME` and a minimal `PATH`.

Four render assertions (absent by default, absent when explicitly false, absent
when *other* App Groups are on, present when the development-apps group is on)
and five behavioral ones. The behavioral half is what the guard needs: a missing
`~/.orbstack`, an unreadable `init.zsh`, and a present one each get sourced, and
the first two have to leave stderr empty — a login shell that prints a
diagnostic on every start is the failure the guard prevents, and exit status
alone would not catch it.

### `wcd` pipeline coverage

The fzf stub now writes stdin to `$FZF_TEST_STDIN_LOG` when that is set, instead
of always discarding it. The fixture gains a third worktree, because two cannot
distinguish correct pairing from a coincidence.

Three assertions read that log:

- one row per worktree
- each row's first field is an existing directory — this is the exact string
  `cd "${selected%%$'\t'*}"` consumes
- each row's display half starts with its own porcelain half. `git worktree
  list` prints the path first, so this catches `paste` mispairing its two inputs
  without depending on git's output order

Plus a set comparison of the offered paths against the three known worktrees,
which catches worktrees being dropped or paths being mangled.

## Tests

Full suite through the runner from #200: **22 test files passed, 2069
assertions** (2056 before: +9 zprofile, +4 wcd).

```
$ sh tests/zprofile_orbstack_test.sh
ok - macOS without the development-apps App Group keeps OrbStack out of zprofile
ok - an explicitly disabled development-apps App Group keeps OrbStack out of zprofile
ok - other macOS App Groups do not pull in the OrbStack shell integration
ok - the development-apps App Group renders the OrbStack shell integration
ok - zprofile without the development-apps App Group is sourceable
ok - the readability guard keeps the login shell working when OrbStack is missing
ok - a missing OrbStack install produces no login-shell diagnostics
ok - an installed OrbStack shell integration is sourced
ok - an unreadable OrbStack shell integration is skipped instead of failing the login shell
```

Every new assertion was mutation-tested against a temporarily edited source
file, since a coverage PR whose tests cannot fail adds nothing:

| Mutation | Caught by |
| --- | --- |
| `dot_zprofile.tmpl`: readability guard removed | missing-OrbStack case, `no such file or directory` |
| `dot_zprofile.tmpl`: condition → `{{ if true }}` | default-off render assertion |
| `dot_zprofile.tmpl`: keyed off `enableMacosAppGroupMonitoring` | other-App-Groups render assertion |
| `dot_zprofile.tmpl`: trailing unterminated `if` | sourceability assertion, `parse error` |
| `dot_zshrc.tmpl`: `substr($0, 10)` → `substr($0, 11)` | first-field-is-a-directory assertion |
| `dot_zshrc.tmpl`: porcelain half re-sorted (mispair) | row-pairing assertion |
| `dot_zshrc.tmpl`: pipeline truncated to `head -1` | row-count assertion |

Both source files were restored after each mutation; this PR touches only test
files.

Two zsh details the new assertions needed, noted in comments so they are not
"fixed" later: `.zshrc` aliases `cat` to `bat`, so reading the log uses `command
cat`; and `mktemp -d` returns a symlinked path on macOS while git reports the
resolved one, so the expected paths use `${tmp_dir:A}`.

## Follow-ups

The three worktrees in the fixture are all normal checkouts. A bare or
prunable worktree changes `git worktree list --porcelain` output shape, which is
the failure mode the issue names; covering it needs a fixture decision beyond
this change.

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKu7yrNkZj6rtDDuF1kzVF
