### PR TITLE
Point git difftool at nvim instead of an uninstalled vimdiff

### DIFF
--- a/dot_config/git/config
+++ b/dot_config/git/config
@@ -7,7 +7,9 @@
 [rebase]
 	autoStash = true
 [diff]
-	tool = vimdiff
+	tool = nvimdiff
+[difftool "nvimdiff"]
+	cmd = nvim -d "$LOCAL" "$REMOTE"
 [fetch]
 	prune = true
 [core]

--- a/tests/git_config_test.sh
+++ b/tests/git_config_test.sh
@@ -122,3 +122,52 @@ assert_contains "$readme" 'git config set --global user.signingKey "ssh-ed25519 
   "README documents optional SSH signing setup"
 assert_not_contains "$readme" "gitAllowedSigners" \
   "README removes the managed Git signer option"
+
+# The configured diff tool has to be one Terrapod actually installs; `vimdiff`
+# was not, so `git difftool` failed on the VPS Shell Profile and fell back to
+# the system vim on macOS.
+assert_contains "$managed_config" "tool = nvimdiff" "shared Git config drives diffs through nvim"
+assert_not_contains "$managed_config" "tool = vimdiff" "shared Git config no longer names an uninstalled diff tool"
+assert_contains "$repo_root/Brewfile" 'brew "neovim"' "the configured diff tool comes from a declared package"
+
+difftool_repo="$tmp_dir/difftool-repo"
+difftool_bin="$tmp_dir/difftool-bin"
+mkdir -p "$difftool_repo" "$difftool_bin"
+
+cat >"$difftool_bin/nvim" <<'STUB'
+#!/bin/sh
+printf '%s\n' "$*" >>"$NVIM_STUB_LOG"
+STUB
+chmod +x "$difftool_bin/nvim"
+
+git -C "$difftool_repo" init -q -b main
+git -C "$difftool_repo" config user.email "test@example.com"
+git -C "$difftool_repo" config user.name "Test User"
+printf 'one\n' >"$difftool_repo/tracked.txt"
+git -C "$difftool_repo" add tracked.txt
+git -C "$difftool_repo" commit -q -m "initial commit"
+printf 'two\n' >"$difftool_repo/tracked.txt"
+
+NVIM_STUB_LOG="$tmp_dir/nvim.log"
+: >"$NVIM_STUB_LOG"
+
+if ! HOME="$test_home" XDG_CONFIG_HOME="$test_xdg" NVIM_STUB_LOG="$NVIM_STUB_LOG" \
+  PATH="$difftool_bin:$PATH" \
+  git -C "$difftool_repo" difftool --no-prompt </dev/null >"$tmp_dir/difftool.out" 2>&1; then
+  fail "git difftool should succeed with the shared Terrapod config: $(cat "$tmp_dir/difftool.out")"
+fi
+
+if [ ! -s "$NVIM_STUB_LOG" ]; then
+  fail "git difftool should open the diff with nvim: $(cat "$tmp_dir/difftool.out")"
+fi
+pass "git difftool opens the diff with nvim"
+
+if ! grep -F -- "-d " "$NVIM_STUB_LOG" >/dev/null; then
+  fail "git difftool should open nvim in diff mode; got '$(cat "$NVIM_STUB_LOG")'"
+fi
+pass "git difftool opens nvim in diff mode"
+
+if ! grep -F -- "tracked.txt" "$NVIM_STUB_LOG" >/dev/null; then
+  fail "git difftool should pass the changed file to nvim; got '$(cat "$NVIM_STUB_LOG")'"
+fi
+pass "git difftool passes the changed file to nvim"


### PR DESCRIPTION
Closes #169

Stacked on #210 (`juty9026/issue-168-zshenv-brew-prefix`).

## Problem

`dot_config/git/config:9-10` set `diff.tool = vimdiff`. Nothing in the repo installs it — `Brewfile:18` declares `neovim`, which provides `nvim` and no `vim`.

- On the VPS Shell Profile there is no `vimdiff` binary at all, so `git difftool` fails.
- On macOS it silently reaches the ancient system `/usr/bin/vim` instead of the editor the rest of the repo standardizes on (`dot_zshrc.tmpl:63-64` aliases both `vim` and `vi` to `nvim`).

## Approach

The decided direction:

```ini
[diff]
	tool = nvimdiff
[difftool "nvimdiff"]
	cmd = nvim -d "$LOCAL" "$REMOTE"
```

Git 2.50 knows `nvimdiff` as a built-in, so the `diff.tool` line alone would work on the machine this was verified on. The explicit `difftool.nvimdiff.cmd` still earns its two lines: it pins the invocation to `nvim -d` rather than to whichever `mergetools/vimdiff` variant the installed Git happens to carry, and Terrapod supports Git from two package sources across two profiles.

`merge.tool` is left alone. It was never set, and setting it is a separate decision.

Code matched the issue description; no discrepancies.

## Tests

`tests/git_config_test.sh` runs the real thing rather than asserting on strings. It builds a repository with one modified tracked file, puts a logging `nvim` stub first on PATH, and runs `git difftool --no-prompt` against the shared config under the test `HOME` / `XDG_CONFIG_HOME` the suite already sets up.

```
$ sh tests/git_config_test.sh
... (21 pre-existing assertions) ...
ok - shared Git config drives diffs through nvim
ok - shared Git config no longer names an uninstalled diff tool
ok - the configured diff tool comes from a declared package
ok - git difftool opens the diff with nvim
ok - git difftool opens nvim in diff mode
ok - git difftool passes the changed file to nvim
```

The pre-change behaviour was reproduced directly, with `tool = vimdiff` and no `vim` stub on PATH:

```
$ git difftool --no-prompt   # rc=0
Vim: Warning: Output is not to a terminal
...
Vim: Error reading input, exiting...
$ wc -c < nvim.log
       0
```

That is the macOS half of the issue — the system `/usr/bin/vim` opened, the configured editor never ran — and it is exactly what the "opens the diff with nvim" assertion catches. On a machine without `vim` the same run fails outright, which is the Ubuntu half.

`brew "neovim"` in `Brewfile` is asserted too. That is the assertion that would have caught this class of defect in the first place: a configured tool must come from a declared package.

`git difftool` is invoked with stdin redirected from `/dev/null`, so a future regression to an interactive editor fails the suite instead of hanging it.

Other suites that touch the managed Git config or render it, all rc=0:

```
sh tests/lazygit_pr_merge_test.sh     (44)
sh tests/terrapod_installer_test.sh   (390)
sh tests/chezmoiignore_test.sh        (328)
sh tests/terrapod_config_test.sh      (393)
```

No `CONTEXT.md` or ADR change: no domain term moved and no architectural decision changed. Neither README nor any doc mentions the diff tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKu7yrNkZj6rtDDuF1kzVF
