### PR TITLE
Complete the Minimal VPS config example

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -357,6 +357,7 @@ enableMacosAppGroupAutomation = false
 enableMacosAppGroupLauncher = false
 enableMacosAppGroupMonitoring = false
 enableMacosAppGroupDevelopmentApps = false
+enableMacosAppGroupMobileDev = false
 ```
 
 Editor-only machine:

--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@ enableMacosAppGroupAutomation = false
 enableMacosAppGroupLauncher = false
 enableMacosAppGroupMonitoring = false
 enableMacosAppGroupDevelopmentApps = false
+enableMacosAppGroupMobileDev = false
 ```
 
 Editor-only machine:

--- a/tests/readme_optional_stack_profiles_test.sh
+++ b/tests/readme_optional_stack_profiles_test.sh
@@ -3,6 +3,8 @@ set -eu
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 readme="$repo_root/README.md"
+korean_readme="$repo_root/README.ko.md"
+terrapod_command="$repo_root/dot_local/bin/executable_terrapod"
 
 fail() {
   printf '%s\n' "not ok - $1" >&2
@@ -91,6 +93,54 @@ assert_raycast_restore_contains() {
 
   pass "$message"
 }
+
+# Derived from the command rather than restated here: a new managed key must
+# reach the Minimal VPS example, because routine commands call a config
+# complete only when every managed key is present, including disabled ones.
+managed_setup_keys="$(awk '
+  /^managed_setup_keys\(\) \{$/ { in_function = 1; next }
+  in_function && /^\}$/ { exit }
+  in_function && $1 == "printf" { next }
+  in_function { gsub(/\\/, ""); print $1 }
+' "$terrapod_command")"
+
+printf '%s\n' "$managed_setup_keys" | grep -Fx profile >/dev/null ||
+  fail "managed setup key list is readable from the Terrapod command"
+pass "managed setup key list is readable from the Terrapod command"
+
+minimal_vps_example() {
+  awk '
+    /^Minimal VPS:$/ { pending = 1; next }
+    pending && /^```toml$/ { in_fence = 1; pending = 0; next }
+    in_fence && /^```$/ { exit }
+    in_fence { print }
+  ' "$1"
+}
+
+assert_minimal_vps_is_complete() {
+  file="$1"
+  label="$2"
+
+  example="$(minimal_vps_example "$file")"
+  [ -n "$example" ] || fail "$label has a Minimal VPS toml example"
+
+  for managed_key in $managed_setup_keys; do
+    printf '%s\n' "$example" | grep -E "^$managed_key = " >/dev/null ||
+      fail "$label Minimal VPS example sets every managed setup key (missing: $managed_key)"
+  done
+  pass "$label Minimal VPS example sets every managed setup key"
+
+  # A for loop, not a "| while read" pipeline: fail exits, and in a pipeline
+  # subshell that exit would not stop the suite.
+  for example_key in $(printf '%s\n' "$example" | sed -n 's/^\([A-Za-z0-9_]*\) = .*/\1/p'); do
+    printf '%s\n' "$managed_setup_keys" | grep -Fx "$example_key" >/dev/null ||
+      fail "$label Minimal VPS example sets only managed setup keys (unexpected: $example_key)"
+  done
+  pass "$label Minimal VPS example sets only managed setup keys"
+}
+
+assert_minimal_vps_is_complete "$readme" "README.md"
+assert_minimal_vps_is_complete "$korean_readme" "README.ko.md"
 
 assert_contains '| `enableEditorStack` | `false` |' \
   "README documents enableEditorStack default"


### PR DESCRIPTION
Closes #171

Stacked on #208 (`juty9026/issue-166-document-jetendard-pin`).

## Problem

`README.md:303-305` states that routine commands treat the setup config
as complete "only when `profile` and every managed optional stack and
macOS App Group key are present, including disabled keys".
`managed_setup_keys` (`dot_local/bin/executable_terrapod:690`) names ten
keys. The Minimal VPS example listed nine — `enableMacosAppGroupMobileDev`
was missing — so a user who copied it got a config the tool calls
incomplete. `README.ko.md` had the same example with the same gap.

`readme_optional_stack_profiles_test.sh` checked the key *table* but
never looked inside the example fences, so nothing caught it.

## Approach

Add `enableMacosAppGroupMobileDev = false` to both examples, in the same
position the key holds in `managed_setup_keys`.

The test now derives the expected key list instead of restating it:

```sh
managed_setup_keys="$(awk '
  /^managed_setup_keys\(\) \{$/ { in_function = 1; next }
  in_function && /^\}$/ { exit }
  in_function && $1 == "printf" { next }
  in_function { gsub(/\\/, ""); print $1 }
' "$terrapod_command")"
```

That is the point of the change — a hardcoded list in the test would
have needed the same edit as the README and would have failed the same
way. Reading it from the command means the next managed key breaks the
suite until both examples are updated. A guard assertion confirms the
extraction found something (`profile` is in the list), so a rename of
`managed_setup_keys` fails loudly instead of yielding an empty list that
vacuously passes.

The check runs in both directions and over both READMEs: every managed
key must appear in the fence, and every key in the fence must be
managed. The second half catches a typo'd key, which the first half
cannot see.

`README.ko.md` is new to this suite; it was only covered by
`readme_korean_test.sh` before, which is why the Korean example drifted
alongside the English one.

## Tests

Both new assertions were red-checked:

```
$ # remove enableMacosAppGroupMobileDev from README.md
not ok - README.md Minimal VPS example sets every managed setup key (missing: enableMacosAppGroupMobileDev)

$ # add enableMacosAppGroupTypo to README.ko.md
not ok - README.ko.md Minimal VPS example sets only managed setup keys (unexpected: enableMacosAppGroupTypo)
```

The key-name loop is a `for` over a command substitution rather than a
`| while read` pipeline: `fail` exits, and inside a pipeline subshell
that exit would not stop the suite.

```
PASS tests/bootstrap_ubuntu_test.sh (31)
PASS tests/chezmoiignore_test.sh (336)
PASS tests/executable_selection_test.sh (47)
PASS tests/ghostty_config_test.sh (2)
PASS tests/git_config_test.sh (21)
PASS tests/hammerspoon_config_test.sh (10)
PASS tests/helper_resolution_test.sh (4)
PASS tests/homebrew_manifests_test.sh (8)
PASS tests/jetendard_font_test.sh (10)
PASS tests/jetendard_settings_test.sh (8)
PASS tests/karabiner_config_test.sh (9)
PASS tests/lazygit_pr_merge_test.sh (44)
PASS tests/readme_korean_test.sh (58)
PASS tests/readme_optional_stack_profiles_test.sh (116)
PASS tests/shell_integrations_test.sh (38)
PASS tests/terrapod_command_test.sh (508)
PASS tests/terrapod_config_test.sh (393)
PASS tests/terrapod_installer_test.sh (390)
PASS tests/zshenv_local_bin_test.sh (17)
PASS tests/zshrc_clear_test.zsh (10)
PASS tests/zshrc_zoxide_test.zsh (22)
TOTAL ok: 2082
```

`readme_optional_stack_profiles_test.sh` 111 → 116.
`homebrew_ubuntu_smoke.sh` skipped (needs a container).

## Follow-ups

- The "Editor-only machine" and "AI-only machine" examples are
  deliberately partial — they are overrides, not whole configs — so they
  are excluded from this check. If the README ever presents them as
  complete configs, they need the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKu7yrNkZj6rtDDuF1kzVF
