### PR TITLE
Move test hooks to the dispatch and drop dead wrappers

### DIFF
--- a/dot_local/bin/executable_terrapod
+++ b/dot_local/bin/executable_terrapod
@@ -554,10 +554,6 @@ setup_option_title() {
   esac
 }
 
-setup_option_prompt_name() {
-  setup_option_title "$1"
-}
-
 show_setup_option_block() {
   label="$1"
 
@@ -622,7 +618,7 @@ prompt_setup_bool() {
   current="$2"
 
   show_setup_option_block "$label" >&2
-  prompt_name="$(setup_option_prompt_name "$label" || printf '%s\n' "$label")"
+  prompt_name="$(setup_option_title "$label" || printf '%s\n' "$label")"
   setup_confirm_actions "$current"
 
   if gum confirm "Enable $prompt_name?" \
@@ -1047,11 +1043,6 @@ zoxide zoxide
 EOF
 }
 
-if [ "${TERRAPOD_PRINT_HOMEBREW_CLI_RECORDS:-}" = "1" ]; then
-  managed_homebrew_cli_records
-  exit 0
-fi
-
 # TERRAPOD_STANDARD_HOMEBREW_PREFIX is deliberately not consulted here: it is
 # how this command hands its own answer down to the executable-selection
 # helper, not a way to override the mapping for this command.
@@ -1059,13 +1050,6 @@ standard_homebrew_prefix() {
   [ "${TERRAPOD_HOMEBREW_PREFIX_LOADED:-}" = 1 ] || return 1
   terrapod_standard_homebrew_prefix_for_profile "$1"
 }
-
-if [ "${TERRAPOD_PRINT_STANDARD_HOMEBREW_PREFIX:-}" = "1" ]; then
-  if standard_homebrew_prefix "${TERRAPOD_PROFILE:-}"; then
-    exit 0
-  fi
-  exit 1
-fi
 
 homebrew_prefix() {
   if ! command -v brew >/dev/null 2>&1; then
@@ -1136,7 +1120,6 @@ print_macos_app_group_status() {
 
 print_key_tool_status() {
   profile="$1"
-  config_file="$2"
 
   print_section "Key tools:"
   for tool in chezmoi git zsh mise nvim zellij; do
@@ -1180,7 +1163,6 @@ print_jetendard_status() {
 
 status_key_tool_warnings() {
   profile="$1"
-  config_file="$2"
   missing="$(missing_tools zsh)"
 
   case "$profile" in
@@ -1233,7 +1215,7 @@ print_status_warnings() {
     printed=1
   fi
 
-  if status_key_tool_warnings "$profile" "$config_file"; then
+  if status_key_tool_warnings "$profile"; then
     printed=1
   fi
 
@@ -1298,7 +1280,7 @@ run_status() {
   fi
   print_optional_setting_status "Optional Development Workspace" "$(config_data_bool "$config_file" enableDevelopmentWorkspace)" "development Zellij layouts"
   print_macos_app_group_status "$config_file" "$profile"
-  print_key_tool_status "$profile" "$config_file"
+  print_key_tool_status "$profile"
   if [ "$profile" = "macos-terminal" ]; then
     print_jetendard_status
   fi
@@ -1341,13 +1323,6 @@ show_config_context() {
   esac
 }
 
-print_named_state_line() {
-  label="$1"
-  state="$2"
-
-  print_colon_state_line "$label" "$state"
-}
-
 show_stack_context() {
   config_file="$1"
   profile="$2"
@@ -1355,14 +1330,14 @@ show_stack_context() {
   print_section "Optional stacks:"
   editor_state="$(bool_state_label "$(effective_optional_stack_enabled "$config_file" enableEditorStack)")"
   workspace_state="$(config_bool_state_label "$config_file" enableDevelopmentWorkspace)"
-  print_named_state_line "Optional Editor Stack" "$editor_state"
+  print_colon_state_line "Optional Editor Stack" "$editor_state"
   if ai_cli_tools_supported_profile "$profile"; then
     ai_state="$(bool_state_label "$(effective_ai_cli_tools_enabled "$config_file" "$profile")")"
-    print_named_state_line "Optional AI Tool Stack" "$ai_state"
+    print_colon_state_line "Optional AI Tool Stack" "$ai_state"
   else
     print_colon_state_line "Optional AI Tool Stack" "not applicable" "($(profile_context_label))"
   fi
-  print_named_state_line "Optional Development Workspace" "$workspace_state"
+  print_colon_state_line "Optional Development Workspace" "$workspace_state"
 
   if [ "$profile" != "macos-terminal" ]; then
     printf '%s\n' "macOS App Groups: not applicable for $(profile_context_label)"
@@ -1371,7 +1346,7 @@ show_stack_context() {
 
   print_section "macOS App Groups:"
   macos_app_group_table | while IFS='|' read -r group_key group_label group_apps; do
-    print_named_state_line "$group_label" "$(config_bool_state_label "$config_file" "$group_key")"
+    print_colon_state_line "$group_label" "$(config_bool_state_label "$config_file" "$group_key")"
   done
 }
 
@@ -2503,13 +2478,6 @@ write_preset_settings() {
   write_managed_config "$config_file" "$preset" "$profile"
 }
 
-write_setup_settings() {
-  config_file="$1"
-  settings_data="$2"
-
-  write_managed_settings "$config_file" "$settings_data"
-}
-
 run_setup() {
   if [ "$#" -ne 0 ]; then
     fail_usage "setup accepts no arguments"
@@ -2530,7 +2498,7 @@ run_setup() {
     return 1
   fi
 
-  write_setup_settings "$config_file" "$setup_settings_data"
+  write_managed_settings "$config_file" "$setup_settings_data"
   printf '%s\n' "Configured Terrapod Preset '$preset' in $config_file"
   printf '%s\n' "Run 'tpod apply' to apply these changes."
 }
@@ -2572,6 +2540,25 @@ run_configure() {
   printf '%s\n' "Configured Terrapod Preset '$preset' in $config_file"
   printf '%s\n' "Run 'tpod apply' to apply these changes."
 }
+
+# Test-only entry points, kept beside the command dispatch so no production
+# invocation walks past a mid-file exit on the way to its command.
+dispatch_test_hooks() {
+  if [ "${TERRAPOD_PRINT_HOMEBREW_CLI_RECORDS:-}" = "1" ]; then
+    managed_homebrew_cli_records
+    exit 0
+  fi
+
+  if [ "${TERRAPOD_PRINT_STANDARD_HOMEBREW_PREFIX:-}" = "1" ]; then
+    if standard_homebrew_prefix "${TERRAPOD_PROFILE:-}"; then
+      exit 0
+    fi
+
+    exit 1
+  fi
+}
+
+dispatch_test_hooks
 
 command_name="${1:-help}"
 

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -862,6 +862,19 @@ if [ -n "$unsupported_override_output" ]; then
 fi
 pass "unsupported architecture does not print an overridden Homebrew prefix"
 
+test_hook_records_output="$(
+  TERRAPOD_PRINT_HOMEBREW_CLI_RECORDS=1 TERRAPOD_PROFILE=macos-terminal /bin/sh "$terrapod" status
+)"
+assert_line "$test_hook_records_output" "$(printf 'chezmoi\tchezmoi')" "the Homebrew CLI record hook answers ahead of any command"
+assert_not_contains "$test_hook_records_output" "Terrapod status" "the Homebrew CLI record hook does not also run the requested command"
+
+unset_hook_help_output="$(
+  TERRAPOD_PRINT_HOMEBREW_CLI_RECORDS=0 TERRAPOD_PRINT_STANDARD_HOMEBREW_PREFIX=0 \
+    TERRAPOD_PROFILE=macos-terminal /bin/sh "$terrapod" help
+)"
+assert_contains "$unset_hook_help_output" "Terrapod - a small landing pod for your dotfiles" "an unset test hook leaves normal command dispatch alone"
+assert_not_contains "$unset_hook_help_output" "$(printf 'chezmoi\tchezmoi')" "an unset test hook prints no Homebrew CLI records"
+
 managed_targets="$(
   chezmoi \
     --source "$repo_root" \


### PR DESCRIPTION
Closes #174

Stacked on #209 (`juty9026/issue-173-effective-state-table`).

## Change

- `TERRAPOD_PRINT_HOMEBREW_CLI_RECORDS` and `TERRAPOD_PRINT_STANDARD_HOMEBREW_PREFIX` were two top-level `if`/`exit` blocks sitting mid-file, so every production invocation ran through a test-only early exit on its way to the command dispatch. They now live in one `dispatch_test_hooks` called immediately before the bottom `case`, in the same order, with the same exit statuses. `managed_homebrew_cli_records` stays as the hook's data source, which is still its only caller.
- `print_named_state_line`, `setup_option_prompt_name`, and `write_setup_settings` each forwarded to another function with no change of behavior. All three are gone and their call sites (4, 1, and 1 respectively) name `print_colon_state_line`, `setup_option_title`, and `write_managed_settings` directly.
- `print_key_tool_status` and `status_key_tool_warnings` took a `config_file` argument neither read. Both the parameters and the arguments at their call sites are gone.

## Note on the issue text

The issue's line numbers (`:1006-1009`, `:1033-1038`, `:978`, `:1320`, `:519`, `:2421`, `:1119`, `:1163`) are from the review baseline; on `main` the same code sits at `:1050-1053`, `:1063-1068`, `:1022`, `:1344`, `:557`, `:2506`, `:1137`, `:1181`. Every item described was found exactly as stated.

## Tests

`tests/homebrew_manifests_test.sh:45` — the reason the record hook exists — still passes. New assertions in `tests/terrapod_command_test.sh` pin the moved dispatch: the record hook answers ahead of an explicit command and does not also run it, and a hook variable set to something other than `1` leaves normal dispatch alone.

The wrapper and unused-argument removals are behavior-preserving, which the existing `status`, `diff`, `apply`, `doctor`, and `setup` assertions cover.

```
$ sh tests/homebrew_manifests_test.sh   -> 8 ok, exit 0
$ sh tests/terrapod_command_test.sh     -> 525 ok, exit 0
$ sh tests/terrapod_config_test.sh      -> 418 ok, exit 0
$ sh tests/terrapod_installer_test.sh   -> 404 ok, exit 0
$ sh tests/helper_resolution_test.sh    -> 4 ok, exit 0
$ sh tests/executable_selection_test.sh -> 47 ok, exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKu7yrNkZj6rtDDuF1kzVF