### PR TITLE
Record on ADR 0006 that ADR 0008 superseded it

### DIFF
--- a/docs/adr/0006-use-official-installers-for-ai-cli-tools.md
+++ b/docs/adr/0006-use-official-installers-for-ai-cli-tools.md
@@ -2,6 +2,8 @@
 
 The **Optional AI Tool Stack** now installs Antigravity CLI, Claude Code, and Codex through each vendor's official native or standalone installer instead of managing all three as global npm packages through the mise-managed Node.js runtime. This follows current vendor installation guidance and replaces Gemini CLI with Antigravity CLI for the Google assistant slot. Terrapod's command output follows the same naming: setup describes Antigravity CLI, while status and doctor validate the `agy` binary. The transition remains non-destructive by leaving any existing npm-installed AI CLIs unmanaged rather than uninstalling them.
 
+ADR 0008 supersedes this decision's package source: the **Optional AI Tool Stack** installs Antigravity CLI, Claude Code, and Codex from Homebrew casks rather than from vendor installers. ADR 0017 later restored a vendor installer for Claude Code alone — the **Claude Code Installer** at `https://claude.ai/install.sh` — while Antigravity CLI and Codex stay Homebrew casks. This ADR's replacement of Gemini CLI with Antigravity CLI for the Google assistant slot, and the command naming that follows from it, remain in force.
+
 ## Consequences
 
 - Vendor installers may edit shell profiles during installation, so the AI CLI installer runs before the final chezmoi-managed shell files are applied.

--- a/tests/adr_supersession_test.sh
+++ b/tests/adr_supersession_test.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+adr_dir="$repo_root/docs/adr"
+
+fail() {
+  printf '%s\n' "not ok - $1" >&2
+  exit 1
+}
+
+pass() {
+  printf '%s\n' "ok - $1"
+}
+
+# Every "ADR NNNN" an ADR names must resolve to a file, so a renumbered or
+# deleted record cannot leave a dangling cross-reference behind.
+for adr in "$adr_dir"/*.md; do
+  adr_name="${adr##*/}"
+
+  for referenced in $(sed -n 's/.*ADR \([0-9][0-9][0-9][0-9]\).*/\1/p' "$adr" | sort -u); do
+    [ -n "$(find "$adr_dir" -name "$referenced-*.md")" ] ||
+      fail "$adr_name references an existing ADR (missing: ADR $referenced)"
+  done
+done
+pass "every ADR cross-reference resolves to an existing record"
+
+# ADR 0008 has always recorded that it supersedes ADR 0006; this is the reverse
+# direction, so a reader landing on 0006 is not left believing it is current.
+adr_0006="$adr_dir/0006-use-official-installers-for-ai-cli-tools.md"
+grep -F 'ADR 0008 supersedes this decision' "$adr_0006" >/dev/null ||
+  fail "ADR 0006 records that ADR 0008 superseded its package source"
+pass "ADR 0006 records that ADR 0008 superseded its package source"
+
+grep -F 'ADR 0017' "$adr_0006" >/dev/null ||
+  fail "ADR 0006 records the Claude Code vendor installer ADR 0017 restored"
+pass "ADR 0006 records the Claude Code vendor installer ADR 0017 restored"
+
+grep -F "ADR 0006's vendor-installer choice" "$adr_dir/0008-use-homebrew-for-optional-ai-cli-tools.md" >/dev/null ||
+  fail "ADR 0008 still records the supersession ADR 0006 points back to"
+pass "ADR 0008 still records the supersession ADR 0006 points back to"


### PR DESCRIPTION
Closes #182

Stacked on #212 (`juty9026/issue-171-minimal-vps-mobile-dev`).

## Problem

ADR 0008 records "This decision supersedes ADR 0001's blanket rejection
of Homebrew on Linux and ADR 0006's vendor-installer choice only for the
Optional AI Tool Stack." The supersession is written down — but only on
the superseding side. A reader who lands on ADR 0006 reads a record whose
entire subject is stale, with no signal.

## Note on the requested format

The issue asks for "a Status line … matching the convention the other
ADRs use", naming 0007/0010/0011/0012. Those ADRs carry no Status field —
none of the seventeen ADRs in this repo does. What 0007/0010/0011/0012
have is a prose sentence, in the ADR's own voice, in the paragraph
directly after the decision, saying what *they* supersede. This branch
follows that actual convention in the reverse direction rather than
introducing a Status field that would be the only one in `docs/adr`.

## Approach

One paragraph on ADR 0006, after the decision:

> ADR 0008 supersedes this decision's package source: the **Optional AI
> Tool Stack** installs Antigravity CLI, Claude Code, and Codex from
> Homebrew casks rather than from vendor installers. ADR 0017 later
> restored a vendor installer for Claude Code alone — the **Claude Code
> Installer** at `https://claude.ai/install.sh` — while Antigravity CLI
> and Codex stay Homebrew casks. This ADR's replacement of Gemini CLI
> with Antigravity CLI for the Google assistant slot, and the command
> naming that follows from it, remain in force.

Two things beyond a bare pointer, both because a reader arriving here
today would otherwise be misled a second time:

- **ADR 0017 is named.** It reinstated a vendor installer for Claude
  Code, so "0006 is superseded by 0008" alone would tell a reader that no
  AI CLI uses a vendor installer, which is no longer true.
- **What survives is stated.** ADR 0008 superseded 0006's *package
  source*, not its stack membership; Antigravity CLI replacing Gemini CLI
  is still current, and 0006 is where that is recorded.

The issue's note that ADR 0008's cross-profile cask claim needs
correcting is already handled — ADR 0015 supersedes exactly that claim.
Nothing here touches it.

## Tests

New `tests/adr_supersession_test.sh`, four assertions:

- every `ADR NNNN` reference across `docs/adr` resolves to an existing
  file (a general link-integrity invariant; green on the current tree);
- ADR 0006 carries the back-reference;
- ADR 0006 names ADR 0017;
- ADR 0008 still carries the forward reference the back-reference points
  at, so deleting one side breaks the pair.

Both directions red-checked:

```
$ # delete the new paragraph from ADR 0006
not ok - ADR 0006 records that ADR 0008 superseded its package source

$ # append "See ADR 0099 for details." to ADR 0006
not ok - 0006-use-official-installers-for-ai-cli-tools.md references an existing ADR (missing: ADR 0099)
```

```
PASS tests/adr_supersession_test.sh (4)
PASS tests/bootstrap_ubuntu_test.sh (31)
PASS tests/chezmoiignore_test.sh (336)
PASS tests/executable_selection_test.sh (47)
PASS tests/ghostty_config_test.sh (2)
PASS tests/git_config_test.sh (21)
PASS tests/hammerspoon_config_test.sh (10)
PASS tests/helper_resolution_test.sh (4)
PASS tests/homebrew_manifests_test.sh (8)
PASS tests/jetendard_font_test.sh (10)
PASS tests/jetendard_settings_test.sh (8)
PASS tests/karabiner_config_test.sh (9)
PASS tests/lazygit_pr_merge_test.sh (44)
PASS tests/readme_korean_test.sh (58)
PASS tests/readme_optional_stack_profiles_test.sh (116)
PASS tests/shell_integrations_test.sh (38)
PASS tests/terrapod_command_test.sh (508)
PASS tests/terrapod_config_test.sh (393)
PASS tests/terrapod_installer_test.sh (390)
PASS tests/zshenv_local_bin_test.sh (17)
PASS tests/zshrc_clear_test.zsh (10)
PASS tests/zshrc_zoxide_test.zsh (22)
TOTAL ok: 2086
```

`homebrew_ubuntu_smoke.sh` skipped (needs a container).

## Follow-ups

- ADR 0006 is not the only record missing a back-reference: 0001, 0003,
  0008, 0010, and 0011 are each partially superseded and say nothing
  about it. A test asserting the invariant for *every* pair would be the
  real fix; it fails on the current tree, so it belongs in its own issue
  with the five edits.
- ADR 0008's Consequences still list `brew upgrade --cask claude-code
  codex antigravity-cli`, which ADR 0017 superseded for `claude-code`.
  Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKu7yrNkZj6rtDDuF1kzVF
