### PR TITLE
Extract a shared test harness for the assertion vocabulary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,3 +28,16 @@ the run: `PATH="$(mise where python)/bin:$PATH" tests/run`.
 
 `tests/homebrew_ubuntu_smoke.sh` is not part of `tests/run` — it builds an
 Ubuntu container image and has to be invoked directly with Docker available.
+
+Every test file sources `tests/lib/harness.sh` for its assertion vocabulary
+instead of declaring its own. The harness provides `fail`, `pass`, `skip`, a
+`make_tmp_dir` preamble that fills `$tmp_dir` and removes it however the test
+ends, and four assertions with fixed signatures:
+
+    assert_contains          <haystack> <needle> <message>
+    assert_not_contains      <haystack> <needle> <message>
+    assert_file_contains     <file>     <needle> <message>
+    assert_file_not_contains <file>     <needle> <message>
+
+The haystack forms take a string and the file forms take a path; neither
+guesses. Assertions specific to one test file still live in that file.

--- a/tests/adr_supersession_test.sh
+++ b/tests/adr_supersession_test.sh
@@ -2,16 +2,8 @@
 set -eu
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+. "$repo_root/tests/lib/harness.sh"
 adr_dir="$repo_root/docs/adr"
-
-fail() {
-  printf '%s\n' "not ok - $1" >&2
-  exit 1
-}
-
-pass() {
-  printf '%s\n' "ok - $1"
-}
 
 # Every "ADR NNNN" an ADR names must resolve to a file, so a renumbered or
 # deleted record cannot leave a dangling cross-reference behind.

--- a/tests/bootstrap_ubuntu_test.sh
+++ b/tests/bootstrap_ubuntu_test.sh
@@ -2,46 +2,9 @@
 set -eu
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
-tmp_dir="$(mktemp -d)"
+. "$repo_root/tests/lib/harness.sh"
+make_tmp_dir
 chezmoi_bin="$(command -v chezmoi)"
-
-cleanup() {
-  rm -rf "$tmp_dir"
-}
-trap cleanup EXIT INT TERM
-
-fail() {
-  printf '%s\n' "not ok - $1" >&2
-  exit 1
-}
-
-pass() {
-  printf '%s\n' "ok - $1"
-}
-
-assert_contains() {
-  haystack="$1"
-  needle="$2"
-  message="$3"
-
-  if ! printf '%s\n' "$haystack" | grep -F "$needle" >/dev/null; then
-    fail "$message"
-  fi
-
-  pass "$message"
-}
-
-assert_not_contains() {
-  haystack="$1"
-  needle="$2"
-  message="$3"
-
-  if printf '%s\n' "$haystack" | grep -F -e "$needle" >/dev/null; then
-    fail "$message"
-  fi
-
-  pass "$message"
-}
 
 assert_first_occurrence_before() {
   haystack="$1"

--- a/tests/chezmoiignore_test.sh
+++ b/tests/chezmoiignore_test.sh
@@ -2,24 +2,11 @@
 set -eu
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
-tmp_dir="$(mktemp -d)"
+. "$repo_root/tests/lib/harness.sh"
+make_tmp_dir
 chezmoi_config="$tmp_dir/chezmoi.toml"
 
-cleanup() {
-  rm -rf "$tmp_dir"
-}
-trap cleanup EXIT INT TERM
-
 : >"$chezmoi_config"
-
-fail() {
-  printf '%s\n' "not ok - $1" >&2
-  exit 1
-}
-
-pass() {
-  printf '%s\n' "ok - $1"
-}
 
 managed_source_paths() {
   data="$1"
@@ -83,30 +70,6 @@ write_stub() {
     printf '%s\n' "$@"
   } >"$path"
   chmod +x "$path"
-}
-
-assert_contains_text() {
-  text="$1"
-  needle="$2"
-  message="$3"
-
-  if ! printf '%s\n' "$text" | grep -F -- "$needle" >/dev/null; then
-    fail "$message"
-  fi
-
-  pass "$message"
-}
-
-assert_not_contains_text() {
-  text="$1"
-  needle="$2"
-  message="$3"
-
-  if printf '%s\n' "$text" | grep -F -- "$needle" >/dev/null; then
-    fail "$message"
-  fi
-
-  pass "$message"
 }
 
 assert_texts_differ() {
@@ -343,15 +306,15 @@ macos_terminal_apps_karabiner_opener="$(render_template "$macos_terminal_apps_da
 macos_automation_apps_karabiner_opener="$(render_template "$macos_automation_apps_data" ".chezmoiscripts/run_onchange_after_50-open-karabiner-if-needed.sh.tmpl")"
 macos_development_apps_karabiner_opener="$(render_template "$macos_development_apps_data" ".chezmoiscripts/run_onchange_after_50-open-karabiner-if-needed.sh.tmpl")"
 
-assert_contains_text \
+assert_contains \
   "$macos_bootstrap" \
   'terrapod_homebrew_core_run_bundle "$core_brewfile"' \
   "macOS bootstrap always runs the core Brewfile through the core bundle helper"
 
-assert_contains_text "$ubuntu_homebrew_bootstrap" 'core_brewfile="' "Ubuntu renders the mandatory CLI bundle"
-assert_contains_text "$ubuntu_homebrew_bootstrap" 'HOMEBREW_NO_AUTO_UPDATE=1 brew bundle --no-upgrade' "Ubuntu bundle apply disables automatic updates"
-assert_not_contains_text "$ubuntu_homebrew_bootstrap" 'linux:arm64' "Ubuntu Homebrew bootstrap rejects the arm64 identifier"
-assert_contains_text "$ubuntu_homebrew_bootstrap" 'linux:x86_64|linux:aarch64)' "Ubuntu Homebrew reconciliation accepts exactly the supported Linux architecture identifiers"
+assert_contains "$ubuntu_homebrew_bootstrap" 'core_brewfile="' "Ubuntu renders the mandatory CLI bundle"
+assert_contains "$ubuntu_homebrew_bootstrap" 'HOMEBREW_NO_AUTO_UPDATE=1 brew bundle --no-upgrade' "Ubuntu bundle apply disables automatic updates"
+assert_not_contains "$ubuntu_homebrew_bootstrap" 'linux:arm64' "Ubuntu Homebrew bootstrap rejects the arm64 identifier"
+assert_contains "$ubuntu_homebrew_bootstrap" 'linux:x86_64|linux:aarch64)' "Ubuntu Homebrew reconciliation accepts exactly the supported Linux architecture identifiers"
 
 for bundle_source in \
   "$repo_root/.chezmoiscripts/run_before_10-reconcile-homebrew.sh.tmpl" \
@@ -364,22 +327,22 @@ do
 done
 pass "every Homebrew bundle call disables automatic updates"
 
-assert_not_contains_text \
+assert_not_contains \
   "$macos_bootstrap" \
   "Brewfile.macos-desktop-apps" \
   "macOS bootstrap default skips macOS Desktop App Stack Brewfile"
 
-assert_not_contains_text \
+assert_not_contains \
   "$macos_bootstrap" \
   "terrapod-macos-desktop-apps" \
   "macOS bootstrap default skips macOS Desktop App Stack temp Brewfile"
 
-assert_not_contains_text \
+assert_not_contains \
   "$macos_bootstrap" \
   'brew bundle --no-upgrade --file="$desktop_brewfile"' \
   "macOS bootstrap default skips macOS Desktop App Stack bundle"
 
-assert_contains_text \
+assert_contains \
   "$macos_bootstrap" \
   "clear_install_warning homebrew-desktop-apps" \
   "macOS bootstrap default renders macOS Desktop App Stack warning cleanup"
@@ -399,22 +362,22 @@ printf '%s\n' "$macos_jetendard_retry" >"$macos_jetendard_retry_script"
 sh -n "$macos_jetendard_retry_script" || fail "macOS Jetendard retry script should be valid sh"
 pass "macOS Jetendard retry script is valid sh"
 
-assert_contains_text \
+assert_contains \
   "$macos_jetendard_installer" \
   "Jetendard font helper checksum:" \
   "Jetendard installer tracks the helper checksum"
 
-assert_contains_text \
+assert_contains \
   "$macos_jetendard_installer" \
   'python3 "$font_helper" install' \
   "Jetendard installer invokes the helper install command"
 
-assert_contains_text \
+assert_contains \
   "$macos_jetendard_retry" \
   'if ! terrapod_install_warning_existing_path jetendard-font >/dev/null 2>&1; then' \
   "Jetendard retry is gated by its warning marker"
 
-assert_contains_text \
+assert_contains \
   "$macos_jetendard_retry" \
   'python3 "$font_helper" install' \
   "Jetendard retry invokes the helper install command"
@@ -841,8 +804,8 @@ fi
 pass "macOS bootstrap records homebrew-core marker when the Homebrew installer command fails"
 
 homebrew_installer_failure_marker_text="$(cat "$homebrew_installer_failure_marker")"
-assert_contains_text "$homebrew_installer_failure_marker_text" "summary='Homebrew core install needs attention'" "macOS bootstrap Homebrew installer failure marker keeps the expected summary"
-assert_contains_text "$homebrew_installer_failure_marker_text" "guidance='Install Homebrew from https://brew.sh, then rerun tpod apply.'" "macOS bootstrap Homebrew installer failure marker keeps recovery guidance"
+assert_contains "$homebrew_installer_failure_marker_text" "summary='Homebrew core install needs attention'" "macOS bootstrap Homebrew installer failure marker keeps the expected summary"
+assert_contains "$homebrew_installer_failure_marker_text" "guidance='Install Homebrew from https://brew.sh, then rerun tpod apply.'" "macOS bootstrap Homebrew installer failure marker keeps recovery guidance"
 
 homebrew_first_run_failure_state="$tmp_dir/homebrew-first-run-failure-state"
 homebrew_first_run_failure_home="$tmp_dir/homebrew-first-run-failure-home"
@@ -953,7 +916,7 @@ for shellenv_mode in command-failure eval-failure; do
   if [ ! -f "$shellenv_failure_marker" ]; then
     fail "core Homebrew $shellenv_mode records a homebrew-core marker"
   fi
-  assert_contains_text "$(cat "$shellenv_failure_marker")" \
+  assert_contains "$(cat "$shellenv_failure_marker")" \
     "Fix Homebrew shellenv, then rerun tpod apply." \
     "core Homebrew $shellenv_mode marker provides actionable recovery guidance"
   if grep -F "brew args:bundle" "$shellenv_failure_log" >/dev/null; then
@@ -991,7 +954,7 @@ if ! HOME="$core_detail_home" XDG_STATE_HOME="$core_detail_state" MACOS_BREW_LOG
 fi
 chmod 755 "$core_detail_prefix"
 
-assert_contains_text "$(cat "$tmp_dir/core-detail.out")" "visible brew bundle output:" "core Homebrew failure preserves visible brew output"
+assert_contains "$(cat "$tmp_dir/core-detail.out")" "visible brew bundle output:" "core Homebrew failure preserves visible brew output"
 core_detail_marker="$core_detail_state/terrapod/install-warnings/homebrew-core"
 if [ ! -f "$core_detail_marker" ]; then
   fail "core Homebrew bundle failure records a homebrew-core marker"
@@ -999,13 +962,13 @@ fi
 pass "core Homebrew bundle failure records a homebrew-core marker"
 
 core_detail_marker_text="$(cat "$core_detail_marker")"
-assert_contains_text "$core_detail_marker_text" "category='homebrew-core'" "core marker keeps one stable category"
-assert_contains_text "$core_detail_marker_text" "summary='Homebrew core install needs attention'" "core marker keeps stable summary"
-assert_contains_text "$core_detail_marker_text" "failed formulae: gum" "core marker guidance includes reliable failed formula names"
-assert_not_contains_text "$core_detail_marker_text" "failed casks:" "core marker guidance contains no cask detail after core casks are removed"
-assert_contains_text "$core_detail_marker_text" "Homebrew prefix is not writable: $core_detail_prefix" "core marker guidance identifies unwritable shared prefix"
-assert_not_contains_text "$core_detail_marker_text" "btop" "core marker excludes successful formula names"
-assert_not_contains_text "$core_detail_marker_text" "chown" "core marker avoids broad ownership command guidance"
+assert_contains "$core_detail_marker_text" "category='homebrew-core'" "core marker keeps one stable category"
+assert_contains "$core_detail_marker_text" "summary='Homebrew core install needs attention'" "core marker keeps stable summary"
+assert_contains "$core_detail_marker_text" "failed formulae: gum" "core marker guidance includes reliable failed formula names"
+assert_not_contains "$core_detail_marker_text" "failed casks:" "core marker guidance contains no cask detail after core casks are removed"
+assert_contains "$core_detail_marker_text" "Homebrew prefix is not writable: $core_detail_prefix" "core marker guidance identifies unwritable shared prefix"
+assert_not_contains "$core_detail_marker_text" "btop" "core marker excludes successful formula names"
+assert_not_contains "$core_detail_marker_text" "chown" "core marker avoids broad ownership command guidance"
 
 core_fallback_bin="$tmp_dir/core-fallback-bin"
 core_fallback_state="$tmp_dir/core-fallback-state"
@@ -1020,9 +983,9 @@ if ! HOME="$core_fallback_home" XDG_STATE_HOME="$core_fallback_state" MACOS_BREW
 fi
 
 core_fallback_marker_text="$(cat "$core_fallback_state/terrapod/install-warnings/homebrew-core")"
-assert_contains_text "$core_fallback_marker_text" "Review Homebrew core bundle output, fix package access, then rerun tpod apply." "core marker falls back to visible-output rerun guidance"
-assert_not_contains_text "$core_fallback_marker_text" "failed formulae:" "core fallback marker avoids invented formula detail"
-assert_not_contains_text "$core_fallback_marker_text" "failed casks:" "core fallback marker avoids invented cask detail"
+assert_contains "$core_fallback_marker_text" "Review Homebrew core bundle output, fix package access, then rerun tpod apply." "core marker falls back to visible-output rerun guidance"
+assert_not_contains "$core_fallback_marker_text" "failed formulae:" "core fallback marker avoids invented formula detail"
+assert_not_contains "$core_fallback_marker_text" "failed casks:" "core fallback marker avoids invented cask detail"
 
 core_retry_success_bin="$tmp_dir/core-retry-success-bin"
 core_retry_success_state="$tmp_dir/core-retry-success-state"
@@ -1060,10 +1023,10 @@ if ! HOME="$core_retry_failure_home" XDG_STATE_HOME="$core_retry_failure_state" 
 fi
 
 core_retry_failure_marker_text="$(cat "$core_retry_failure_state/terrapod/install-warnings/homebrew-core")"
-assert_contains_text "$core_retry_failure_marker_text" "failed formulae: mise" "failed core reconciliation replaces marker with current failed formula detail"
-assert_not_contains_text "$core_retry_failure_marker_text" "old core retry warning" "failed core reconciliation replaces stale marker guidance"
+assert_contains "$core_retry_failure_marker_text" "failed formulae: mise" "failed core reconciliation replaces marker with current failed formula detail"
+assert_not_contains "$core_retry_failure_marker_text" "old core retry warning" "failed core reconciliation replaces stale marker guidance"
 
-assert_contains_text "$core_retry_failure_marker_text" "updated_at='" "failed core reconciliation replacement marker keeps updated_at"
+assert_contains "$core_retry_failure_marker_text" "updated_at='" "failed core reconciliation replacement marker keeps updated_at"
 
 # A cask post-install step that reads stdin must not consume the per-item record
 # list, which would silently skip every package after the first.
@@ -1080,7 +1043,7 @@ if ! HOME="$core_stdin_home" XDG_STATE_HOME="$core_stdin_state" MACOS_BREW_LOG="
 fi
 
 core_stdin_marker_text="$(cat "$core_stdin_state/terrapod/install-warnings/homebrew-core")"
-assert_contains_text "$core_stdin_marker_text" "failed formulae: bat, zoxide" "core retry keeps reading records when brew bundle consumes stdin"
+assert_contains "$core_stdin_marker_text" "failed formulae: bat, zoxide" "core retry keeps reading records when brew bundle consumes stdin"
 
 mise_missing_without_core_home="$tmp_dir/mise-missing-without-core-home"
 mise_missing_without_core_state="$tmp_dir/mise-missing-without-core-state"
@@ -1136,41 +1099,41 @@ assert_managed_paths_exclude_prefix \
   "Brewfile.macos-desktop-apps" \
   "terminal-apps group does not manage rendered macOS Desktop App Stack Brewfile target"
 
-assert_not_contains_text "$macos_brewfile" 'cask "ghostty"' "macOS default does not render Ghostty"
-assert_not_contains_text "$macos_brewfile" 'cask "cmux"' "macOS default does not render cmux"
-assert_not_contains_text "$macos_brewfile" 'cask "hammerspoon"' "macOS default does not render Hammerspoon"
-assert_not_contains_text "$macos_brewfile" 'cask "karabiner-elements"' "macOS default does not render Karabiner-Elements"
-assert_not_contains_text "$macos_brewfile" 'cask "scroll-reverser"' "macOS default does not render Scroll Reverser"
-assert_not_contains_text "$macos_brewfile" 'cask "raycast"' "macOS default does not render Raycast"
-assert_not_contains_text "$macos_brewfile" 'cask "1password-cli"' "macOS default does not render 1Password CLI"
-assert_not_contains_text "$macos_brewfile" 'cask "istat-menus"' "macOS default does not render iStat Menus"
-assert_not_contains_text "$macos_brewfile" 'cask "claude"' "macOS default does not render Claude Desktop"
-assert_not_contains_text "$macos_brewfile" 'cask "codex-app"' "macOS default does not render the unified ChatGPT desktop app"
-assert_not_contains_text "$macos_brewfile" 'cask "chatgpt"' "macOS default does not render the legacy ChatGPT cask"
-assert_not_contains_text "$macos_brewfile" 'cask "codex"' "macOS default does not render Codex CLI as a desktop app"
-assert_not_contains_text "$macos_brewfile" 'cask "antigravity"' "macOS default does not render Antigravity 2.0"
-assert_not_contains_text "$macos_brewfile" 'cask "antigravity-ide"' "macOS default does not render Antigravity IDE"
-assert_not_contains_text "$macos_brewfile" 'cask "stablyai/orca/orca"' "macOS default does not render Orca"
-assert_not_contains_text "$macos_brewfile" 'cask "orbstack"' "macOS default does not render OrbStack"
+assert_not_contains "$macos_brewfile" 'cask "ghostty"' "macOS default does not render Ghostty"
+assert_not_contains "$macos_brewfile" 'cask "cmux"' "macOS default does not render cmux"
+assert_not_contains "$macos_brewfile" 'cask "hammerspoon"' "macOS default does not render Hammerspoon"
+assert_not_contains "$macos_brewfile" 'cask "karabiner-elements"' "macOS default does not render Karabiner-Elements"
+assert_not_contains "$macos_brewfile" 'cask "scroll-reverser"' "macOS default does not render Scroll Reverser"
+assert_not_contains "$macos_brewfile" 'cask "raycast"' "macOS default does not render Raycast"
+assert_not_contains "$macos_brewfile" 'cask "1password-cli"' "macOS default does not render 1Password CLI"
+assert_not_contains "$macos_brewfile" 'cask "istat-menus"' "macOS default does not render iStat Menus"
+assert_not_contains "$macos_brewfile" 'cask "claude"' "macOS default does not render Claude Desktop"
+assert_not_contains "$macos_brewfile" 'cask "codex-app"' "macOS default does not render the unified ChatGPT desktop app"
+assert_not_contains "$macos_brewfile" 'cask "chatgpt"' "macOS default does not render the legacy ChatGPT cask"
+assert_not_contains "$macos_brewfile" 'cask "codex"' "macOS default does not render Codex CLI as a desktop app"
+assert_not_contains "$macos_brewfile" 'cask "antigravity"' "macOS default does not render Antigravity 2.0"
+assert_not_contains "$macos_brewfile" 'cask "antigravity-ide"' "macOS default does not render Antigravity IDE"
+assert_not_contains "$macos_brewfile" 'cask "stablyai/orca/orca"' "macOS default does not render Orca"
+assert_not_contains "$macos_brewfile" 'cask "orbstack"' "macOS default does not render OrbStack"
 
-assert_contains_text "$terminal_apps_brewfile" 'cask "ghostty"' "terminal-apps group renders Ghostty"
-assert_not_contains_text "$terminal_apps_brewfile" 'cask "cmux"' "terminal-apps group does not render cmux"
-assert_not_contains_text "$terminal_apps_brewfile" 'cask "hammerspoon"' "terminal-apps group does not render automation casks"
+assert_contains "$terminal_apps_brewfile" 'cask "ghostty"' "terminal-apps group renders Ghostty"
+assert_not_contains "$terminal_apps_brewfile" 'cask "cmux"' "terminal-apps group does not render cmux"
+assert_not_contains "$terminal_apps_brewfile" 'cask "hammerspoon"' "terminal-apps group does not render automation casks"
 
-assert_contains_text "$automation_apps_brewfile" 'cask "hammerspoon"' "automation group renders Hammerspoon"
-assert_contains_text "$automation_apps_brewfile" 'cask "karabiner-elements"' "automation group renders Karabiner-Elements"
-assert_contains_text "$automation_apps_brewfile" 'cask "scroll-reverser"' "automation group renders Scroll Reverser"
+assert_contains "$automation_apps_brewfile" 'cask "hammerspoon"' "automation group renders Hammerspoon"
+assert_contains "$automation_apps_brewfile" 'cask "karabiner-elements"' "automation group renders Karabiner-Elements"
+assert_contains "$automation_apps_brewfile" 'cask "scroll-reverser"' "automation group renders Scroll Reverser"
 
-assert_contains_text "$launcher_apps_brewfile" 'cask "raycast"' "launcher group renders Raycast"
-assert_contains_text "$launcher_apps_brewfile" 'cask "1password-cli"' "launcher group renders 1Password CLI"
+assert_contains "$launcher_apps_brewfile" 'cask "raycast"' "launcher group renders Raycast"
+assert_contains "$launcher_apps_brewfile" 'cask "1password-cli"' "launcher group renders 1Password CLI"
 
-assert_contains_text "$monitoring_apps_brewfile" 'cask "istat-menus"' "monitoring group renders iStat Menus"
+assert_contains "$monitoring_apps_brewfile" 'cask "istat-menus"' "monitoring group renders iStat Menus"
 
-assert_contains_text "$development_apps_brewfile" 'cask "zed"' "development-apps group renders Zed"
-assert_contains_text "$development_apps_brewfile" 'cask "stablyai/orca/orca", trusted: true' "development-apps group trusts only Orca's fully-qualified vendor cask"
-assert_contains_text "$development_apps_brewfile" 'cask "orbstack"' "development-apps group renders OrbStack"
+assert_contains "$development_apps_brewfile" 'cask "zed"' "development-apps group renders Zed"
+assert_contains "$development_apps_brewfile" 'cask "stablyai/orca/orca", trusted: true' "development-apps group trusts only Orca's fully-qualified vendor cask"
+assert_contains "$development_apps_brewfile" 'cask "orbstack"' "development-apps group renders OrbStack"
 for removed_cask in claude codex-app chatgpt antigravity antigravity-ide; do
-  assert_not_contains_text "$development_apps_brewfile" "cask \"$removed_cask\"" "development-apps group excludes removed desktop cask: $removed_cask"
+  assert_not_contains "$development_apps_brewfile" "cask \"$removed_cask\"" "development-apps group excludes removed desktop cask: $removed_cask"
 done
 development_apps_casks="$(
   printf '%s\n' "$development_apps_brewfile" |
@@ -1184,13 +1147,13 @@ assert_text_equals \
   "$expected_development_apps_casks" \
   "development-apps group renders exactly the expected casks"
 
-assert_contains_text "$mobile_dev_brewfile" 'cask "android-studio"' "mobile-dev group renders Android Studio"
-assert_contains_text "$mobile_dev_brewfile" 'brew "mobile-dev-inc/tap/maestro", trusted: true' "mobile-dev group trusts only the fully-qualified Maestro formula, not the entire mobile-dev-inc/tap tap"
-assert_not_contains_text "$mobile_dev_brewfile" 'cask "maestro"' "mobile-dev group does not render the unrelated homebrew-cask maestro"
-assert_not_contains_text "$mobile_dev_brewfile" 'tap "mobile-dev-inc/tap"' "mobile-dev group taps on demand through the fully-qualified token instead of trusting the whole tap"
-assert_not_contains_text "$mobile_dev_brewfile" 'android-platform-tools' "mobile-dev group leaves platform tools to the Android SDK"
-assert_not_contains_text "$mobile_dev_brewfile" 'cask "temurin"' "mobile-dev group resolves Java through the Android Studio bundled runtime instead of a declared JDK"
-assert_not_contains_text "$mobile_dev_brewfile" 'cask "zed"' "mobile-dev group does not render development-apps casks"
+assert_contains "$mobile_dev_brewfile" 'cask "android-studio"' "mobile-dev group renders Android Studio"
+assert_contains "$mobile_dev_brewfile" 'brew "mobile-dev-inc/tap/maestro", trusted: true' "mobile-dev group trusts only the fully-qualified Maestro formula, not the entire mobile-dev-inc/tap tap"
+assert_not_contains "$mobile_dev_brewfile" 'cask "maestro"' "mobile-dev group does not render the unrelated homebrew-cask maestro"
+assert_not_contains "$mobile_dev_brewfile" 'tap "mobile-dev-inc/tap"' "mobile-dev group taps on demand through the fully-qualified token instead of trusting the whole tap"
+assert_not_contains "$mobile_dev_brewfile" 'android-platform-tools' "mobile-dev group leaves platform tools to the Android SDK"
+assert_not_contains "$mobile_dev_brewfile" 'cask "temurin"' "mobile-dev group resolves Java through the Android Studio bundled runtime instead of a declared JDK"
+assert_not_contains "$mobile_dev_brewfile" 'cask "zed"' "mobile-dev group does not render development-apps casks"
 
 mobile_dev_packages="$(
   printf '%s\n' "$mobile_dev_brewfile" |
@@ -1203,21 +1166,21 @@ assert_text_equals \
   "$expected_mobile_dev_packages" \
   "mobile-dev group renders exactly the expected packages"
 
-assert_not_contains_text "$macos_brewfile" 'cask "android-studio"' "macOS default does not render Android Studio"
-assert_not_contains_text "$macos_brewfile" 'mobile-dev-inc/tap/maestro' "macOS default does not render Maestro"
-assert_not_contains_text "$development_apps_brewfile" 'cask "android-studio"' "development-apps group does not render Android Studio"
+assert_not_contains "$macos_brewfile" 'cask "android-studio"' "macOS default does not render Android Studio"
+assert_not_contains "$macos_brewfile" 'mobile-dev-inc/tap/maestro' "macOS default does not render Maestro"
+assert_not_contains "$development_apps_brewfile" 'cask "android-studio"' "development-apps group does not render Android Studio"
 
 mobile_dev_zshenv="$(render_managed_file "$macos_mobile_dev_data" ".zshenv")"
 macos_default_zshenv="$(render_managed_file "$macos_data" ".zshenv")"
 
-assert_contains_text "$mobile_dev_zshenv" 'export ANDROID_HOME="$HOME/Library/Android/sdk"' "mobile-dev group exports ANDROID_HOME"
-assert_contains_text "$mobile_dev_zshenv" 'export ANDROID_SDK_ROOT="$ANDROID_HOME"' "mobile-dev group exports ANDROID_SDK_ROOT"
-assert_contains_text "$mobile_dev_zshenv" 'export JAVA_HOME="$android_studio_jbr"' "mobile-dev group resolves JAVA_HOME to the Android Studio bundled runtime"
-assert_contains_text "$mobile_dev_zshenv" 'if [[ -d "$android_studio_jbr" ]]; then' "JAVA_HOME is guarded so a failed Android Studio install cannot break java"
-assert_contains_text "$mobile_dev_zshenv" 'if [[ -d "$ANDROID_HOME/platform-tools" ]]; then' "platform-tools joins PATH only when the SDK provides it"
-assert_not_contains_text "$mobile_dev_zshenv" '.maestro/bin' "Maestro resolves through the Homebrew prefix instead of its vendor install directory"
-assert_not_contains_text "$mobile_dev_zshenv" 'mise activate' "the Android environment does not repeat the mise activation the managed zshrc already runs"
-assert_not_contains_text "$macos_default_zshenv" 'ANDROID_HOME' "macOS default does not render the Android environment"
+assert_contains "$mobile_dev_zshenv" 'export ANDROID_HOME="$HOME/Library/Android/sdk"' "mobile-dev group exports ANDROID_HOME"
+assert_contains "$mobile_dev_zshenv" 'export ANDROID_SDK_ROOT="$ANDROID_HOME"' "mobile-dev group exports ANDROID_SDK_ROOT"
+assert_contains "$mobile_dev_zshenv" 'export JAVA_HOME="$android_studio_jbr"' "mobile-dev group resolves JAVA_HOME to the Android Studio bundled runtime"
+assert_contains "$mobile_dev_zshenv" 'if [[ -d "$android_studio_jbr" ]]; then' "JAVA_HOME is guarded so a failed Android Studio install cannot break java"
+assert_contains "$mobile_dev_zshenv" 'if [[ -d "$ANDROID_HOME/platform-tools" ]]; then' "platform-tools joins PATH only when the SDK provides it"
+assert_not_contains "$mobile_dev_zshenv" '.maestro/bin' "Maestro resolves through the Homebrew prefix instead of its vendor install directory"
+assert_not_contains "$mobile_dev_zshenv" 'mise activate' "the Android environment does not repeat the mise activation the managed zshrc already runs"
+assert_not_contains "$macos_default_zshenv" 'ANDROID_HOME' "macOS default does not render the Android environment"
 
 mobile_dev_android_line="$(printf '%s\n' "$mobile_dev_zshenv" | grep -n 'export ANDROID_HOME' | head -1 | cut -d: -f1)"
 mobile_dev_override_line="$(printf '%s\n' "$mobile_dev_zshenv" | grep -n 'zsh/path.d' | head -1 | cut -d: -f1)"
@@ -1232,15 +1195,15 @@ pass "the Android environment renders before the machine-local override loop"
 development_apps_zprofile="$(render_managed_file "$macos_development_apps_data" ".zprofile")"
 macos_default_zprofile="$(render_managed_file "$macos_data" ".zprofile")"
 
-assert_contains_text \
+assert_contains \
   "$development_apps_zprofile" \
   '. "$HOME/.orbstack/shell/init.zsh"' \
   "development-apps group renders the OrbStack shell integration in .zprofile"
-assert_contains_text \
+assert_contains \
   "$development_apps_zprofile" \
   '[ -r "$HOME/.orbstack/shell/init.zsh" ]' \
   "OrbStack shell integration is guarded by a readability check so a missing cask cannot break login shells"
-assert_not_contains_text \
+assert_not_contains \
   "$macos_default_zprofile" \
   '.orbstack/shell/init.zsh' \
   "macOS default does not render the OrbStack shell integration"
@@ -1301,11 +1264,11 @@ assert_text_equals \
   "$expected_headerless_records" \
   "a declaration before the first macOS App Group header keeps a non-empty group field"
 
-assert_contains_text \
+assert_contains \
   "$macos_development_apps_bootstrap" \
   'read -r app_group token declaration' \
   "per-package retry reads the declaration field alongside the group and token"
-assert_contains_text \
+assert_contains \
   "$macos_development_apps_bootstrap" \
   '>"$single_package_brewfile"' \
   "per-package retry writes the recorded declaration so options such as trusted: true survive"
@@ -1329,8 +1292,8 @@ fi
 pass "Orca desktop app bundle failure records a homebrew-desktop-apps marker"
 
 development_apps_failure_marker_text="$(cat "$development_apps_failure_marker")"
-assert_contains_text "$development_apps_failure_marker_text" "failed casks: stablyai/orca/orca" "Orca failure attribution preserves its fully-qualified cask source"
-assert_contains_text "$development_apps_failure_marker_text" "App Groups: development-apps" "Orca failure attribution identifies the development-apps group"
+assert_contains "$development_apps_failure_marker_text" "failed casks: stablyai/orca/orca" "Orca failure attribution preserves its fully-qualified cask source"
+assert_contains "$development_apps_failure_marker_text" "App Groups: development-apps" "Orca failure attribution identifies the development-apps group"
 
 mobile_dev_bootstrap_script="$tmp_dir/macos-mobile-dev-bootstrap.sh"
 printf '%s\n' "$macos_mobile_dev_bootstrap" | sed \
@@ -1359,9 +1322,9 @@ fi
 pass "Maestro formula failure records a homebrew-desktop-apps marker"
 
 mobile_dev_failure_marker_text="$(cat "$mobile_dev_failure_marker")"
-assert_contains_text "$mobile_dev_failure_marker_text" "mobile-dev-inc/tap/maestro" \
+assert_contains "$mobile_dev_failure_marker_text" "mobile-dev-inc/tap/maestro" \
   "a failed tap formula is named in the desktop app warning marker"
-assert_contains_text "$mobile_dev_failure_marker_text" "App Groups: mobile-dev" \
+assert_contains "$mobile_dev_failure_marker_text" "App Groups: mobile-dev" \
   "a failed tap formula is attributed to its macOS App Group"
 
 terminal_launcher_bootstrap_script="$tmp_dir/macos-terminal-launcher-bootstrap.sh"
@@ -1391,11 +1354,11 @@ fi
 pass "macOS desktop app bundle failure records a homebrew-desktop-apps marker"
 
 terminal_launcher_marker_text="$(cat "$terminal_launcher_marker")"
-assert_contains_text "$terminal_launcher_marker_text" "category='homebrew-desktop-apps'" "desktop app marker keeps one stable category"
-assert_contains_text "$terminal_launcher_marker_text" "summary='Homebrew desktop app install needs attention'" "desktop app marker keeps stable summary"
-assert_contains_text "$terminal_launcher_marker_text" "failed casks: ghostty, raycast" "desktop app marker guidance includes only casks whose single-cask bundle failed"
-assert_contains_text "$terminal_launcher_marker_text" "App Groups: terminal-apps, launcher" "desktop app marker guidance includes enabled App Groups"
-assert_not_contains_text "$terminal_launcher_marker_text" "1password-cli" "desktop app marker excludes casks whose single-cask bundle succeeded"
+assert_contains "$terminal_launcher_marker_text" "category='homebrew-desktop-apps'" "desktop app marker keeps one stable category"
+assert_contains "$terminal_launcher_marker_text" "summary='Homebrew desktop app install needs attention'" "desktop app marker keeps stable summary"
+assert_contains "$terminal_launcher_marker_text" "failed casks: ghostty, raycast" "desktop app marker guidance includes only casks whose single-cask bundle failed"
+assert_contains "$terminal_launcher_marker_text" "App Groups: terminal-apps, launcher" "desktop app marker guidance includes enabled App Groups"
+assert_not_contains "$terminal_launcher_marker_text" "1password-cli" "desktop app marker excludes casks whose single-cask bundle succeeded"
 
 # Same stdin hazard as the core retry loop: ghostty is the first record, so a
 # stdin-reading brew would hide the later raycast failure entirely.
@@ -1412,7 +1375,7 @@ if ! HOME="$desktop_stdin_home" XDG_STATE_HOME="$desktop_stdin_state" MACOS_BREW
 fi
 
 desktop_stdin_marker_text="$(cat "$desktop_stdin_state/terrapod/install-warnings/homebrew-desktop-apps")"
-assert_contains_text "$desktop_stdin_marker_text" "failed casks: ghostty, raycast" "desktop app retry keeps reading records when brew bundle consumes stdin"
+assert_contains "$desktop_stdin_marker_text" "failed casks: ghostty, raycast" "desktop app retry keeps reading records when brew bundle consumes stdin"
 
 core_then_desktop_bin="$tmp_dir/core-then-desktop-bin"
 core_then_desktop_state="$tmp_dir/core-then-desktop-state"
@@ -1442,8 +1405,8 @@ pass "macOS bootstrap records core and desktop app warnings in one App Groups ru
 
 core_then_desktop_core_text="$(cat "$core_then_desktop_core_marker")"
 core_then_desktop_desktop_text="$(cat "$core_then_desktop_desktop_marker")"
-assert_contains_text "$core_then_desktop_core_text" "failed formulae: mise" "combined bootstrap core marker keeps failed formula detail"
-assert_contains_text "$core_then_desktop_desktop_text" "failed casks: ghostty, raycast" "combined bootstrap desktop marker keeps failed cask detail"
+assert_contains "$core_then_desktop_core_text" "failed formulae: mise" "combined bootstrap core marker keeps failed formula detail"
+assert_contains "$core_then_desktop_desktop_text" "failed casks: ghostty, raycast" "combined bootstrap desktop marker keeps failed cask detail"
 
 terminal_launcher_marker_failure_bin="$tmp_dir/terminal-launcher-marker-failure-bin"
 terminal_launcher_marker_failure_state="$tmp_dir/terminal-launcher-marker-failure-state"
@@ -1515,9 +1478,9 @@ if ! HOME="$bulk_only_home" XDG_STATE_HOME="$bulk_only_state" MACOS_BREW_LOG="$b
 fi
 
 bulk_only_marker_text="$(cat "$bulk_only_state/terrapod/install-warnings/homebrew-desktop-apps")"
-assert_contains_text "$bulk_only_marker_text" "Review Homebrew desktop app bundle output" "desktop app marker falls back when bulk fails but single-cask attribution succeeds"
-assert_not_contains_text "$bulk_only_marker_text" "failed casks:" "desktop app bulk-only fallback avoids invented cask detail"
-assert_not_contains_text "$bulk_only_marker_text" "App Groups:" "desktop app bulk-only fallback avoids invented App Group detail"
+assert_contains "$bulk_only_marker_text" "Review Homebrew desktop app bundle output" "desktop app marker falls back when bulk fails but single-cask attribution succeeds"
+assert_not_contains "$bulk_only_marker_text" "failed casks:" "desktop app bulk-only fallback avoids invented cask detail"
+assert_not_contains "$bulk_only_marker_text" "App Groups:" "desktop app bulk-only fallback avoids invented App Group detail"
 
 fallback_bootstrap_script="$tmp_dir/macos-desktop-fallback-bootstrap.sh"
 awk '
@@ -1553,9 +1516,9 @@ if ! HOME="$fallback_home" XDG_STATE_HOME="$fallback_state" MACOS_BREW_LOG="$fal
 fi
 
 fallback_marker_text="$(cat "$fallback_state/terrapod/install-warnings/homebrew-desktop-apps")"
-assert_contains_text "$fallback_marker_text" "Review Homebrew desktop app bundle output" "desktop app marker falls back to bulk bundle guidance when casks are not reliable"
-assert_not_contains_text "$fallback_marker_text" "failed casks:" "desktop app fallback marker avoids invented cask detail"
-assert_not_contains_text "$fallback_marker_text" "App Groups:" "desktop app fallback marker avoids invented App Group detail"
+assert_contains "$fallback_marker_text" "Review Homebrew desktop app bundle output" "desktop app marker falls back to bulk bundle guidance when casks are not reliable"
+assert_not_contains "$fallback_marker_text" "failed casks:" "desktop app fallback marker avoids invented cask detail"
+assert_not_contains "$fallback_marker_text" "App Groups:" "desktop app fallback marker avoids invented App Group detail"
 
 headerless_bootstrap_script="$tmp_dir/macos-desktop-headerless-bootstrap.sh"
 awk '
@@ -1602,11 +1565,11 @@ fi
 pass "headerless desktop app bundle failure records a homebrew-desktop-apps marker"
 
 headerless_marker_text="$(cat "$headerless_marker")"
-assert_contains_text "$headerless_marker_text" "failed casks: ghostty" \
+assert_contains "$headerless_marker_text" "failed casks: ghostty" \
   "a cask declared before the first macOS App Group header is still retried and attributed"
-assert_not_contains_text "$headerless_marker_text" "App Groups:" \
+assert_not_contains "$headerless_marker_text" "App Groups:" \
   "a cask with no macOS App Group contributes no App Group detail"
-assert_not_contains_text "$headerless_marker_text" "raycast" \
+assert_not_contains "$headerless_marker_text" "raycast" \
   "a grouped cask whose single-cask bundle succeeds stays out of the marker"
 
 terminal_only_bootstrap_script="$tmp_dir/macos-terminal-only-bootstrap.sh"
@@ -1634,11 +1597,11 @@ if ! HOME="$terminal_only_home" XDG_STATE_HOME="$terminal_only_state" MACOS_BREW
 fi
 
 terminal_only_marker_text="$(cat "$terminal_only_state/terrapod/install-warnings/homebrew-desktop-apps")"
-assert_contains_text "$terminal_only_marker_text" "failed casks: ghostty" "enabled terminal-apps failure remains in desktop app marker"
-assert_contains_text "$terminal_only_marker_text" "App Groups: terminal-apps" "enabled terminal-apps group remains in desktop app marker"
-assert_not_contains_text "$terminal_only_marker_text" "raycast" "disabled launcher cask is removed from desktop app marker"
-assert_not_contains_text "$terminal_only_marker_text" "1password-cli" "disabled launcher CLI cask is removed from desktop app marker"
-assert_not_contains_text "$terminal_only_marker_text" "launcher" "disabled launcher group is removed from desktop app marker"
+assert_contains "$terminal_only_marker_text" "failed casks: ghostty" "enabled terminal-apps failure remains in desktop app marker"
+assert_contains "$terminal_only_marker_text" "App Groups: terminal-apps" "enabled terminal-apps group remains in desktop app marker"
+assert_not_contains "$terminal_only_marker_text" "raycast" "disabled launcher cask is removed from desktop app marker"
+assert_not_contains "$terminal_only_marker_text" "1password-cli" "disabled launcher CLI cask is removed from desktop app marker"
+assert_not_contains "$terminal_only_marker_text" "launcher" "disabled launcher group is removed from desktop app marker"
 
 terminal_success_bin="$tmp_dir/terminal-success-bin"
 terminal_success_state="$tmp_dir/terminal-success-state"
@@ -1661,57 +1624,57 @@ if [ -e "$terminal_success_state/terrapod/install-warnings/homebrew-desktop-apps
 fi
 pass "successful desktop app rerun clears homebrew-desktop-apps marker"
 
-assert_contains_text \
+assert_contains \
   "$macos_terminal_apps_bootstrap" \
   "terrapod-macos-desktop-apps" \
   "terminal-apps group renders macOS Desktop App Stack Brewfile"
 
-assert_contains_text \
+assert_contains \
   "$macos_terminal_apps_bootstrap" \
   'run_desktop_app_bundle "$desktop_brewfile"' \
   "terminal-apps group runs macOS Desktop App Stack installer"
 
-assert_contains_text \
+assert_contains \
   "$macos_development_apps_bootstrap" \
   "terrapod-macos-desktop-apps" \
   "development-apps group renders macOS Desktop App Stack Brewfile"
 
-assert_contains_text \
+assert_contains \
   "$macos_development_apps_bootstrap" \
   'run_desktop_app_bundle "$desktop_brewfile"' \
   "development-apps group runs macOS Desktop App Stack installer"
 
-assert_not_contains_text \
+assert_not_contains \
   "$macos_development_workspace_bootstrap" \
   "Brewfile.macos-desktop-apps" \
   "enableDevelopmentWorkspace does not imply macOS Desktop App Stack Brewfile"
 
-assert_contains_text \
+assert_contains \
   "$macos_karabiner_opener" \
   "macOS Desktop App Stack enabled: false" \
   "Karabiner opener tracks disabled macOS Desktop App Stack state"
 
-assert_not_contains_text \
+assert_not_contains \
   "$macos_karabiner_opener" \
   "macOS Desktop App Stack Brewfile checksum" \
   "Karabiner opener default skips macOS Desktop App Stack Brewfile checksum"
 
-assert_contains_text \
+assert_contains \
   "$macos_automation_apps_karabiner_opener" \
   "macOS Desktop App Stack enabled: true" \
   "Karabiner opener tracks enabled macOS Desktop App Stack state"
 
-assert_contains_text \
+assert_contains \
   "$macos_automation_apps_karabiner_opener" \
   "macOS Desktop App Stack Brewfile checksum" \
   "Karabiner opener tracks macOS Desktop App Stack Brewfile changes"
 
-assert_contains_text \
+assert_contains \
   "$macos_development_apps_karabiner_opener" \
   "macOS Desktop App Stack enabled: true" \
   "Karabiner opener tracks enabled development-apps Desktop App Stack state"
 
-assert_contains_text \
+assert_contains \
   "$macos_development_apps_karabiner_opener" \
   "macOS Desktop App Stack Brewfile checksum" \
   "Karabiner opener tracks development-apps Desktop App Stack Brewfile changes"
@@ -1771,9 +1734,9 @@ assert_managed_paths_exclude_prefix \
 ghostty_font_lines="$(grep -E '^[[:space:]]*font-family[[:space:]]*=' "$repo_root/dot_config/ghostty/config")"
 assert_text_equals "$ghostty_font_lines" 'font-family = "Jetendard"' \
   "Ghostty uses Jetendard as its sole font family"
-assert_not_contains_text "$(cat "$repo_root/dot_config/ghostty/config")" "JetBrainsMono Nerd Font" \
+assert_not_contains "$(cat "$repo_root/dot_config/ghostty/config")" "JetBrainsMono Nerd Font" \
   "Ghostty no longer declares JetBrains Mono Nerd Font"
-assert_not_contains_text "$(cat "$repo_root/dot_config/ghostty/config")" "D2Coding" \
+assert_not_contains "$(cat "$repo_root/dot_config/ghostty/config")" "D2Coding" \
   "Ghostty no longer declares D2Coding"
 
 cmux_fixture_source="$tmp_dir/cmux-fixture-source"
@@ -1913,9 +1876,9 @@ pass "cross-profile Brewfile declares migrated Neovim and GitHub CLI"
 
 mise_tools_installer="$(render_template "$ubuntu_data" ".chezmoiscripts/run_after_20-install-mise-tools.sh.tmpl")"
 
-assert_contains_text "$mise_tools_installer" 'mise_bin="$(standard_mise_path || true)"' "mise installer resolves mise from a standard Homebrew prefix"
-assert_contains_text "$mise_tools_installer" '"$mise_bin" install --yes -C "$HOME"' "Ubuntu runtime install invokes the resolved Homebrew mise"
-assert_not_contains_text "$mise_tools_installer" '/usr/bin/mise' "Ubuntu runtime install never falls back to APT mise"
+assert_contains "$mise_tools_installer" 'mise_bin="$(standard_mise_path || true)"' "mise installer resolves mise from a standard Homebrew prefix"
+assert_contains "$mise_tools_installer" '"$mise_bin" install --yes -C "$HOME"' "Ubuntu runtime install invokes the resolved Homebrew mise"
+assert_not_contains "$mise_tools_installer" '/usr/bin/mise' "Ubuntu runtime install never falls back to APT mise"
 
 # run_after_20 is not a run_onchange_ script, so a source checksum in it gates
 # nothing and only reads as if the script were change-tracked.
@@ -1983,15 +1946,15 @@ if [ ! -f "$mise_tools_marker" ]; then
   fail "mise tool installer should write a mise-tools warning marker after mise install failure"
 fi
 mise_tools_marker_text="$(cat "$mise_tools_marker")"
-assert_contains_text "$mise_tools_marker_text" "summary='mise tool install needs attention'" "mise install failure marker keeps the expected summary"
-assert_contains_text "$mise_tools_marker_text" "Failed step(s): mise install" "mise install failure marker records failed mise install step"
-assert_contains_text "$mise_tools_marker_text" "GITHUB_TOKEN" "mise install failure marker suggests GitHub token recovery"
-assert_contains_text "$mise_tools_marker_text" "gh auth login" "mise install failure marker suggests GitHub auth recovery"
+assert_contains "$mise_tools_marker_text" "summary='mise tool install needs attention'" "mise install failure marker keeps the expected summary"
+assert_contains "$mise_tools_marker_text" "Failed step(s): mise install" "mise install failure marker records failed mise install step"
+assert_contains "$mise_tools_marker_text" "GITHUB_TOKEN" "mise install failure marker suggests GitHub token recovery"
+assert_contains "$mise_tools_marker_text" "gh auth login" "mise install failure marker suggests GitHub auth recovery"
 mise_tools_log_text="$(cat "$mise_tools_log")"
-assert_contains_text "$mise_tools_log_text" "/home/linuxbrew/.linuxbrew/bin/mise args:install --yes -C $mise_tools_home" "Ubuntu runtime install uses Linuxbrew mise"
-assert_not_contains_text "$mise_tools_log_text" "/usr/bin/mise" "Ubuntu runtime install never falls back to APT mise"
-assert_contains_text "$mise_tools_log_text" "mise args:exec --yes -C $mise_tools_home -- sh -c command -v corepack" "mise install failure still checks corepack availability"
-assert_contains_text "$mise_tools_log_text" "mise args:exec --yes -C $mise_tools_home -- corepack enable" "mise install failure still attempts corepack enable"
+assert_contains "$mise_tools_log_text" "/home/linuxbrew/.linuxbrew/bin/mise args:install --yes -C $mise_tools_home" "Ubuntu runtime install uses Linuxbrew mise"
+assert_not_contains "$mise_tools_log_text" "/usr/bin/mise" "Ubuntu runtime install never falls back to APT mise"
+assert_contains "$mise_tools_log_text" "mise args:exec --yes -C $mise_tools_home -- sh -c command -v corepack" "mise install failure still checks corepack availability"
+assert_contains "$mise_tools_log_text" "mise args:exec --yes -C $mise_tools_home -- corepack enable" "mise install failure still attempts corepack enable"
 
 HOME="$mise_tools_home" \
   XDG_STATE_HOME="$mise_tools_state" \
@@ -2019,10 +1982,10 @@ HOME="$mise_tools_home" \
   PATH="$mise_tools_bin:/usr/bin:/bin" \
   sh "$mise_tools_installer_script"
 mise_tools_marker_text="$(cat "$mise_tools_marker")"
-assert_contains_text "$mise_tools_marker_text" "summary='mise tool install needs attention'" "mise tool installer replacement marker keeps the expected summary"
-assert_contains_text "$mise_tools_marker_text" "Failed step(s): corepack enable" "mise tool installer replaces stale marker with corepack enable failure"
-assert_not_contains_text "$mise_tools_marker_text" "stale guidance" "mise tool installer replaces stale marker guidance"
-assert_contains_text "$mise_tools_marker_text" "updated_at='" "mise tool installer replacement marker includes update timestamp"
+assert_contains "$mise_tools_marker_text" "summary='mise tool install needs attention'" "mise tool installer replacement marker keeps the expected summary"
+assert_contains "$mise_tools_marker_text" "Failed step(s): corepack enable" "mise tool installer replaces stale marker with corepack enable failure"
+assert_not_contains "$mise_tools_marker_text" "stale guidance" "mise tool installer replaces stale marker guidance"
+assert_contains "$mise_tools_marker_text" "updated_at='" "mise tool installer replacement marker includes update timestamp"
 
 : >"$mise_tools_log"
 HOME="$mise_tools_home" \
@@ -2036,7 +1999,7 @@ if [ -e "$mise_tools_marker" ]; then
 fi
 pass "mise tool reconciliation clears stale mise-tools marker after a successful apply"
 mise_tools_retry_log_text="$(cat "$mise_tools_log")"
-assert_contains_text "$mise_tools_retry_log_text" "mise args:install --yes -C $mise_tools_home" "mise tool reconciliation attempts mise install when marker exists"
+assert_contains "$mise_tools_retry_log_text" "mise args:install --yes -C $mise_tools_home" "mise tool reconciliation attempts mise install when marker exists"
 
 : >"$mise_tools_log"
 HOME="$mise_tools_home" \
@@ -2066,7 +2029,7 @@ if [ ! -f "$mise_tools_marker" ]; then
 fi
 pass "mise tool reconciliation keeps a warning marker when apply still fails"
 mise_tools_marker_text="$(cat "$mise_tools_marker")"
-assert_contains_text "$mise_tools_marker_text" "Failed step(s): mise install" "mise tool reconciliation replacement marker records failed mise install step"
+assert_contains "$mise_tools_marker_text" "Failed step(s): mise install" "mise tool reconciliation replacement marker records failed mise install step"
 
 : >"$mise_tools_log"
 HOME="$mise_tools_home" \
@@ -2090,28 +2053,28 @@ disabled_ai_cli_tools_brewfile="$(render_template "$ubuntu_data" "Brewfile.ai-cl
 macos_ai_cli_tools_brewfile="$(render_template "$macos_ai_cli_tools_data" "Brewfile.ai-cli-tools.tmpl")"
 macos_development_workspace_ai_brewfile="$(render_template "$macos_development_workspace_data" "Brewfile.ai-cli-tools.tmpl")"
 
-assert_not_contains_text "$ai_cli_tools_installer" "bootstrap_linux_homebrew" "AI installer no longer owns Linuxbrew bootstrap"
-assert_not_contains_text "$ai_cli_tools_installer" "raw.githubusercontent.com/Homebrew/install" "AI installer never downloads Homebrew"
-assert_not_contains_text "$ai_cli_tools_installer" "HOMEBREW_NO_AUTO_UPDATE=1" "Ubuntu AI installer runs no Homebrew bundle"
-assert_not_contains_text "$ai_cli_tools_installer" "install_ai_cli_bundle" "Ubuntu AI installer renders no Homebrew bundle step"
-assert_not_contains_text "$ai_cli_tools_installer" 'cask "codex"' "Ubuntu AI installer renders no macOS-only casks"
-assert_contains_text "$ai_cli_tools_installer" 'clear_install_warning "$AI_CLI_WARNING_CATEGORY"' "Ubuntu AI installer only clears stale optional AI CLI markers"
-assert_contains_text "$macos_ai_cli_tools_installer" "/opt/homebrew/bin/brew" "macOS AI installer uses mandatory standard Homebrew"
-assert_contains_text "$macos_ai_cli_tools_installer" "HOMEBREW_NO_AUTO_UPDATE=1" "AI bundle disables Homebrew auto-update"
-assert_contains_text "$macos_terminal_apps_bootstrap" "HOMEBREW_NO_AUTO_UPDATE=1" "desktop bundle disables Homebrew auto-update"
+assert_not_contains "$ai_cli_tools_installer" "bootstrap_linux_homebrew" "AI installer no longer owns Linuxbrew bootstrap"
+assert_not_contains "$ai_cli_tools_installer" "raw.githubusercontent.com/Homebrew/install" "AI installer never downloads Homebrew"
+assert_not_contains "$ai_cli_tools_installer" "HOMEBREW_NO_AUTO_UPDATE=1" "Ubuntu AI installer runs no Homebrew bundle"
+assert_not_contains "$ai_cli_tools_installer" "install_ai_cli_bundle" "Ubuntu AI installer renders no Homebrew bundle step"
+assert_not_contains "$ai_cli_tools_installer" 'cask "codex"' "Ubuntu AI installer renders no macOS-only casks"
+assert_contains "$ai_cli_tools_installer" 'clear_install_warning "$AI_CLI_WARNING_CATEGORY"' "Ubuntu AI installer only clears stale optional AI CLI markers"
+assert_contains "$macos_ai_cli_tools_installer" "/opt/homebrew/bin/brew" "macOS AI installer uses mandatory standard Homebrew"
+assert_contains "$macos_ai_cli_tools_installer" "HOMEBREW_NO_AUTO_UPDATE=1" "AI bundle disables Homebrew auto-update"
+assert_contains "$macos_terminal_apps_bootstrap" "HOMEBREW_NO_AUTO_UPDATE=1" "desktop bundle disables Homebrew auto-update"
 
 for rendered_brewfile in "$macos_ai_cli_tools_brewfile" "$macos_development_workspace_ai_brewfile"; do
-  assert_contains_text "$rendered_brewfile" 'cask "antigravity-cli"' "Optional AI Tool Stack declares Antigravity CLI cask"
-  assert_contains_text "$rendered_brewfile" 'cask "codex"' "Optional AI Tool Stack declares Codex CLI cask"
-  assert_not_contains_text "$rendered_brewfile" 'cask "claude-code"' "Optional AI Tool Stack no longer declares a Claude Code cask"
+  assert_contains "$rendered_brewfile" 'cask "antigravity-cli"' "Optional AI Tool Stack declares Antigravity CLI cask"
+  assert_contains "$rendered_brewfile" 'cask "codex"' "Optional AI Tool Stack declares Codex CLI cask"
+  assert_not_contains "$rendered_brewfile" 'cask "claude-code"' "Optional AI Tool Stack no longer declares a Claude Code cask"
 done
 assert_text_equals "$disabled_ai_cli_tools_brewfile" "" "disabled Optional AI Tool Stack renders no Homebrew casks"
 assert_text_equals "$ai_cli_tools_brewfile" "" "Ubuntu Optional AI Tool Stack renders no Homebrew casks"
 assert_text_equals "$development_workspace_ai_brewfile" "" "Ubuntu Optional Development Workspace renders no AI Homebrew casks"
 
-assert_contains_text "$disabled_ai_cli_tools_cleanup" "AI_CLI_WARNING_CATEGORY=optional-ai-cli-tools" "disabled Optional AI Tool Stack renders optional AI CLI warning category"
-assert_contains_text "$disabled_ai_cli_tools_cleanup" 'clear_install_warning "$AI_CLI_WARNING_CATEGORY"' "disabled Optional AI Tool Stack renders stale marker cleanup"
-assert_not_contains_text "$disabled_ai_cli_tools_cleanup" "raw.githubusercontent.com/Homebrew/install" "disabled Optional AI Tool Stack cleanup does not render Homebrew installer URL"
+assert_contains "$disabled_ai_cli_tools_cleanup" "AI_CLI_WARNING_CATEGORY=optional-ai-cli-tools" "disabled Optional AI Tool Stack renders optional AI CLI warning category"
+assert_contains "$disabled_ai_cli_tools_cleanup" 'clear_install_warning "$AI_CLI_WARNING_CATEGORY"' "disabled Optional AI Tool Stack renders stale marker cleanup"
+assert_not_contains "$disabled_ai_cli_tools_cleanup" "raw.githubusercontent.com/Homebrew/install" "disabled Optional AI Tool Stack cleanup does not render Homebrew installer URL"
 
 disabled_ai_cli_tools_cleanup_script="$tmp_dir/disabled-ai-cli-tools-cleanup.sh"
 printf '%s\n' "$disabled_ai_cli_tools_cleanup" >"$disabled_ai_cli_tools_cleanup_script"
@@ -2216,10 +2179,10 @@ run_macos_ai_arch_case() {
     AI_UNAME_ARCH="$arch" AI_BREW_BIN="$expected_brew_bin" AI_BREW_LOG="$case_log" AI_BREW_FAIL=0 \
     PATH="$macos_ai_brew_bin:/usr/bin:/bin" sh "$macos_ai_cli_tools_installer_script"
   case_log_text="$(cat "$case_log")"
-  assert_contains_text "$case_log_text" "brew path:$expected_brew_bin/brew" "macOS $arch Optional AI Tool Stack selects its standard Homebrew prefix"
-  assert_contains_text "$case_log_text" "brew args:shellenv" "macOS $arch Optional AI Tool Stack loads Homebrew shellenv"
-  assert_contains_text "$case_log_text" "brew args:bundle --no-upgrade --file=" "macOS $arch Optional AI Tool Stack installs the common no-upgrade bundle"
-  assert_contains_text "$case_log_text" "brew auto-update:1" "macOS $arch Optional AI Tool Stack disables Homebrew auto-update"
+  assert_contains "$case_log_text" "brew path:$expected_brew_bin/brew" "macOS $arch Optional AI Tool Stack selects its standard Homebrew prefix"
+  assert_contains "$case_log_text" "brew args:shellenv" "macOS $arch Optional AI Tool Stack loads Homebrew shellenv"
+  assert_contains "$case_log_text" "brew args:bundle --no-upgrade --file=" "macOS $arch Optional AI Tool Stack installs the common no-upgrade bundle"
+  assert_contains "$case_log_text" "brew auto-update:1" "macOS $arch Optional AI Tool Stack disables Homebrew auto-update"
 }
 
 run_macos_ai_arch_case arm64 "$macos_ai_brew_bin"
@@ -2250,15 +2213,15 @@ for vendor_url in \
   "https://antigravity.google/cli/install.sh" \
   "https://chatgpt.com/codex/install.sh"
 do
-  assert_not_contains_text "$ai_cli_tools_installer" "$vendor_url" "Optional AI Tool Stack no longer renders vendor installer URL: $vendor_url"
-  assert_not_contains_text "$macos_ai_cli_tools_installer" "$vendor_url" "macOS Optional AI Tool Stack no longer renders vendor installer URL: $vendor_url"
+  assert_not_contains "$ai_cli_tools_installer" "$vendor_url" "Optional AI Tool Stack no longer renders vendor installer URL: $vendor_url"
+  assert_not_contains "$macos_ai_cli_tools_installer" "$vendor_url" "macOS Optional AI Tool Stack no longer renders vendor installer URL: $vendor_url"
 done
 
-assert_contains_text "$macos_ai_cli_tools_installer" "https://claude.ai/install.sh" \
+assert_contains "$macos_ai_cli_tools_installer" "https://claude.ai/install.sh" \
   "macOS Optional AI Tool Stack renders the Claude Code installer URL"
-assert_not_contains_text "$ai_cli_tools_installer" "https://claude.ai/install.sh" \
+assert_not_contains "$ai_cli_tools_installer" "https://claude.ai/install.sh" \
   "Ubuntu Optional AI Tool Stack renders no Claude Code installer URL"
-assert_contains_text "$macos_ai_cli_tools_installer" 'bash "$claude_code_installer" </dev/null' \
+assert_contains "$macos_ai_cli_tools_installer" 'bash "$claude_code_installer" </dev/null' \
   "Claude Code installer runs under bash with stdin detached"
 
 linux_ai_brew_bin="$tmp_dir/linux-ai-brew-bin"
@@ -2346,9 +2309,9 @@ HOME="$claude_fresh_home" XDG_STATE_HOME="$claude_fresh_state" \
   AI_UNAME_ARCH=arm64 AI_BREW_BIN="$macos_ai_brew_bin" AI_BREW_LOG="$claude_fresh_brew_log" AI_BREW_FAIL=0 \
   CLAUDE_INSTALLER_LOG="$claude_fresh_installer_log" \
   PATH="$macos_ai_brew_bin:/usr/bin:/bin" sh "$macos_ai_cli_tools_installer_script"
-assert_contains_text "$(cat "$claude_fresh_installer_log")" "curl args:" \
+assert_contains "$(cat "$claude_fresh_installer_log")" "curl args:" \
   "Optional AI Tool Stack downloads the Claude Code installer when Claude Code is absent"
-assert_contains_text "$(cat "$claude_fresh_installer_log")" "bash args:" \
+assert_contains "$(cat "$claude_fresh_installer_log")" "bash args:" \
   "Optional AI Tool Stack runs the Claude Code installer when Claude Code is absent"
 if [ ! -x "$claude_fresh_home/.local/bin/claude" ]; then
   fail "Optional AI Tool Stack installs the canonical Claude Code executable"
@@ -2391,9 +2354,9 @@ claude_failure_marker="$claude_failure_state/terrapod/install-warnings/optional-
 if [ ! -f "$claude_failure_marker" ]; then
   fail "a Claude Code install failure records the optional-ai-cli-tools marker"
 fi
-assert_contains_text "$(cat "$claude_failure_marker")" "Claude Code" \
+assert_contains "$(cat "$claude_failure_marker")" "Claude Code" \
   "a Claude Code install failure names Claude Code in its marker"
-assert_not_contains_text "$(cat "$claude_failure_marker")" "Homebrew bundle" \
+assert_not_contains "$(cat "$claude_failure_marker")" "Homebrew bundle" \
   "a Claude Code install failure does not name the Homebrew bundle in its marker"
 pass "a Claude Code install failure records a warning and exits zero"
 
@@ -2418,7 +2381,7 @@ claude_skip_binary_marker="$claude_skip_binary_state/terrapod/install-warnings/o
 if [ ! -f "$claude_skip_binary_marker" ]; then
   fail "a vendor installer that exits zero without the canonical executable records the optional-ai-cli-tools marker"
 fi
-assert_contains_text "$(cat "$claude_skip_binary_marker")" "Claude Code" \
+assert_contains "$(cat "$claude_skip_binary_marker")" "Claude Code" \
   "a vendor installer that exits zero without the canonical executable names Claude Code in its marker"
 pass "a vendor installer that exits zero without installing the canonical executable records a warning and exits zero"
 
@@ -2443,7 +2406,7 @@ claude_curl_failure_marker="$claude_curl_failure_state/terrapod/install-warnings
 if [ ! -f "$claude_curl_failure_marker" ]; then
   fail "a Claude Code installer download failure records the optional-ai-cli-tools marker"
 fi
-assert_contains_text "$(cat "$claude_curl_failure_marker")" "Claude Code" \
+assert_contains "$(cat "$claude_curl_failure_marker")" "Claude Code" \
   "a Claude Code installer download failure names Claude Code in its marker"
 pass "a Claude Code installer download failure records a warning and exits zero"
 
@@ -2465,9 +2428,9 @@ if [ ! -f "$claude_both_failure_marker" ]; then
   fail "a Homebrew bundle failure together with a Claude Code install failure records the optional-ai-cli-tools marker"
 fi
 claude_both_failure_marker_text="$(cat "$claude_both_failure_marker")"
-assert_contains_text "$claude_both_failure_marker_text" "Homebrew bundle" \
+assert_contains "$claude_both_failure_marker_text" "Homebrew bundle" \
   "a combined install failure names the Homebrew bundle in its marker"
-assert_contains_text "$claude_both_failure_marker_text" "Claude Code" \
+assert_contains "$claude_both_failure_marker_text" "Claude Code" \
   "a combined install failure names Claude Code in its marker"
 if ! grep -F "Failed: Homebrew bundle, Claude Code." "$claude_both_failure_marker" >/dev/null; then
   fail "a combined install failure names both sources on a single line"
@@ -2488,13 +2451,13 @@ HOME="$claude_bundle_failure_home" XDG_STATE_HOME="$claude_bundle_failure_state"
 if [ "$claude_bundle_failure_status" -ne 0 ]; then
   fail "a Homebrew bundle failure should continue apply after recording a warning"
 fi
-assert_contains_text "$(cat "$claude_bundle_failure_installer_log")" "bash args:" \
+assert_contains "$(cat "$claude_bundle_failure_installer_log")" "bash args:" \
   "a Homebrew bundle failure does not skip the Claude Code step"
 claude_bundle_failure_marker="$claude_bundle_failure_state/terrapod/install-warnings/optional-ai-cli-tools"
 if [ ! -f "$claude_bundle_failure_marker" ]; then
   fail "a Homebrew bundle failure records the optional-ai-cli-tools marker"
 fi
-assert_contains_text "$(cat "$claude_bundle_failure_marker")" "Homebrew bundle" \
+assert_contains "$(cat "$claude_bundle_failure_marker")" "Homebrew bundle" \
   "a Homebrew bundle failure names the bundle in its marker"
 
 development_workspace_zellij_layout="$(render_managed_file "$development_workspace_data" ".config/zellij/layouts/dev.kdl")"
@@ -2586,12 +2549,12 @@ done
 for warning_script in $inlined_warning_scripts; do
   rendered_warning_script="$(render_template "$(warning_script_data "$warning_script")" "$warning_script")"
 
-  assert_contains_text \
+  assert_contains \
     "$rendered_warning_script" \
     "terrapod_install_warning_write() {" \
     "always-run script inlines the marker library: $warning_script"
 
-  assert_not_contains_text \
+  assert_not_contains \
     "$rendered_warning_script" \
     'if [ -f "$install_warnings_lib" ]; then' \
     "always-run script keeps no install warning loader guard: $warning_script"
@@ -2600,17 +2563,17 @@ done
 for warning_script in $path_sourced_warning_scripts; do
   rendered_warning_script="$(render_template "$(warning_script_data "$warning_script")" "$warning_script")"
 
-  assert_not_contains_text \
+  assert_not_contains \
     "$rendered_warning_script" \
     "terrapod_install_warning_write() {" \
     "run_onchange script keeps the marker library out of its content hash: $warning_script"
 
-  assert_contains_text \
+  assert_contains \
     "$rendered_warning_script" \
     "/dot_local/lib/terrapod/install-warnings.sh" \
     "run_onchange script sources the marker library by path: $warning_script"
 
-  assert_not_contains_text \
+  assert_not_contains \
     "$rendered_warning_script" \
     'if [ -f "$install_warnings_lib" ]; then' \
     "run_onchange script keeps no install warning loader guard: $warning_script"

--- a/tests/executable_selection_test.sh
+++ b/tests/executable_selection_test.sh
@@ -2,48 +2,9 @@
 set -eu
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+. "$repo_root/tests/lib/harness.sh"
 selection="$repo_root/dot_local/lib/terrapod/executable_executable-selection"
-tmp_dir="$(mktemp -d)"
-
-cleanup() {
-  rm -rf "$tmp_dir"
-}
-trap cleanup EXIT INT TERM
-
-fail() {
-  printf '%s\n' "not ok - $1" >&2
-  exit 1
-}
-
-pass() {
-  printf '%s\n' "ok - $1"
-}
-
-assert_contains() {
-  text="$1"
-  expected="$2"
-  label="$3"
-  case "$text" in
-    *"$expected"*) pass "$label" ;;
-    *)
-      printf '%s\n' "$text" >&2
-      fail "$label (missing: $expected)"
-      ;;
-  esac
-}
-
-assert_not_contains() {
-  text="$1"
-  unexpected="$2"
-  label="$3"
-  case "$text" in
-    *"$unexpected"*)
-      printf '%s\n' "$text" >&2
-      fail "$label (unexpected: $unexpected)"
-      ;;
-    *) pass "$label" ;;
-  esac
-}
+make_tmp_dir
 
 write_executable() {
   path="$1"

--- a/tests/ghostty_config_test.sh
+++ b/tests/ghostty_config_test.sh
@@ -2,16 +2,8 @@
 set -eu
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+. "$repo_root/tests/lib/harness.sh"
 ghostty_config="$repo_root/dot_config/ghostty/config"
-
-fail() {
-  printf '%s\n' "not ok - $1" >&2
-  exit 1
-}
-
-pass() {
-  printf '%s\n' "ok - $1"
-}
 
 features_line="$(
   sed -n 's/^shell-integration-features[[:space:]]*=[[:space:]]*//p' "$ghostty_config" |

--- a/tests/git_config_test.sh
+++ b/tests/git_config_test.sh
@@ -2,44 +2,11 @@
 set -eu
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+. "$repo_root/tests/lib/harness.sh"
 managed_config="$repo_root/dot_config/git/config"
 user_config_source="$repo_root/create_dot_gitconfig"
 readme="$repo_root/README.md"
-tmp_dir="$(mktemp -d)"
-trap 'rm -rf "$tmp_dir"' EXIT INT TERM
-
-fail() {
-  printf '%s\n' "not ok - $1" >&2
-  exit 1
-}
-
-pass() {
-  printf '%s\n' "ok - $1"
-}
-
-assert_contains() {
-  file="$1"
-  needle="$2"
-  message="$3"
-
-  if ! grep -F "$needle" "$file" >/dev/null; then
-    fail "$message"
-  fi
-
-  pass "$message"
-}
-
-assert_not_contains() {
-  file="$1"
-  needle="$2"
-  message="$3"
-
-  if grep -F "$needle" "$file" >/dev/null; then
-    fail "$message"
-  fi
-
-  pass "$message"
-}
+make_tmp_dir
 
 if [ ! -f "$managed_config" ]; then
   fail "Terrapod manages shared Git settings through ~/.config/git/config"
@@ -61,9 +28,9 @@ if [ -e "$repo_root/private_dot_ssh/allowed_signers.tmpl" ]; then
 fi
 pass "Terrapod leaves SSH allowed signers unmanaged"
 
-assert_contains "$managed_config" "[merge]" "shared Git config preserves merge settings"
-assert_contains "$managed_config" "[pull]" "shared Git config preserves pull settings"
-assert_contains "$managed_config" "[delta]" "shared Git config preserves delta settings"
+assert_file_contains "$managed_config" "[merge]" "shared Git config preserves merge settings"
+assert_file_contains "$managed_config" "[pull]" "shared Git config preserves pull settings"
+assert_file_contains "$managed_config" "[delta]" "shared Git config preserves delta settings"
 
 for personal_setting in \
   "[user]" \
@@ -73,7 +40,7 @@ for personal_setting in \
   "allowedSignersFile" \
   "gpgsign"
 do
-  assert_not_contains "$managed_config" "$personal_setting" \
+  assert_file_not_contains "$managed_config" "$personal_setting" \
     "shared Git config excludes personal setting: $personal_setting"
 done
 
@@ -114,21 +81,21 @@ if ! cmp -s "$tmp_dir/user-config-before" "$test_home/.gitconfig"; then
 fi
 pass "Terrapod preserves user changes in ~/.gitconfig on later applies"
 
-assert_contains "$readme" 'git config set --global user.name "Your Name"' \
+assert_file_contains "$readme" 'git config set --global user.name "Your Name"' \
   "README documents user-level Git name setup"
-assert_contains "$readme" 'git config set --global user.email "you@example.com"' \
+assert_file_contains "$readme" 'git config set --global user.email "you@example.com"' \
   "README documents user-level Git email setup"
-assert_contains "$readme" 'git config set --global user.signingKey "ssh-ed25519 YOUR_PUBLIC_KEY"' \
+assert_file_contains "$readme" 'git config set --global user.signingKey "ssh-ed25519 YOUR_PUBLIC_KEY"' \
   "README documents optional SSH signing setup"
-assert_not_contains "$readme" "gitAllowedSigners" \
+assert_file_not_contains "$readme" "gitAllowedSigners" \
   "README removes the managed Git signer option"
 
 # The configured diff tool has to be one Terrapod actually installs; `vimdiff`
 # was not, so `git difftool` failed on the VPS Shell Profile and fell back to
 # the system vim on macOS.
-assert_contains "$managed_config" "tool = nvimdiff" "shared Git config drives diffs through nvim"
-assert_not_contains "$managed_config" "tool = vimdiff" "shared Git config no longer names an uninstalled diff tool"
-assert_contains "$repo_root/Brewfile" 'brew "neovim"' "the configured diff tool comes from a declared package"
+assert_file_contains "$managed_config" "tool = nvimdiff" "shared Git config drives diffs through nvim"
+assert_file_not_contains "$managed_config" "tool = vimdiff" "shared Git config no longer names an uninstalled diff tool"
+assert_file_contains "$repo_root/Brewfile" 'brew "neovim"' "the configured diff tool comes from a declared package"
 
 difftool_repo="$tmp_dir/difftool-repo"
 difftool_bin="$tmp_dir/difftool-bin"

--- a/tests/hammerspoon_config_test.sh
+++ b/tests/hammerspoon_config_test.sh
@@ -2,22 +2,9 @@
 set -eu
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+. "$repo_root/tests/lib/harness.sh"
 hammerspoon_config="$repo_root/dot_hammerspoon/init.lua"
-tmp_dir="$(mktemp -d)"
-
-cleanup() {
-  rm -rf "$tmp_dir"
-}
-trap cleanup EXIT INT TERM
-
-fail() {
-  printf '%s\n' "not ok - $1" >&2
-  exit 1
-}
-
-pass() {
-  printf '%s\n' "ok - $1"
-}
+make_tmp_dir
 
 # Reads the appBindings table out of init.lua as tab-separated
 # key/label/bundleID rows. Entries may name a top-level `local` string instead

--- a/tests/helper_resolution_test.sh
+++ b/tests/helper_resolution_test.sh
@@ -2,48 +2,9 @@
 set -eu
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+. "$repo_root/tests/lib/harness.sh"
 terrapod="$repo_root/dot_local/bin/executable_terrapod"
-tmp_dir="$(mktemp -d)"
-
-cleanup() {
-  rm -rf "$tmp_dir"
-}
-trap cleanup EXIT INT TERM
-
-fail() {
-  printf '%s\n' "not ok - $1" >&2
-  exit 1
-}
-
-pass() {
-  printf '%s\n' "ok - $1"
-}
-
-assert_contains() {
-  text="$1"
-  expected="$2"
-  label="$3"
-  case "$text" in
-    *"$expected"*) pass "$label" ;;
-    *)
-      printf '%s\n' "$text" >&2
-      fail "$label (missing: $expected)"
-      ;;
-  esac
-}
-
-assert_not_contains() {
-  text="$1"
-  unexpected="$2"
-  label="$3"
-  case "$text" in
-    *"$unexpected"*)
-      printf '%s\n' "$text" >&2
-      fail "$label (unexpected: $unexpected)"
-      ;;
-    *) pass "$label" ;;
-  esac
-}
+make_tmp_dir
 
 stub_bin="$tmp_dir/bin"
 config_file="$tmp_dir/config/chezmoi.toml"

--- a/tests/homebrew_manifests_test.sh
+++ b/tests/homebrew_manifests_test.sh
@@ -2,11 +2,8 @@
 set -eu
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
-tmp_dir="$(mktemp -d)"
-trap 'rm -rf "$tmp_dir"' EXIT INT TERM
-
-fail() { printf '%s\n' "not ok - $1" >&2; exit 1; }
-pass() { printf '%s\n' "ok - $1"; }
+. "$repo_root/tests/lib/harness.sh"
+make_tmp_dir
 
 expected_formulae="$tmp_dir/expected-formulae"
 actual_formulae="$tmp_dir/actual-formulae"

--- a/tests/jetendard_font_test.sh
+++ b/tests/jetendard_font_test.sh
@@ -4,12 +4,9 @@ set -eu
 export PYTHONDONTWRITEBYTECODE=1
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+. "$repo_root/tests/lib/harness.sh"
 helper="$repo_root/dot_local/lib/terrapod/executable_jetendard-font"
-tmp_dir="$(mktemp -d)"
-trap 'rm -rf "$tmp_dir"' EXIT INT TERM
-
-fail() { printf '%s\n' "not ok - $1" >&2; exit 1; }
-pass() { printf '%s\n' "ok - $1"; }
+make_tmp_dir
 
 first_statement="$(awk 'NR == 1 && /^#!/ { next } /^[[:space:]]*$/ { next } { print; exit }' "$helper")"
 [ "$first_statement" = "from __future__ import annotations" ] || fail "helper defers annotation evaluation so Python 3.9 can import it"

--- a/tests/jetendard_settings_test.sh
+++ b/tests/jetendard_settings_test.sh
@@ -2,22 +2,9 @@
 set -eu
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+. "$repo_root/tests/lib/harness.sh"
 helper="$repo_root/dot_local/lib/terrapod/executable_jetendard-settings"
-tmp_dir="$(mktemp -d)"
-
-cleanup() {
-  rm -rf "$tmp_dir"
-}
-trap cleanup EXIT INT TERM
-
-fail() {
-  printf '%s\n' "not ok - $1" >&2
-  exit 1
-}
-
-pass() {
-  printf '%s\n' "ok - $1"
-}
+make_tmp_dir
 
 first_statement="$(awk 'NR == 1 && /^#!/ { next } /^[[:space:]]*$/ { next } { print; exit }' "$helper")"
 [ "$first_statement" = "from __future__ import annotations" ] || fail "helper defers annotation evaluation so Python 3.9 can import it"

--- a/tests/karabiner_config_test.sh
+++ b/tests/karabiner_config_test.sh
@@ -2,16 +2,8 @@
 set -eu
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+. "$repo_root/tests/lib/harness.sh"
 karabiner_config="$repo_root/dot_config/private_karabiner/private_karabiner.json"
-
-fail() {
-  printf '%s\n' "not ok - $1" >&2
-  exit 1
-}
-
-pass() {
-  printf '%s\n' "ok - $1"
-}
 
 assert_json_value() {
   filter="$1"

--- a/tests/lazygit_pr_merge_test.sh
+++ b/tests/lazygit_pr_merge_test.sh
@@ -2,21 +2,8 @@
 set -eu
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
-tmp_dir="$(mktemp -d)"
-
-cleanup() {
-  rm -rf "$tmp_dir"
-}
-trap cleanup EXIT INT TERM
-
-fail() {
-  printf '%s\n' "not ok - $1" >&2
-  exit 1
-}
-
-pass() {
-  printf '%s\n' "ok - $1"
-}
+. "$repo_root/tests/lib/harness.sh"
+make_tmp_dir
 
 write_stub() {
   path="$1"
@@ -26,30 +13,6 @@ write_stub() {
     printf '%s\n' "$@"
   } >"$path"
   chmod +x "$path"
-}
-
-assert_contains() {
-  haystack="$1"
-  needle="$2"
-  message="$3"
-
-  if ! printf '%s\n' "$haystack" | grep -F "$needle" >/dev/null; then
-    fail "$message"
-  fi
-
-  pass "$message"
-}
-
-assert_not_contains() {
-  haystack="$1"
-  needle="$2"
-  message="$3"
-
-  if printf '%s\n' "$haystack" | grep -F "$needle" >/dev/null; then
-    fail "$message"
-  fi
-
-  pass "$message"
 }
 
 assert_no_arg() {

--- a/tests/lib/harness.sh
+++ b/tests/lib/harness.sh
@@ -1,0 +1,118 @@
+# Assertion vocabulary and temporary-directory preamble shared by every
+# Terrapod test file.
+#
+# Written in POSIX shell and sourced by both tests/*_test.sh and
+# tests/*_test.zsh, so the two interpreters read one set of definitions
+# instead of near-identical copies.
+#
+# Canonical assertion signatures:
+#
+#   assert_contains          <haystack> <needle> <message>
+#   assert_not_contains      <haystack> <needle> <message>
+#   assert_file_contains     <file>     <needle> <message>
+#   assert_file_not_contains <file>     <needle> <message>
+#
+# The haystack forms take a string, the file forms take a path, and neither
+# infers which one it was handed. That is deliberate: the copies these replaced
+# disagreed about whether the first argument was text or a filename, so an
+# assertion copied between test files could silently change meaning.
+#
+# Helper working variables carry a harness_ prefix so sourcing this file never
+# shadows a name the test itself holds. The one deliberate exception is
+# make_tmp_dir, which fills $tmp_dir because that is the name every test reads.
+
+fail() {
+  printf '%s\n' "not ok - $1" >&2
+  exit 1
+}
+
+pass() {
+  printf '%s\n' "ok - $1"
+}
+
+# Reported instead of an assertion when a case cannot hold on this platform.
+# tests/run counts these lines, so a skip stays visible in a green CI log.
+skip() {
+  printf '%s\n' "skip - $1"
+}
+
+# Scratch directory for the test, removed however the test ends. The trap is
+# armed here rather than inside make_tmp_dir because zsh runs an EXIT trap set
+# inside a function as soon as that function returns.
+tmp_dir=""
+
+harness_remove_tmp_dir() {
+  if [ -n "$tmp_dir" ]; then
+    rm -rf "$tmp_dir"
+  fi
+}
+
+trap harness_remove_tmp_dir EXIT INT TERM
+
+make_tmp_dir() {
+  tmp_dir="$(mktemp -d)"
+}
+
+# Failure diagnostics: what was looked for, then the text or file it was looked
+# for in, indented so it cannot be misread as an ok/not ok line.
+harness_report_text() {
+  printf '%s\n' "$1" >&2
+  printf '%s\n' "$2" | sed 's/^/  /' >&2
+}
+
+harness_report_file() {
+  printf '%s\n' "$1" >&2
+  sed 's/^/  /' "$2" >&2
+}
+
+assert_contains() {
+  harness_haystack="$1"
+  harness_needle="$2"
+  harness_message="$3"
+
+  if ! printf '%s\n' "$harness_haystack" | grep -F -e "$harness_needle" >/dev/null; then
+    harness_report_text "missing: $harness_needle" "$harness_haystack"
+    fail "$harness_message"
+  fi
+
+  pass "$harness_message"
+}
+
+assert_not_contains() {
+  harness_haystack="$1"
+  harness_needle="$2"
+  harness_message="$3"
+
+  if printf '%s\n' "$harness_haystack" | grep -F -e "$harness_needle" >/dev/null; then
+    harness_report_text "unexpected: $harness_needle" "$harness_haystack"
+    fail "$harness_message"
+  fi
+
+  pass "$harness_message"
+}
+
+assert_file_contains() {
+  harness_file="$1"
+  harness_needle="$2"
+  harness_message="$3"
+
+  if ! grep -F -e "$harness_needle" "$harness_file" >/dev/null; then
+    harness_report_file "missing from $harness_file: $harness_needle" "$harness_file"
+    fail "$harness_message"
+  fi
+
+  pass "$harness_message"
+}
+
+assert_file_not_contains() {
+  harness_file="$1"
+  harness_needle="$2"
+  harness_message="$3"
+
+  if grep -F -e "$harness_needle" "$harness_file" >/dev/null; then
+    harness_report_file "unexpected in $harness_file: $harness_needle" "$harness_file"
+    fail "$harness_message"
+  fi
+
+  pass "$harness_message"
+}

--- a/tests/readme_korean_test.sh
+++ b/tests/readme_korean_test.sh
@@ -2,53 +2,16 @@
 set -eu
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+. "$repo_root/tests/lib/harness.sh"
 readme="$repo_root/README.md"
 korean_readme="$repo_root/README.ko.md"
-tmp_dir="$(mktemp -d)"
-
-cleanup() {
-  rm -rf "$tmp_dir"
-}
-trap cleanup EXIT INT TERM
-
-fail() {
-  printf '%s\n' "not ok - $1" >&2
-  exit 1
-}
-
-pass() {
-  printf '%s\n' "ok - $1"
-}
+make_tmp_dir
 
 assert_file_exists() {
   file="$1"
   message="$2"
 
   if [ ! -f "$file" ]; then
-    fail "$message"
-  fi
-
-  pass "$message"
-}
-
-assert_contains() {
-  file="$1"
-  needle="$2"
-  message="$3"
-
-  if ! grep -F "$needle" "$file" >/dev/null; then
-    fail "$message"
-  fi
-
-  pass "$message"
-}
-
-assert_not_contains() {
-  file="$1"
-  needle="$2"
-  message="$3"
-
-  if grep -F "$needle" "$file" >/dev/null; then
     fail "$message"
   fi
 
@@ -101,113 +64,113 @@ assert_headings_ignore_fenced_code
 assert_file_exists "$readme" "README.md exists"
 assert_file_exists "$korean_readme" "README.ko.md exists"
 
-assert_contains "$readme" '🌐 Language: **English** | [한국어](README.ko.md)' \
+assert_file_contains "$readme" '🌐 Language: **English** | [한국어](README.ko.md)' \
   "README.md has the agreed language switcher"
-assert_contains "$korean_readme" '🌐 언어: [English](README.md) | **한국어**' \
+assert_file_contains "$korean_readme" '🌐 언어: [English](README.md) | **한국어**' \
   "README.ko.md has the agreed language switcher"
-assert_not_contains "$korean_readme" '번역본' \
+assert_file_not_contains "$korean_readme" '번역본' \
   "README.ko.md does not label itself as a translation"
-assert_contains "$korean_readme" '`terrapod configure <Preset>`는 script-friendly Preset configuration' \
+assert_file_contains "$korean_readme" '`terrapod configure <Preset>`는 script-friendly Preset configuration' \
   "README.ko.md documents configure as script-friendly Preset configuration"
-assert_contains "$korean_readme" 'command입니다. 지원되는 Preset 정확히 하나의 concrete settings를 쓰고,' \
+assert_file_contains "$korean_readme" 'command입니다. 지원되는 Preset 정확히 하나의 concrete settings를 쓰고,' \
   "README.ko.md documents configure writes concrete settings for one Preset"
-assert_contains "$korean_readme" 'Terrapod Setup은 `gum`(Bootstrap UI Dependency)을 사용하며, gum이 지원하는' \
+assert_file_contains "$korean_readme" 'Terrapod Setup은 `gum`(Bootstrap UI Dependency)을 사용하며, gum이 지원하는' \
   "README.ko.md documents Bootstrap UI Dependency requirement for setup"
-assert_contains "$korean_readme" '`gum`이 필요 없으며, interactive customization은 제공하지 않습니다.' \
+assert_file_contains "$korean_readme" '`gum`이 필요 없으며, interactive customization은 제공하지 않습니다.' \
   "README.ko.md documents configure as no-gum and non-interactive"
-assert_contains "$korean_readme" 'Plain text fallback은 없습니다.' \
+assert_file_contains "$korean_readme" 'Plain text fallback은 없습니다.' \
   "README.ko.md documents no plain text fallback behavior"
-assert_contains "$korean_readme" 'initial apply가 끝나면 installer는 `tpod help`를' \
+assert_file_contains "$korean_readme" 'initial apply가 끝나면 installer는 `tpod help`를' \
   "README.ko.md documents tpod help after first-run apply"
-assert_contains "$korean_readme" 'bootstrap 이후의 day-to-day 관리 명령은 `tpod`입니다.' \
+assert_file_contains "$korean_readme" 'bootstrap 이후의 day-to-day 관리 명령은 `tpod`입니다.' \
   "README.ko.md presents tpod as the day-to-day command"
-assert_contains "$korean_readme" '`terrapod configure <Preset>`는 Terrapod Setup의 plain fallback이 아닙니다.' \
+assert_file_contains "$korean_readme" '`terrapod configure <Preset>`는 Terrapod Setup의 plain fallback이 아닙니다.' \
   "README.ko.md states configure is not a Setup fallback"
-assert_contains "$korean_readme" '`terrapod configure <Preset>`는 setup UI 없이 설정을 쓰는' \
+assert_file_contains "$korean_readme" '`terrapod configure <Preset>`는 setup UI 없이 설정을 쓰는' \
   "README.ko.md verifies configure writes without setup UI"
-assert_contains "$korean_readme" 'script-friendly 경로입니다. 이 경로는 Terrapod Setup과 의도적으로 분리되어' \
+assert_file_contains "$korean_readme" 'script-friendly 경로입니다. 이 경로는 Terrapod Setup과 의도적으로 분리되어' \
   "README.ko.md documents setup and configure are separate by design"
-assert_contains "$korean_readme" 'Terrapod Setup이 `gum` 또는 interactive terminal 부재로 실행되지 않으면' \
+assert_file_contains "$korean_readme" 'Terrapod Setup이 `gum` 또는 interactive terminal 부재로 실행되지 않으면' \
   "README.ko.md documents missing-gum Setup recovery start"
-assert_contains "$korean_readme" '`gum` 또는 terminal environment를 고친 뒤 `terrapod setup`을 다시 실행합니다.' \
+assert_file_contains "$korean_readme" '`gum` 또는 terminal environment를 고친 뒤 `terrapod setup`을 다시 실행합니다.' \
   "README.ko.md documents missing-gum Setup recovery"
-assert_contains "$korean_readme" 'Homebrew는 지원되는 두 profile 모두에서 Core Shell Stack의 Modern CLI Provider입니다.' \
+assert_file_contains "$korean_readme" 'Homebrew는 지원되는 두 profile 모두에서 Core Shell Stack의 Modern CLI Provider입니다.' \
   "README.ko.md names Homebrew as the cross-profile Modern CLI Provider"
-assert_contains "$korean_readme" 'mise는 Bun, Node.js, Python, uv의 Development Runtime Manager입니다.' \
+assert_file_contains "$korean_readme" 'mise는 Bun, Node.js, Python, uv의 Development Runtime Manager입니다.' \
   "README.ko.md limits mise to development runtimes"
-assert_contains "$korean_readme" 'Apple Silicon에서는 Homebrew를 `/opt/homebrew`에 설치하고, Intel Mac에서는 `/usr/local`에 설치합니다.' \
+assert_file_contains "$korean_readme" 'Apple Silicon에서는 Homebrew를 `/opt/homebrew`에 설치하고, Intel Mac에서는 `/usr/local`에 설치합니다.' \
   "README.ko.md documents macOS architecture-to-prefix mapping"
-assert_contains "$korean_readme" 'Ubuntu 24.04는 모든 Preset에서 `/home/linuxbrew/.linuxbrew`에 Homebrew를 설치합니다.' \
+assert_file_contains "$korean_readme" 'Ubuntu 24.04는 모든 Preset에서 `/home/linuxbrew/.linuxbrew`에 Homebrew를 설치합니다.' \
   "README.ko.md documents mandatory Linuxbrew"
-assert_contains "$korean_readme" 'first-run installer는 Terrapod Setup 전에 Homebrew로 `chezmoi`와 `gum`을 설치합니다.' \
+assert_file_contains "$korean_readme" 'first-run installer는 Terrapod Setup 전에 Homebrew로 `chezmoi`와 `gum`을 설치합니다.' \
   "README.ko.md documents cross-profile Setup bootstrap"
-assert_contains "$korean_readme" '설치 전에 1 vCPU, 1 GiB RAM, 최소 3 GiB의 여유 disk space를 권장' \
+assert_file_contains "$korean_readme" '설치 전에 1 vCPU, 1 GiB RAM, 최소 3 GiB의 여유 disk space를 권장' \
   "README.ko.md documents the recommended VPS floor"
-assert_contains "$korean_readme" '`x86_64`와 `aarch64`' \
+assert_file_contains "$korean_readme" '`x86_64`와 `aarch64`' \
   "README.ko.md documents supported Ubuntu architectures"
-assert_not_contains "$korean_readme" 'get.chezmoi.io' \
+assert_file_not_contains "$korean_readme" 'get.chezmoi.io' \
   "README.ko.md removes the standalone chezmoi installer"
-assert_not_contains "$korean_readme" 'Charm APT' \
+assert_file_not_contains "$korean_readme" 'Charm APT' \
   "README.ko.md removes the Charm APT trust boundary"
-assert_not_contains "$korean_readme" '공식 mise APT repository' \
+assert_file_not_contains "$korean_readme" '공식 mise APT repository' \
   "README.ko.md removes mise APT ownership"
-assert_contains "$korean_readme" 'HOMEBREW_NO_AUTO_UPDATE=1 brew bundle --no-upgrade' \
+assert_file_contains "$korean_readme" 'HOMEBREW_NO_AUTO_UPDATE=1 brew bundle --no-upgrade' \
   "README.ko.md documents restore-only apply semantics"
-assert_contains "$korean_readme" '기존 mise, APT, vendor-installed 및 기타 alternate payload를 자동으로 제거하지 않습니다.' \
+assert_file_contains "$korean_readme" '기존 mise, APT, vendor-installed 및 기타 alternate payload를 자동으로 제거하지 않습니다.' \
   "README.ko.md documents non-destructive package source handling"
-assert_contains "$korean_readme" '선택된 executable의 installer provenance를 추론하거나 uninstall command를 제안하지 않습니다.' \
+assert_file_contains "$korean_readme" '선택된 executable의 installer provenance를 추론하거나 uninstall command를 제안하지 않습니다.' \
   "README.ko.md documents provenance-neutral executable guidance"
-assert_not_contains "$korean_readme" 'Proceed with removing these legacy package installations? [y/N]' \
+assert_file_not_contains "$korean_readme" 'Proceed with removing these legacy package installations? [y/N]' \
   "README.ko.md removes the package migration confirmation"
-assert_contains "$korean_readme" 'Claude Code는 package source의 결과가 아니라 profile 결정으로 macOS 전용을 유지합니다.' \
+assert_file_contains "$korean_readme" 'Claude Code는 package source의 결과가 아니라 profile 결정으로 macOS 전용을 유지합니다.' \
   "README.ko.md attributes Claude Code's macOS scope to a profile decision, not its package source"
-assert_contains "$korean_readme" '`development-apps`: Zed, Orca ADE(`stablyai/orca/orca`), OrbStack.' \
+assert_file_contains "$korean_readme" '`development-apps`: Zed, Orca ADE(`stablyai/orca/orca`), OrbStack.' \
   "README.ko.md documents Zed, Orca ADE, and OrbStack in the development-apps inventory"
-assert_contains "$korean_readme" '| `enableMacosAppGroupDevelopmentApps` | `false` | development-apps macOS App Group인 Zed, Orca ADE(`stablyai/orca/orca`), OrbStack을 설치합니다. |' \
+assert_file_contains "$korean_readme" '| `enableMacosAppGroupDevelopmentApps` | `false` | development-apps macOS App Group인 Zed, Orca ADE(`stablyai/orca/orca`), OrbStack을 설치합니다. |' \
   "README.ko.md documents Zed, Orca ADE, and OrbStack on the development-apps option row"
-assert_contains "$korean_readme" 'development-apps group은 OrbStack이 설치되어 있으면 managed `.zprofile`에서 OrbStack shell integration을 source합니다.' \
+assert_file_contains "$korean_readme" 'development-apps group은 OrbStack이 설치되어 있으면 managed `.zprofile`에서 OrbStack shell integration을 source합니다.' \
   "README.ko.md documents where the OrbStack shell integration comes from"
-assert_contains "$korean_readme" 'Terrapod은 Orca를 설치할 때 fully-qualified `stablyai/orca/orca` cask만 trust하며, `stablyai/orca` tap 전체를 trust하지 않습니다.' \
+assert_file_contains "$korean_readme" 'Terrapod은 Orca를 설치할 때 fully-qualified `stablyai/orca/orca` cask만 trust하며, `stablyai/orca` tap 전체를 trust하지 않습니다.' \
   "README.ko.md documents Orca's cask-specific trust boundary"
-assert_contains "$korean_readme" '`mobile-dev`: Android Studio와 Maestro(`mobile-dev-inc/tap/maestro`).' \
+assert_file_contains "$korean_readme" '`mobile-dev`: Android Studio와 Maestro(`mobile-dev-inc/tap/maestro`).' \
   "README.ko.md documents Android Studio and Maestro in the mobile-dev inventory"
-assert_contains "$korean_readme" '| `enableMacosAppGroupMobileDev` | `false` | mobile-dev macOS App Group인 Android Studio와 Maestro(`mobile-dev-inc/tap/maestro`)를 설치합니다. `ANDROID_HOME`과 `JAVA_HOME`도 함께 설정합니다. |' \
+assert_file_contains "$korean_readme" '| `enableMacosAppGroupMobileDev` | `false` | mobile-dev macOS App Group인 Android Studio와 Maestro(`mobile-dev-inc/tap/maestro`)를 설치합니다. `ANDROID_HOME`과 `JAVA_HOME`도 함께 설정합니다. |' \
   "README.ko.md documents the mobile-dev option row"
-assert_contains "$korean_readme" 'Terrapod은 Android SDK component와 Xcode를 설치하지 않습니다. SDK는 Android Studio의 SDK Manager가 소유하고, Xcode는 App Store로 배포됩니다.' \
+assert_file_contains "$korean_readme" 'Terrapod은 Android SDK component와 Xcode를 설치하지 않습니다. SDK는 Android Studio의 SDK Manager가 소유하고, Xcode는 App Store로 배포됩니다.' \
   "README.ko.md documents the mobile development scope boundary"
-assert_not_contains "$korean_readme" 'Terminal font cask' \
+assert_file_not_contains "$korean_readme" 'Terminal font cask' \
   "README.ko.md no longer documents terminal font casks"
-assert_contains "$korean_readme" '최신 안정 GitHub release에서 제공하는 Jetendard terminal font' \
+assert_file_contains "$korean_readme" '최신 안정 GitHub release에서 제공하는 Jetendard terminal font' \
   "README.ko.md documents the Jetendard release source"
-assert_contains "$korean_readme" 'Terrapod은 managed font installer source가 변경되거나 실패한 설치를 재시도할 때만 최신 Jetendard release를 확인합니다.' \
+assert_file_contains "$korean_readme" 'Terrapod은 managed font installer source가 변경되거나 실패한 설치를 재시도할 때만 최신 Jetendard release를 확인합니다.' \
   "README.ko.md documents the Jetendard release-check trigger"
-assert_contains "$korean_readme" 'Terrapod은 해당 Jetendard release의 모든 TTF를 설치하고 GitHub에서 제공하는 asset digest를 검증합니다.' \
+assert_file_contains "$korean_readme" 'Terrapod은 해당 Jetendard release의 모든 TTF를 설치하고 GitHub에서 제공하는 asset digest를 검증합니다.' \
   "README.ko.md directly documents every-TTF installation and digest verification"
-assert_contains "$korean_readme" 'Ghostty, Zed buffer와 terminal, Orca terminal에서 사용하는 font-family key만 설정합니다.' \
+assert_file_contains "$korean_readme" 'Ghostty, Zed buffer와 terminal, Orca terminal에서 사용하는 font-family key만 설정합니다.' \
   "README.ko.md directly documents the app-key-only settings scope"
-assert_contains "$korean_readme" '기존 window가 cached font를 계속 사용하면 Ghostty, Zed 또는 Orca를 다시 시작해야 할 수 있습니다.' \
+assert_file_contains "$korean_readme" '기존 window가 cached font를 계속 사용하면 Ghostty, Zed 또는 Orca를 다시 시작해야 할 수 있습니다.' \
   "README.ko.md directly documents cached-font restart guidance"
-assert_contains "$korean_readme" 'Terrapod은 기존에 설치된 JetBrains Mono Nerd Font 또는 D2Coding을 제거하지 않습니다.' \
+assert_file_contains "$korean_readme" 'Terrapod은 기존에 설치된 JetBrains Mono Nerd Font 또는 D2Coding을 제거하지 않습니다.' \
   "README.ko.md documents non-destructive legacy font migration"
-assert_contains "$korean_readme" 'Jetendard 설정 적용이 보류되면 Orca를 종료한 뒤 `tpod apply`를 다시 실행합니다.' \
+assert_file_contains "$korean_readme" 'Jetendard 설정 적용이 보류되면 Orca를 종료한 뒤 `tpod apply`를 다시 실행합니다.' \
   "README.ko.md documents Orca font-setting recovery"
-assert_contains "$readme" 'Jetendard stays pinned to the release Terrapod installed until the managed font installer source itself changes.' \
+assert_file_contains "$readme" 'Jetendard stays pinned to the release Terrapod installed until the managed font installer source itself changes.' \
   "README.md documents that Jetendard is pinned between installer changes"
-assert_contains "$readme" '~/.local/lib/terrapod/jetendard-font install' \
+assert_file_contains "$readme" '~/.local/lib/terrapod/jetendard-font install' \
   "README.md documents the manual Jetendard upgrade command"
-assert_contains "$readme" 'Deleting that manifest is not an upgrade path' \
+assert_file_contains "$readme" 'Deleting that manifest is not an upgrade path' \
   "README.md rules out manifest removal as an upgrade path"
-assert_contains "$korean_readme" 'Jetendard는 managed font installer source가 바뀌기 전까지 Terrapod이 설치한 release에 고정됩니다.' \
+assert_file_contains "$korean_readme" 'Jetendard는 managed font installer source가 바뀌기 전까지 Terrapod이 설치한 release에 고정됩니다.' \
   "README.ko.md documents that Jetendard is pinned between installer changes"
-assert_contains "$korean_readme" '~/.local/lib/terrapod/jetendard-font install' \
+assert_file_contains "$korean_readme" '~/.local/lib/terrapod/jetendard-font install' \
   "README.ko.md documents the manual Jetendard upgrade command"
-assert_contains "$korean_readme" 'manifest를 지우는 것은 업그레이드 경로가 아닙니다.' \
+assert_file_contains "$korean_readme" 'manifest를 지우는 것은 업그레이드 경로가 아닙니다.' \
   "README.ko.md rules out manifest removal as an upgrade path"
-assert_contains "$korean_readme" 'brew upgrade --cask codex antigravity-cli' \
+assert_file_contains "$korean_readme" 'brew upgrade --cask codex antigravity-cli' \
   "README.ko.md documents targeted AI CLI upgrades"
-assert_contains "$korean_readme" 'Claude Code는 자체적으로 업데이트하며 이 명령의 대상이 아닙니다.' \
+assert_file_contains "$korean_readme" 'Claude Code는 자체적으로 업데이트하며 이 명령의 대상이 아닙니다.' \
   "README.ko.md documents who owns Claude Code freshness"
-assert_contains "$korean_readme" '`enableMacosAppGroupAiApps`는 deprecated key이며 alias로 해석하지 않습니다.' \
+assert_file_contains "$korean_readme" '`enableMacosAppGroupAiApps`는 deprecated key이며 alias로 해석하지 않습니다.' \
   "README.ko.md documents explicit development-apps key migration"
 
 extract_headings "$readme" >"$tmp_dir/readme.headings"

--- a/tests/readme_optional_stack_profiles_test.sh
+++ b/tests/readme_optional_stack_profiles_test.sh
@@ -2,40 +2,10 @@
 set -eu
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+. "$repo_root/tests/lib/harness.sh"
 readme="$repo_root/README.md"
 korean_readme="$repo_root/README.ko.md"
 terrapod_command="$repo_root/dot_local/bin/executable_terrapod"
-
-fail() {
-  printf '%s\n' "not ok - $1" >&2
-  exit 1
-}
-
-pass() {
-  printf '%s\n' "ok - $1"
-}
-
-assert_contains() {
-  needle="$1"
-  message="$2"
-
-  if ! grep -F "$needle" "$readme" >/dev/null; then
-    fail "$message"
-  fi
-
-  pass "$message"
-}
-
-assert_not_contains() {
-  needle="$1"
-  message="$2"
-
-  if grep -F "$needle" "$readme" >/dev/null; then
-    fail "$message"
-  fi
-
-  pass "$message"
-}
 
 assert_key_row_contains() {
   key="$1"
@@ -141,9 +111,9 @@ assert_minimal_vps_is_complete() {
 assert_minimal_vps_is_complete "$readme" "README.md"
 assert_minimal_vps_is_complete "$korean_readme" "README.ko.md"
 
-assert_contains '| `enableEditorStack` | `false` |' \
+assert_file_contains "$readme" '| `enableEditorStack` | `false` |' \
   "README documents enableEditorStack default"
-assert_contains '| `enableAiCliTools` | `false` |' \
+assert_file_contains "$readme" '| `enableAiCliTools` | `false` |' \
   "README documents enableAiCliTools default"
 assert_key_row_contains '`enableAiCliTools`' 'Antigravity CLI, Claude Code, and Codex' \
   "README documents the new Optional AI Tool Stack membership"
@@ -151,11 +121,11 @@ assert_key_row_contains '`enableAiCliTools`' 'Homebrew casks `antigravity-cli` a
   "README documents Homebrew-owned Optional AI Tool Stack members"
 assert_key_row_contains '`enableAiCliTools`' 'Claude Code through its official installer' \
   "README documents the vendor-installed Optional AI Tool Stack member"
-assert_contains '| `enableDevelopmentWorkspace` | `false` |' \
+assert_file_contains "$readme" '| `enableDevelopmentWorkspace` | `false` |' \
   "README documents enableDevelopmentWorkspace default"
-assert_contains '| `profile` |' \
+assert_file_contains "$readme" '| `profile` |' \
   "README documents profile as a managed setup config key"
-assert_not_contains 'enableMacosDesktopApps' \
+assert_file_not_contains "$readme" 'enableMacosDesktopApps' \
   "README does not document legacy enableMacosDesktopApps option"
 
 for key in \
@@ -166,7 +136,7 @@ for key in \
   enableMacosAppGroupDevelopmentApps \
   enableMacosAppGroupMobileDev
 do
-  assert_contains "\`$key\`" "README documents $key option"
+  assert_file_contains "$readme" "\`$key\`" "README documents $key option"
   if ! awk -F '|' -v key="\`$key\`" '$0 ~ key { gsub(/^[[:space:]]+|[[:space:]]+$/, "", $3); if ($3 == "`false`") found=1 } END { exit found ? 0 : 1 }' "$readme"; then
     fail "README documents $key default"
   fi
@@ -177,7 +147,7 @@ assert_key_row_contains '`enableMacosAppGroupTerminalApps`' 'terminal-apps' \
   "README documents terminal-apps group on its option row"
 assert_key_row_contains '`enableMacosAppGroupTerminalApps`' 'Ghostty' \
   "README documents Ghostty on the terminal-apps option row"
-assert_not_contains 'cmux' \
+assert_file_not_contains "$readme" 'cmux' \
   "README no longer documents cmux as part of the macOS Desktop App Stack"
 assert_key_row_contains '`enableMacosAppGroupAutomation`' 'automation' \
   "README documents automation group on its option row"
@@ -205,7 +175,7 @@ assert_key_row_contains '`enableMacosAppGroupDevelopmentApps`' 'OrbStack' \
   "README documents OrbStack on the development-apps option row"
 assert_key_row_contains '`enableMacosAppGroupDevelopmentApps`' 'stablyai/orca/orca' \
   "README documents Orca's fully-qualified cask source"
-assert_contains 'When installing Orca, Terrapod trusts only the fully-qualified `stablyai/orca/orca` cask, not the entire `stablyai/orca` tap.' \
+assert_file_contains "$readme" 'When installing Orca, Terrapod trusts only the fully-qualified `stablyai/orca/orca` cask, not the entire `stablyai/orca` tap.' \
   "README documents Orca's cask-specific trust boundary"
 
 assert_key_row_contains '`enableMacosAppGroupMobileDev`' 'mobile-dev' \
@@ -214,83 +184,83 @@ assert_key_row_contains '`enableMacosAppGroupMobileDev`' 'Android Studio' \
   "README documents Android Studio on the mobile-dev option row"
 assert_key_row_contains '`enableMacosAppGroupMobileDev`' 'mobile-dev-inc/tap/maestro' \
   "README documents Maestro's fully-qualified formula source"
-assert_contains 'Terrapod does not install Android SDK components or Xcode. Android Studio'"'"'s SDK Manager owns the SDK, and Xcode is distributed through the App Store.' \
+assert_file_contains "$readme" 'Terrapod does not install Android SDK components or Xcode. Android Studio'"'"'s SDK Manager owns the SDK, and Xcode is distributed through the App Store.' \
   "README documents the mobile development scope boundary"
 
-assert_contains 'The development-apps group also sources the OrbStack shell integration from the managed `.zprofile` when OrbStack is installed.' \
+assert_file_contains "$readme" 'The development-apps group also sources the OrbStack shell integration from the managed `.zprofile` when OrbStack is installed.' \
   "README documents where the OrbStack shell integration comes from"
 
-assert_contains 'Optional stack profiles and macOS App Group settings are disabled by default.' \
+assert_file_contains "$readme" 'Optional stack profiles and macOS App Group settings are disabled by default.' \
   "README states optional stack profiles and App Groups are disabled by default"
-assert_contains 'complete managed setup config' \
+assert_file_contains "$readme" 'complete managed setup config' \
   "README explains local overrides must keep a complete managed setup config"
-assert_contains 'not standalone config files' \
+assert_file_contains "$readme" 'not standalone config files' \
   "README marks optional stack examples as fragments instead of standalone configs"
-assert_not_contains 'false or omitted' \
+assert_file_not_contains "$readme" 'false or omitted' \
   "README no longer suggests omitted managed setup keys are valid routine-command config"
-assert_contains 'Terrapod is a small landing pod for your machines' \
+assert_file_contains "$readme" 'Terrapod is a small landing pod for your machines' \
   "README opens with the Terrapod product promise"
-assert_contains 'Under the hood, Terrapod uses chezmoi as the apply engine' \
+assert_file_contains "$readme" 'Under the hood, Terrapod uses chezmoi as the apply engine' \
   "README keeps chezmoi visible as underlying machinery"
-assert_contains '## Quick Start' \
+assert_file_contains "$readme" '## Quick Start' \
   "README leads with a Quick Start section"
-assert_contains '## What Terrapod Carries' \
+assert_file_contains "$readme" '## What Terrapod Carries' \
   "README summarizes Terrapod's carried domain concepts"
-assert_contains '## Choose a Preset' \
+assert_file_contains "$readme" '## Choose a Preset' \
   "README uses the canonical Preset section title"
-assert_contains 'Terrapod Setup requires `gum` (the Bootstrap UI Dependency)' \
+assert_file_contains "$readme" 'Terrapod Setup requires `gum` (the Bootstrap UI Dependency)' \
   "README documents Bootstrap UI Dependency requirement for setup"
-assert_contains '`terrapod configure <Preset>` is the script-friendly Preset configuration' \
+assert_file_contains "$readme" '`terrapod configure <Preset>` is the script-friendly Preset configuration' \
   "README documents script-friendly Preset configuration"
-assert_contains 'It writes concrete settings for exactly one supported Preset' \
+assert_file_contains "$readme" 'It writes concrete settings for exactly one supported Preset' \
   "README documents configure writes concrete settings for one Preset"
-assert_contains 'require `gum`, and has no interactive customization.' \
+assert_file_contains "$readme" 'require `gum`, and has no interactive customization.' \
   "README documents configure as no-gum and non-interactive"
-assert_contains 'There is no plain text fallback.' \
+assert_file_contains "$readme" 'There is no plain text fallback.' \
   "README documents plain text fallback is intentionally disabled"
-assert_contains '`terrapod configure <Preset>` are intentionally separate.' \
+assert_file_contains "$readme" '`terrapod configure <Preset>` are intentionally separate.' \
   "README documents setup and configure are intentionally separate"
-assert_contains '`terrapod configure <Preset>` are intentionally separate. The latter writes' \
+assert_file_contains "$readme" '`terrapod configure <Preset>` are intentionally separate. The latter writes' \
   "README documents setup and configure are intentionally separate"
-assert_contains 'settings without the setup UI. If Terrapod Setup cannot run because `gum` or an' \
+assert_file_contains "$readme" 'settings without the setup UI. If Terrapod Setup cannot run because `gum` or an' \
   "README documents configure is script-friendly and setup UI is intentionally separate"
-assert_contains '<Preset>` is not a plain fallback for Terrapod Setup.' \
+assert_file_contains "$readme" '<Preset>` is not a plain fallback for Terrapod Setup.' \
   "README states configure is not a Setup fallback"
-assert_contains 'terminal environment and rerun `terrapod setup`.' \
+assert_file_contains "$readme" 'terminal environment and rerun `terrapod setup`.' \
   "README documents missing-gum Setup recovery guidance"
-assert_contains 'Homebrew is the Modern CLI Provider for the Core Shell Stack on both supported profiles.' \
+assert_file_contains "$readme" 'Homebrew is the Modern CLI Provider for the Core Shell Stack on both supported profiles.' \
   "README names Homebrew as the cross-profile Modern CLI Provider"
-assert_contains 'mise is the Development Runtime Manager for Bun, Node.js, Python, and uv.' \
+assert_file_contains "$readme" 'mise is the Development Runtime Manager for Bun, Node.js, Python, and uv.' \
   "README limits mise to development runtimes"
-assert_contains 'On Apple Silicon, Homebrew installs at `/opt/homebrew`; on Intel Macs, it installs at `/usr/local`.' \
+assert_file_contains "$readme" 'On Apple Silicon, Homebrew installs at `/opt/homebrew`; on Intel Macs, it installs at `/usr/local`.' \
   "README documents macOS architecture-to-prefix mapping"
-assert_contains 'Ubuntu 24.04 installs Homebrew at `/home/linuxbrew/.linuxbrew` for every Preset.' \
+assert_file_contains "$readme" 'Ubuntu 24.04 installs Homebrew at `/home/linuxbrew/.linuxbrew` for every Preset.' \
   "README documents mandatory Linuxbrew"
-assert_contains 'The first-run installer installs `chezmoi` and `gum` through Homebrew before Terrapod Setup.' \
+assert_file_contains "$readme" 'The first-run installer installs `chezmoi` and `gum` through Homebrew before Terrapod Setup.' \
   "README documents cross-profile Setup bootstrap"
-assert_contains '1 vCPU, 1 GiB RAM, and at least 3 GiB of free disk space before installation' \
+assert_file_contains "$readme" '1 vCPU, 1 GiB RAM, and at least 3 GiB of free disk space before installation' \
   "README documents the recommended VPS floor"
-assert_contains '`x86_64` and `aarch64`' \
+assert_file_contains "$readme" '`x86_64` and `aarch64`' \
   "README documents supported Ubuntu architectures"
-assert_not_contains 'get.chezmoi.io' \
+assert_file_not_contains "$readme" 'get.chezmoi.io' \
   "README removes the standalone chezmoi installer"
-assert_not_contains 'Charm APT' \
+assert_file_not_contains "$readme" 'Charm APT' \
   "README removes the Charm APT trust boundary"
-assert_not_contains 'mise from the official mise APT repository' \
+assert_file_not_contains "$readme" 'mise from the official mise APT repository' \
   "README removes mise APT ownership"
-assert_contains 'HOMEBREW_NO_AUTO_UPDATE=1 brew bundle --no-upgrade' \
+assert_file_contains "$readme" 'HOMEBREW_NO_AUTO_UPDATE=1 brew bundle --no-upgrade' \
   "README documents restore-only apply semantics"
-assert_contains 'Existing mise, APT, vendor-installed, and other alternate payloads are not' \
+assert_file_contains "$readme" 'Existing mise, APT, vendor-installed, and other alternate payloads are not' \
   "README documents non-destructive package source handling"
-assert_contains 'Terrapod does not infer the installer provenance of the selected' \
+assert_file_contains "$readme" 'Terrapod does not infer the installer provenance of the selected' \
   "README documents provenance-neutral executable guidance"
-assert_not_contains 'Proceed with removing these legacy package installations? [y/N]' \
+assert_file_not_contains "$readme" 'Proceed with removing these legacy package installations? [y/N]' \
   "README removes the package migration confirmation"
-assert_contains '## What Terrapod Leaves Alone' \
+assert_file_contains "$readme" '## What Terrapod Leaves Alone' \
   "README documents product boundaries near the top"
-assert_contains '## Daily Commands' \
+assert_file_contains "$readme" '## Daily Commands' \
   "README uses a product-friendly daily command section"
-assert_contains '## Platform Details' \
+assert_file_contains "$readme" '## Platform Details' \
   "README moves platform inventory into platform details"
 assert_ubuntu_setup_contains 'GitHub CLI (`gh`)' \
   "README documents gh as part of the Ubuntu Core Shell Stack"
@@ -302,60 +272,60 @@ assert_ubuntu_setup_contains 'Claude Code stays macOS-only as a profile decision
   "README attributes Claude Code's macOS scope to a profile decision, not its package source"
 assert_key_row_contains '`enableAiCliTools`' 'ignored on the VPS Shell Profile' \
   "README documents that enableAiCliTools is ignored on the VPS Shell Profile"
-assert_contains 'When `enableDevelopmentWorkspace` is `true`' \
+assert_file_contains "$readme" 'When `enableDevelopmentWorkspace` is `true`' \
   "README documents enableDevelopmentWorkspace behavior"
-assert_contains 'Optional Editor Stack and Optional AI Tool Stack' \
+assert_file_contains "$readme" 'Optional Editor Stack and Optional AI Tool Stack' \
   "README documents development workspace included stacks"
-assert_contains 'macOS Desktop App Stack' \
+assert_file_contains "$readme" 'macOS Desktop App Stack' \
   "README documents macOS Desktop App Stack"
-assert_not_contains 'Terminal font casks' \
+assert_file_not_contains "$readme" 'Terminal font casks' \
   "README no longer documents terminal font casks"
-assert_contains 'Jetendard terminal font from the latest stable GitHub release' \
+assert_file_contains "$readme" 'Jetendard terminal font from the latest stable GitHub release' \
   "README documents the Jetendard release source"
-assert_contains 'Terrapod checks the latest Jetendard release only when its managed font installer source changes or a failed install is retried.' \
+assert_file_contains "$readme" 'Terrapod checks the latest Jetendard release only when its managed font installer source changes or a failed install is retried.' \
   "README documents the Jetendard release-check trigger"
-assert_contains 'Terrapod installs every TTF in that Jetendard release and verifies the asset digest published by GitHub.' \
+assert_file_contains "$readme" 'Terrapod installs every TTF in that Jetendard release and verifies the asset digest published by GitHub.' \
   "README directly documents every-TTF installation and digest verification"
-assert_contains 'It sets only the font-family keys used by Ghostty, Zed buffers and terminals, and Orca terminals.' \
+assert_file_contains "$readme" 'It sets only the font-family keys used by Ghostty, Zed buffers and terminals, and Orca terminals.' \
   "README directly documents the app-key-only settings scope"
-assert_contains 'Restart Ghostty, Zed, or Orca if an existing window still uses a cached font.' \
+assert_file_contains "$readme" 'Restart Ghostty, Zed, or Orca if an existing window still uses a cached font.' \
   "README directly documents cached-font restart guidance"
-assert_contains 'Terrapod does not uninstall existing JetBrains Mono Nerd Font or D2Coding copies.' \
+assert_file_contains "$readme" 'Terrapod does not uninstall existing JetBrains Mono Nerd Font or D2Coding copies.' \
   "README documents non-destructive legacy font migration"
-assert_contains 'Quit Orca before rerunning `tpod apply` when Jetendard settings are deferred.' \
+assert_file_contains "$readme" 'Quit Orca before rerunning `tpod apply` when Jetendard settings are deferred.' \
   "README documents Orca font-setting recovery"
-assert_contains 'separate from `enableDevelopmentWorkspace`' \
+assert_file_contains "$readme" 'separate from `enableDevelopmentWorkspace`' \
   "README documents macOS Desktop App Stack separation from enableDevelopmentWorkspace"
-assert_contains 'casks can affect shared applications' \
+assert_file_contains "$readme" 'casks can affect shared applications' \
   "README documents why macOS Desktop App Stack remains separate"
-assert_contains '`terrapod update` refreshes the Terrapod Source Repository and installed command' \
+assert_file_contains "$readme" '`terrapod update` refreshes the Terrapod Source Repository and installed command' \
   "README documents Terrapod update source refresh"
-assert_contains 'then hands off to the refreshed' \
+assert_file_contains "$readme" 'then hands off to the refreshed' \
   "README documents refreshed tpod apply handoff"
-assert_contains 'Terrapod does not run broad Homebrew, APT, or mise upgrades.' \
+assert_file_contains "$readme" 'Terrapod does not run broad Homebrew, APT, or mise upgrades.' \
   "README states Terrapod does not run broad package or tool upgrades"
-assert_contains 'Use OS package managers directly only when intentionally updating OS-managed packages.' \
+assert_file_contains "$readme" 'Use OS package managers directly only when intentionally updating OS-managed packages.' \
   "README keeps OS package upgrades outside Terrapod"
-assert_contains 'Use mise directly when intentionally updating development runtimes.' \
+assert_file_contains "$readme" 'Use mise directly when intentionally updating development runtimes.' \
   "README keeps Development Runtime Manager upgrades outside Terrapod"
 assert_raycast_restore_contains '`enableMacosAppGroupLauncher`' \
   "README Raycast restore procedure mentions launcher App Group"
-assert_contains 'Opting out of an optional stack excludes its files from chezmoi management; it does not remove files already present on a machine.' \
+assert_file_contains "$readme" 'Opting out of an optional stack excludes its files from chezmoi management; it does not remove files already present on a machine.' \
   "README documents non-destructive optional stack opt-out"
-assert_contains 'brew upgrade --cask codex antigravity-cli' \
+assert_file_contains "$readme" 'brew upgrade --cask codex antigravity-cli' \
   "README documents targeted AI CLI upgrades"
-assert_contains 'Claude Code updates itself and is not part of that command.' \
+assert_file_contains "$readme" 'Claude Code updates itself and is not part of that command.' \
   "README documents who owns Claude Code freshness"
-assert_contains '`enableMacosAppGroupAiApps` is deprecated and is not treated as an alias' \
+assert_file_contains "$readme" '`enableMacosAppGroupAiApps` is deprecated and is not treated as an alias' \
   "README documents explicit development-apps key migration"
-assert_contains 'If another executable is selected first, Terrapod' \
+assert_file_contains "$readme" 'If another executable is selected first, Terrapod' \
   "README documents primary executable advisories"
 
-assert_contains 'Minimal VPS' \
+assert_file_contains "$readme" 'Minimal VPS' \
   "README includes a minimal VPS example"
-assert_contains 'Editor-only machine' \
+assert_file_contains "$readme" 'Editor-only machine' \
   "README includes an editor-only example"
-assert_contains 'AI-only machine' \
+assert_file_contains "$readme" 'AI-only machine' \
   "README includes an AI-only example"
-assert_contains 'Full development workspace machine' \
+assert_file_contains "$readme" 'Full development workspace machine' \
   "README includes a full development workspace example"

--- a/tests/shell_integrations_test.sh
+++ b/tests/shell_integrations_test.sh
@@ -2,49 +2,12 @@
 set -eu
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
-tmp_dir="$(mktemp -d)"
-
-cleanup() {
-  rm -rf "$tmp_dir"
-}
-trap cleanup EXIT INT TERM
-
-fail() {
-  printf '%s\n' "not ok - $1" >&2
-  exit 1
-}
-
-pass() {
-  printf '%s\n' "ok - $1"
-}
+. "$repo_root/tests/lib/harness.sh"
+make_tmp_dir
 
 file_inode() {
   path="$1"
   stat -f %i "$path" 2>/dev/null || stat -c %i "$path"
-}
-
-assert_contains() {
-  haystack="$1"
-  needle="$2"
-  message="$3"
-
-  if ! printf '%s\n' "$haystack" | grep -F "$needle" >/dev/null; then
-    fail "$message"
-  fi
-
-  pass "$message"
-}
-
-assert_not_contains() {
-  haystack="$1"
-  needle="$2"
-  message="$3"
-
-  if printf '%s\n' "$haystack" | grep -F "$needle" >/dev/null; then
-    fail "$message"
-  fi
-
-  pass "$message"
 }
 
 write_stub() {

--- a/tests/terrapod_command_test.sh
+++ b/tests/terrapod_command_test.sh
@@ -2,31 +2,12 @@
 set -eu
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
-tmp_dir="$(mktemp -d)"
+. "$repo_root/tests/lib/harness.sh"
+make_tmp_dir
 
 # PATH is later pointed at a stub bin directory whose uname always reports
 # Darwin, so the real host has to be recorded before that happens.
 host_os="$(uname -s)"
-
-cleanup() {
-  rm -rf "$tmp_dir"
-}
-trap cleanup EXIT INT TERM
-
-fail() {
-  printf '%s\n' "not ok - $1" >&2
-  exit 1
-}
-
-pass() {
-  printf '%s\n' "ok - $1"
-}
-
-# Reported instead of an assertion when a case cannot hold on this platform.
-# tests/run counts these lines, so a skip stays visible in a green CI log.
-skip() {
-  printf '%s\n' "skip - $1"
-}
 
 write_stub() {
   path="$1"
@@ -281,18 +262,6 @@ run_command_in_pty() {
   fi
 }
 
-assert_contains() {
-  haystack="$1"
-  needle="$2"
-  message="$3"
-
-  if ! printf '%s\n' "$haystack" | grep -F "$needle" >/dev/null; then
-    fail "$message"
-  fi
-
-  pass "$message"
-}
-
 assert_status() {
   actual="$1"
   expected="$2"
@@ -310,18 +279,6 @@ assert_failure() {
   message="$2"
 
   if [ "$actual" -eq 0 ]; then
-    fail "$message"
-  fi
-
-  pass "$message"
-}
-
-assert_not_contains() {
-  haystack="$1"
-  needle="$2"
-  message="$3"
-
-  if printf '%s\n' "$haystack" | grep -F "$needle" >/dev/null; then
     fail "$message"
   fi
 

--- a/tests/terrapod_config_test.sh
+++ b/tests/terrapod_config_test.sh
@@ -2,21 +2,8 @@
 set -eu
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
-tmp_dir="$(mktemp -d)"
-
-cleanup() {
-  rm -rf "$tmp_dir"
-}
-trap cleanup EXIT INT TERM
-
-fail() {
-  printf '%s\n' "not ok - $1" >&2
-  exit 1
-}
-
-pass() {
-  printf '%s\n' "ok - $1"
-}
+. "$repo_root/tests/lib/harness.sh"
+make_tmp_dir
 
 write_gum_stub() {
   path="$1"
@@ -169,34 +156,6 @@ run_setup_in_pty() {
   else
     script -q /dev/null env TERM="$term" TERRAPOD_PROFILE="$profile" TERRAPOD_CHEZMOI_CONFIG= HOME="$home_dir" XDG_CONFIG_HOME="$xdg_config_home" sh "$terrapod" setup
   fi
-}
-
-assert_contains() {
-  file="$1"
-  needle="$2"
-  message="$3"
-
-  if ! grep -F "$needle" "$file" >/dev/null; then
-    printf '%s\n' "file contents:" >&2
-    sed 's/^/  /' "$file" >&2
-    fail "$message"
-  fi
-
-  pass "$message"
-}
-
-assert_not_contains() {
-  file="$1"
-  needle="$2"
-  message="$3"
-
-  if grep -F "$needle" "$file" >/dev/null; then
-    printf '%s\n' "file contents:" >&2
-    sed 's/^/  /' "$file" >&2
-    fail "$message"
-  fi
-
-  pass "$message"
 }
 
 extract_data_section() {
@@ -500,9 +459,9 @@ if [ ! -f "$new_config" ]; then
 fi
 pass "minimal Preset creates a chezmoi config file"
 
-assert_contains "$tmp_dir/new-configure.out" "Configured Terrapod Preset 'minimal' in $new_config" "minimal Preset reports config write target"
-assert_contains "$tmp_dir/new-configure.out" "tpod apply" "minimal Preset guides the user to tpod apply after writing config"
-assert_contains "$new_config" "[data]" "new config contains a data section"
+assert_file_contains "$tmp_dir/new-configure.out" "Configured Terrapod Preset 'minimal' in $new_config" "minimal Preset reports config write target"
+assert_file_contains "$tmp_dir/new-configure.out" "tpod apply" "minimal Preset guides the user to tpod apply after writing config"
+assert_file_contains "$new_config" "[data]" "new config contains a data section"
 assert_data_key_once_with_value "$new_config" "profile" "\"vps-shell\"" "minimal Preset writes the detected profile exactly once in data"
 assert_data_key_once_with_value "$new_config" "enableEditorStack" "false" "minimal Preset disables Optional Editor Stack exactly once in data"
 assert_data_key_once_with_value "$new_config" "enableAiCliTools" "false" "minimal Preset disables Optional AI Tool Stack exactly once in data"
@@ -513,8 +472,8 @@ assert_data_key_once_with_value "$new_config" "enableMacosAppGroupLauncher" "fal
 assert_data_key_once_with_value "$new_config" "enableMacosAppGroupMonitoring" "false" "minimal Preset disables monitoring macOS App Group exactly once in data"
 assert_data_key_once_with_value "$new_config" "enableMacosAppGroupDevelopmentApps" "false" "minimal Preset disables development-apps macOS App Group exactly once in data"
 assert_data_key_once_with_value "$new_config" "enableMacosAppGroupMobileDev" "false" "minimal Preset disables mobile-dev macOS App Group exactly once in data"
-assert_not_contains "$new_config" "enableMacosDesktopApps" "minimal Preset does not write the legacy all-in desktop app toggle"
-assert_not_contains "$new_config" "terrapodPreset" "minimal Preset stores concrete values instead of a dynamic Preset"
+assert_file_not_contains "$new_config" "enableMacosDesktopApps" "minimal Preset does not write the legacy all-in desktop app toggle"
+assert_file_not_contains "$new_config" "terrapodPreset" "minimal Preset stores concrete values instead of a dynamic Preset"
 assert_backup_count "$new_config" 0 "new config creation does not create a backup"
 assert_no_shell_startup_backups_under "$new_home" "minimal Preset does not create shell startup backups"
 
@@ -540,8 +499,8 @@ assert_data_key_once_with_value "$development_config" "enableMacosAppGroupLaunch
 assert_data_key_once_with_value "$development_config" "enableMacosAppGroupMonitoring" "false" "development Preset disables monitoring macOS App Group in a new config"
 assert_data_key_once_with_value "$development_config" "enableMacosAppGroupDevelopmentApps" "false" "development Preset disables development-apps macOS App Group in a new config"
 assert_data_key_once_with_value "$development_config" "enableMacosAppGroupMobileDev" "false" "development Preset disables mobile-dev macOS App Group in a new config"
-assert_not_contains "$development_config" "enableMacosDesktopApps" "development Preset does not write the legacy all-in desktop app toggle"
-assert_not_contains "$development_config" "terrapodPreset" "development Preset stores concrete values instead of a dynamic Preset"
+assert_file_not_contains "$development_config" "enableMacosDesktopApps" "development Preset does not write the legacy all-in desktop app toggle"
+assert_file_not_contains "$development_config" "terrapodPreset" "development Preset stores concrete values instead of a dynamic Preset"
 assert_backup_count "$development_config" 0 "development config creation does not create a backup"
 
 macos_development_home="$tmp_dir/macos-development-home"
@@ -582,8 +541,8 @@ assert_data_key_once_with_value "$workstation_config" "enableMacosAppGroupLaunch
 assert_data_key_once_with_value "$workstation_config" "enableMacosAppGroupMonitoring" "true" "workstation Preset enables monitoring macOS App Group exactly once in data"
 assert_data_key_once_with_value "$workstation_config" "enableMacosAppGroupDevelopmentApps" "true" "workstation Preset enables development-apps macOS App Group exactly once in data"
 assert_data_key_once_with_value "$workstation_config" "enableMacosAppGroupMobileDev" "true" "workstation Preset enables mobile-dev macOS App Group exactly once in data"
-assert_not_contains "$workstation_config" "enableMacosDesktopApps" "workstation Preset does not write the legacy all-in desktop app toggle"
-assert_not_contains "$workstation_config" "terrapodPreset" "workstation Preset stores concrete values instead of a dynamic Preset"
+assert_file_not_contains "$workstation_config" "enableMacosDesktopApps" "workstation Preset does not write the legacy all-in desktop app toggle"
+assert_file_not_contains "$workstation_config" "terrapodPreset" "workstation Preset stores concrete values instead of a dynamic Preset"
 assert_backup_count "$workstation_config" 0 "workstation config creation does not create a backup"
 
 nogum_minimal_home="$tmp_dir/nogum-minimal-home"
@@ -602,7 +561,7 @@ assert_data_key_once_with_value "$nogum_minimal_config" "enableEditorStack" "fal
 assert_data_key_once_with_value "$nogum_minimal_config" "enableDevelopmentWorkspace" "false" "no-gum minimal writes concrete Development Workspace setting"
 assert_data_key_once_with_value "$nogum_minimal_config" "enableMacosAppGroupDevelopmentApps" "false" "no-gum minimal writes concrete development-apps App Group setting"
 assert_data_key_once_with_value "$nogum_minimal_config" "enableMacosAppGroupMobileDev" "false" "no-gum minimal writes concrete mobile-dev App Group setting"
-assert_not_contains "$nogum_minimal_config" "terrapodPreset" "no-gum minimal stores concrete values instead of a dynamic Preset"
+assert_file_not_contains "$nogum_minimal_config" "terrapodPreset" "no-gum minimal stores concrete values instead of a dynamic Preset"
 
 nogum_development_home="$tmp_dir/nogum-development-home"
 nogum_development_xdg="$tmp_dir/nogum-development-xdg"
@@ -622,7 +581,7 @@ assert_data_key_once_with_value "$nogum_development_config" "enableDevelopmentWo
 assert_data_key_once_with_value "$nogum_development_config" "enableMacosAppGroupTerminalApps" "false" "no-gum development writes concrete macOS App Group setting"
 assert_data_key_once_with_value "$nogum_development_config" "enableMacosAppGroupDevelopmentApps" "false" "no-gum development writes concrete development-apps App Group setting"
 assert_data_key_once_with_value "$nogum_development_config" "enableMacosAppGroupMobileDev" "false" "no-gum development writes concrete mobile-dev App Group setting"
-assert_not_contains "$nogum_development_config" "terrapodPreset" "no-gum development stores concrete values instead of a dynamic Preset"
+assert_file_not_contains "$nogum_development_config" "terrapodPreset" "no-gum development stores concrete values instead of a dynamic Preset"
 
 nogum_macos_minimal_home="$tmp_dir/nogum-macos-minimal-home"
 nogum_macos_minimal_xdg="$tmp_dir/nogum-macos-minimal-xdg"
@@ -640,7 +599,7 @@ assert_data_key_once_with_value "$nogum_macos_minimal_config" "enableEditorStack
 assert_data_key_once_with_value "$nogum_macos_minimal_config" "enableDevelopmentWorkspace" "false" "no-gum macOS minimal writes concrete Development Workspace setting"
 assert_data_key_once_with_value "$nogum_macos_minimal_config" "enableMacosAppGroupDevelopmentApps" "false" "no-gum macOS minimal writes concrete development-apps App Group setting"
 assert_data_key_once_with_value "$nogum_macos_minimal_config" "enableMacosAppGroupMobileDev" "false" "no-gum macOS minimal writes concrete mobile-dev App Group setting"
-assert_not_contains "$nogum_macos_minimal_config" "terrapodPreset" "no-gum macOS minimal stores concrete values instead of a dynamic Preset"
+assert_file_not_contains "$nogum_macos_minimal_config" "terrapodPreset" "no-gum macOS minimal stores concrete values instead of a dynamic Preset"
 
 nogum_macos_development_home="$tmp_dir/nogum-macos-development-home"
 nogum_macos_development_xdg="$tmp_dir/nogum-macos-development-xdg"
@@ -659,7 +618,7 @@ assert_data_key_once_with_value "$nogum_macos_development_config" "enableDevelop
 assert_data_key_once_with_value "$nogum_macos_development_config" "enableMacosAppGroupTerminalApps" "false" "no-gum macOS development writes concrete macOS App Group setting"
 assert_data_key_once_with_value "$nogum_macos_development_config" "enableMacosAppGroupDevelopmentApps" "false" "no-gum macOS development writes concrete development-apps App Group setting"
 assert_data_key_once_with_value "$nogum_macos_development_config" "enableMacosAppGroupMobileDev" "false" "no-gum macOS development writes concrete mobile-dev App Group setting"
-assert_not_contains "$nogum_macos_development_config" "terrapodPreset" "no-gum macOS development stores concrete values instead of a dynamic Preset"
+assert_file_not_contains "$nogum_macos_development_config" "terrapodPreset" "no-gum macOS development stores concrete values instead of a dynamic Preset"
 
 nogum_workstation_home="$tmp_dir/nogum-workstation-home"
 nogum_workstation_xdg="$tmp_dir/nogum-workstation-xdg"
@@ -678,7 +637,7 @@ assert_data_key_once_with_value "$nogum_workstation_config" "enableDevelopmentWo
 assert_data_key_once_with_value "$nogum_workstation_config" "enableMacosAppGroupMonitoring" "true" "no-gum workstation writes concrete macOS App Group setting"
 assert_data_key_once_with_value "$nogum_workstation_config" "enableMacosAppGroupDevelopmentApps" "true" "no-gum workstation writes concrete development-apps App Group setting"
 assert_data_key_once_with_value "$nogum_workstation_config" "enableMacosAppGroupMobileDev" "true" "no-gum workstation writes concrete mobile-dev App Group setting"
-assert_not_contains "$nogum_workstation_config" "terrapodPreset" "no-gum workstation stores concrete values instead of a dynamic Preset"
+assert_file_not_contains "$nogum_workstation_config" "terrapodPreset" "no-gum workstation stores concrete values instead of a dynamic Preset"
 
 setup_workstation_home="$tmp_dir/setup-workstation-home"
 setup_workstation_xdg="$tmp_dir/setup-workstation-xdg"
@@ -718,10 +677,10 @@ assert_data_key_once_with_value "$setup_workstation_config" "enableMacosAppGroup
 assert_data_key_once_with_value "$setup_workstation_config" "enableMacosAppGroupMonitoring" "true" "confirmed setup enables monitoring macOS App Group exactly once in data"
 assert_data_key_once_with_value "$setup_workstation_config" "enableMacosAppGroupDevelopmentApps" "true" "confirmed setup enables development-apps macOS App Group exactly once in data"
 assert_data_key_once_with_value "$setup_workstation_config" "enableMacosAppGroupMobileDev" "true" "confirmed setup enables mobile-dev macOS App Group exactly once in data"
-assert_not_contains "$setup_workstation_config" "enableMacosDesktopApps" "confirmed setup does not write the legacy all-in desktop app toggle"
-assert_not_contains "$setup_workstation_config" "terrapodPreset" "confirmed setup stores concrete values instead of a dynamic Preset"
+assert_file_not_contains "$setup_workstation_config" "enableMacosDesktopApps" "confirmed setup does not write the legacy all-in desktop app toggle"
+assert_file_not_contains "$setup_workstation_config" "terrapodPreset" "confirmed setup stores concrete values instead of a dynamic Preset"
 assert_backup_count "$setup_workstation_config" 0 "confirmed setup new config creation does not create a backup"
-assert_contains "$tmp_dir/setup-workstation.out" "tpod apply" "confirmed setup guides the user to tpod apply after writing config"
+assert_file_contains "$tmp_dir/setup-workstation.out" "tpod apply" "confirmed setup guides the user to tpod apply after writing config"
 assert_no_shell_startup_backups_under "$setup_workstation_home" "confirmed setup does not create shell startup backups"
 
 setup_custom_workspace_home="$tmp_dir/setup-custom-workspace-home"
@@ -747,22 +706,22 @@ y
 fi
 pass "macOS setup prompts for customization before final confirmation and customizes Optional Development Workspace and App Groups"
 
-assert_contains "$tmp_dir/setup-custom-workspace.out" "  Includes:" "workspace-enabled setup groups included optional stacks"
-assert_contains "$tmp_dir/setup-custom-workspace.out" "    - Optional Editor Stack" "workspace-enabled setup lists Optional Editor Stack under workspace"
-assert_contains "$tmp_dir/setup-custom-workspace.out" "    - Optional AI Tool Stack" "workspace-enabled setup lists Optional AI Tool Stack under workspace"
-assert_contains "$tmp_dir/setup-custom-workspace.out" "🌱 Terrapod Setup" "setup presents a rich setup heading"
-assert_contains "$tmp_dir/setup-custom-workspace.out" "Choose a Preset" "setup presents a Preset choice section"
-assert_not_contains "$tmp_dir/setup-custom-workspace.out" "Preset guide:" "setup does not print a separate Preset guide"
-assert_not_contains "$tmp_dir/setup-custom-workspace.out" "Option guide:" "setup does not print a separate option guide"
-assert_contains "$tmp_dir/setup-custom-workspace.out" "enableEditorStack = true" "workspace-enabled setup summary reflects included Optional Editor Stack"
-assert_contains "$tmp_dir/setup-custom-workspace.out" "enableAiCliTools = true" "workspace-enabled setup summary reflects included Optional AI Tool Stack"
-assert_contains "$tmp_dir/setup-custom-workspace.out" "enableDevelopmentWorkspace = true" "workspace-enabled setup summary reflects enabled Optional Development Workspace"
-assert_contains "$tmp_dir/setup-custom-workspace.out" "enableMacosAppGroupTerminalApps = false" "macOS setup summary reflects customized terminal-apps App Group"
-assert_contains "$tmp_dir/setup-custom-workspace.out" "enableMacosAppGroupAutomation = true" "macOS setup summary reflects customized automation App Group"
-assert_contains "$tmp_dir/setup-custom-workspace.out" "enableMacosAppGroupLauncher = false" "macOS setup summary reflects customized launcher App Group"
-assert_contains "$tmp_dir/setup-custom-workspace.out" "enableMacosAppGroupMonitoring = true" "macOS setup summary reflects customized monitoring App Group"
-assert_contains "$tmp_dir/setup-custom-workspace.out" "enableMacosAppGroupDevelopmentApps = false" "macOS setup summary reflects customized development-apps App Group"
-assert_contains "$tmp_dir/setup-custom-workspace.out" "enableMacosAppGroupMobileDev = false" "macOS setup summary reflects customized mobile-dev App Group"
+assert_file_contains "$tmp_dir/setup-custom-workspace.out" "  Includes:" "workspace-enabled setup groups included optional stacks"
+assert_file_contains "$tmp_dir/setup-custom-workspace.out" "    - Optional Editor Stack" "workspace-enabled setup lists Optional Editor Stack under workspace"
+assert_file_contains "$tmp_dir/setup-custom-workspace.out" "    - Optional AI Tool Stack" "workspace-enabled setup lists Optional AI Tool Stack under workspace"
+assert_file_contains "$tmp_dir/setup-custom-workspace.out" "🌱 Terrapod Setup" "setup presents a rich setup heading"
+assert_file_contains "$tmp_dir/setup-custom-workspace.out" "Choose a Preset" "setup presents a Preset choice section"
+assert_file_not_contains "$tmp_dir/setup-custom-workspace.out" "Preset guide:" "setup does not print a separate Preset guide"
+assert_file_not_contains "$tmp_dir/setup-custom-workspace.out" "Option guide:" "setup does not print a separate option guide"
+assert_file_contains "$tmp_dir/setup-custom-workspace.out" "enableEditorStack = true" "workspace-enabled setup summary reflects included Optional Editor Stack"
+assert_file_contains "$tmp_dir/setup-custom-workspace.out" "enableAiCliTools = true" "workspace-enabled setup summary reflects included Optional AI Tool Stack"
+assert_file_contains "$tmp_dir/setup-custom-workspace.out" "enableDevelopmentWorkspace = true" "workspace-enabled setup summary reflects enabled Optional Development Workspace"
+assert_file_contains "$tmp_dir/setup-custom-workspace.out" "enableMacosAppGroupTerminalApps = false" "macOS setup summary reflects customized terminal-apps App Group"
+assert_file_contains "$tmp_dir/setup-custom-workspace.out" "enableMacosAppGroupAutomation = true" "macOS setup summary reflects customized automation App Group"
+assert_file_contains "$tmp_dir/setup-custom-workspace.out" "enableMacosAppGroupLauncher = false" "macOS setup summary reflects customized launcher App Group"
+assert_file_contains "$tmp_dir/setup-custom-workspace.out" "enableMacosAppGroupMonitoring = true" "macOS setup summary reflects customized monitoring App Group"
+assert_file_contains "$tmp_dir/setup-custom-workspace.out" "enableMacosAppGroupDevelopmentApps = false" "macOS setup summary reflects customized development-apps App Group"
+assert_file_contains "$tmp_dir/setup-custom-workspace.out" "enableMacosAppGroupMobileDev = false" "macOS setup summary reflects customized mobile-dev App Group"
 
 if [ ! -f "$setup_custom_workspace_config" ]; then
   fail "macOS customized setup creates a chezmoi config file"
@@ -802,8 +761,8 @@ y
 fi
 pass "gum setup customizes concrete settings and completes"
 
-assert_contains "$tmp_dir/gum-equivalent.out" "terminal-apps" "gum setup labels terminal-apps App Group with the group name"
-assert_contains "$tmp_dir/gum-equivalent.out" "  Installs Ghostty." "gum setup describes terminal-apps App Group as Ghostty-only"
+assert_file_contains "$tmp_dir/gum-equivalent.out" "terminal-apps" "gum setup labels terminal-apps App Group with the group name"
+assert_file_contains "$tmp_dir/gum-equivalent.out" "  Installs Ghostty." "gum setup describes terminal-apps App Group as Ghostty-only"
 assert_data_key_once_with_value "$gum_equivalent_config" "enableEditorStack" "true" "gum setup writes included Optional Editor Stack"
 assert_data_key_once_with_value "$gum_equivalent_config" "enableAiCliTools" "true" "gum setup writes included Optional AI Tool Stack"
 assert_data_key_once_with_value "$gum_equivalent_config" "enableDevelopmentWorkspace" "true" "gum setup writes enabled Optional Development Workspace"
@@ -846,7 +805,7 @@ y
 fi
 pass "gum Preset selection selects development and completes"
 
-assert_contains "$tmp_dir/gum-development.out" "Configured Terrapod Preset 'development'" "gum Preset selection selects development"
+assert_file_contains "$tmp_dir/gum-development.out" "Configured Terrapod Preset 'development'" "gum Preset selection selects development"
 assert_data_key_once_with_value "$gum_development_config" "enableEditorStack" "true" "gum development writes development Editor Stack setting"
 assert_data_key_once_with_value "$gum_development_config" "enableAiCliTools" "true" "gum development writes development AI Tool Stack setting"
 assert_data_key_once_with_value "$gum_development_config" "enableDevelopmentWorkspace" "true" "gum development writes development workspace setting"
@@ -918,11 +877,11 @@ y
 fi
 pass "workspace-disabled setup prompts for customization before final confirmation and customizes leaf stacks independently"
 
-assert_contains "$tmp_dir/setup-leaf.out" "enableEditorStack = false" "workspace-disabled setup summary reflects customized Optional Editor Stack"
-assert_contains "$tmp_dir/setup-leaf.out" "enableAiCliTools = true" "workspace-disabled setup summary reflects customized Optional AI Tool Stack"
-assert_contains "$tmp_dir/setup-leaf.out" "enableDevelopmentWorkspace = false" "workspace-disabled setup summary reflects disabled Optional Development Workspace"
-assert_contains "$tmp_dir/setup-leaf.out" "enableMacosAppGroupDevelopmentApps = true" "workspace-disabled setup summary reflects customized development-apps App Group"
-assert_contains "$tmp_dir/setup-leaf.out" "enableMacosAppGroupMobileDev = false" "workspace-disabled setup summary reflects customized mobile-dev App Group"
+assert_file_contains "$tmp_dir/setup-leaf.out" "enableEditorStack = false" "workspace-disabled setup summary reflects customized Optional Editor Stack"
+assert_file_contains "$tmp_dir/setup-leaf.out" "enableAiCliTools = true" "workspace-disabled setup summary reflects customized Optional AI Tool Stack"
+assert_file_contains "$tmp_dir/setup-leaf.out" "enableDevelopmentWorkspace = false" "workspace-disabled setup summary reflects disabled Optional Development Workspace"
+assert_file_contains "$tmp_dir/setup-leaf.out" "enableMacosAppGroupDevelopmentApps = true" "workspace-disabled setup summary reflects customized development-apps App Group"
+assert_file_contains "$tmp_dir/setup-leaf.out" "enableMacosAppGroupMobileDev = false" "workspace-disabled setup summary reflects customized mobile-dev App Group"
 
 if [ ! -f "$setup_leaf_config" ]; then
   fail "workspace-disabled customized setup creates a chezmoi config file"
@@ -968,11 +927,11 @@ if printf '%s\n' "$setup_vps_custom_output" | grep -F "Enable Optional AI Tool S
 fi
 pass "VPS setup does not prompt for the Optional AI Tool Stack"
 
-assert_contains "$tmp_dir/setup-vps-custom.out" "Optional AI Tool Stack: not applicable for VPS Shell Profile" "VPS setup explains the Optional AI Tool Stack is not applicable"
-assert_contains "$tmp_dir/setup-vps-custom.out" "macOS App Groups: not applicable for VPS Shell Profile" "VPS setup explains macOS App Groups are not applicable"
-assert_contains "$tmp_dir/setup-vps-custom.out" "enableEditorStack = true" "VPS setup summary reflects customized Optional Editor Stack"
-assert_contains "$tmp_dir/setup-vps-custom.out" "enableAiCliTools = false" "VPS setup summary reflects customized Optional AI Tool Stack"
-assert_contains "$tmp_dir/setup-vps-custom.out" "enableDevelopmentWorkspace = false" "VPS setup summary reflects disabled Optional Development Workspace"
+assert_file_contains "$tmp_dir/setup-vps-custom.out" "Optional AI Tool Stack: not applicable for VPS Shell Profile" "VPS setup explains the Optional AI Tool Stack is not applicable"
+assert_file_contains "$tmp_dir/setup-vps-custom.out" "macOS App Groups: not applicable for VPS Shell Profile" "VPS setup explains macOS App Groups are not applicable"
+assert_file_contains "$tmp_dir/setup-vps-custom.out" "enableEditorStack = true" "VPS setup summary reflects customized Optional Editor Stack"
+assert_file_contains "$tmp_dir/setup-vps-custom.out" "enableAiCliTools = false" "VPS setup summary reflects customized Optional AI Tool Stack"
+assert_file_contains "$tmp_dir/setup-vps-custom.out" "enableDevelopmentWorkspace = false" "VPS setup summary reflects disabled Optional Development Workspace"
 
 if [ ! -f "$setup_vps_custom_config" ]; then
   fail "VPS customized setup creates a chezmoi config file"
@@ -1001,8 +960,8 @@ y
 fi
 pass "VPS setup workstation rejection exits non-zero"
 
-assert_contains "$tmp_dir/setup-vps-workstation-error.out" "workstation Preset is only available for the macOS Terminal Profile" "VPS setup workstation rejection writes the error"
-assert_not_contains "$tmp_dir/setup-vps-workstation-error.err" "workstation Preset is only available for the macOS Terminal Profile" "VPS setup workstation rejection does not write outside the PTY transcript"
+assert_file_contains "$tmp_dir/setup-vps-workstation-error.out" "workstation Preset is only available for the macOS Terminal Profile" "VPS setup workstation rejection writes the error"
+assert_file_not_contains "$tmp_dir/setup-vps-workstation-error.err" "workstation Preset is only available for the macOS Terminal Profile" "VPS setup workstation rejection does not write outside the PTY transcript"
 
 if [ -e "$setup_vps_workstation_error_config" ]; then
   fail "VPS setup workstation rejection does not create a config"
@@ -1023,8 +982,8 @@ __CANCEL__
 fi
 pass "setup setting cancellation exits non-zero"
 
-assert_contains "$tmp_dir/setup-setting-cancel.out" "setup cancelled" "setup setting cancellation writes the error"
-assert_not_contains "$tmp_dir/setup-setting-cancel.err" "setup cancelled" "setup setting cancellation does not write outside the PTY transcript"
+assert_file_contains "$tmp_dir/setup-setting-cancel.out" "setup cancelled" "setup setting cancellation writes the error"
+assert_file_not_contains "$tmp_dir/setup-setting-cancel.err" "setup cancelled" "setup setting cancellation does not write outside the PTY transcript"
 
 if [ -e "$setup_setting_cancel_config" ]; then
   fail "setup setting cancellation does not create a config"
@@ -1052,7 +1011,7 @@ n
 fi
 pass "cancelled setup exits non-zero"
 
-assert_contains "$tmp_dir/setup-cancel.out" "setup cancelled" "cancelled setup explains cancellation"
+assert_file_contains "$tmp_dir/setup-cancel.out" "setup cancelled" "cancelled setup explains cancellation"
 
 if [ -e "$setup_cancel_config" ]; then
   fail "cancelled setup does not create a new config"
@@ -1087,7 +1046,7 @@ if run_terrapod_setup macos-terminal 'development
 fi
 pass "empty final confirmation cancels setup"
 
-assert_contains "$tmp_dir/setup-existing-cancel.out" "setup cancelled" "empty final confirmation explains cancellation"
+assert_file_contains "$tmp_dir/setup-existing-cancel.out" "setup cancelled" "empty final confirmation explains cancellation"
 
 if ! cmp -s "$setup_existing_cancel_config" "$tmp_dir/setup-existing-cancel-before.toml"; then
   fail "cancelled setup leaves existing config unchanged"
@@ -1143,9 +1102,9 @@ cp "$existing_config" "$tmp_dir/existing-before.toml"
 
 run_terrapod_configure_yes development "$existing_home" "$existing_xdg"
 
-assert_contains "$existing_config" "branch = \"main\"" "existing update preserves unrelated sourceState values"
-assert_contains "$existing_config" "email = \"minu@example.com\"" "existing update preserves unrelated data values"
-assert_contains "$existing_config" "command = \"nvim\"" "existing update preserves unrelated later sections"
+assert_file_contains "$existing_config" "branch = \"main\"" "existing update preserves unrelated sourceState values"
+assert_file_contains "$existing_config" "email = \"minu@example.com\"" "existing update preserves unrelated data values"
+assert_file_contains "$existing_config" "command = \"nvim\"" "existing update preserves unrelated later sections"
 assert_data_key_once_with_value "$existing_config" "profile" "\"vps-shell\"" "existing update writes the detected profile exactly once in data"
 assert_data_key_once_with_value "$existing_config" "enableEditorStack" "true" "development Preset enables Optional Editor Stack exactly once in data"
 assert_data_key_once_with_value "$existing_config" "enableAiCliTools" "false" "development Preset leaves Optional AI Tool Stack disabled exactly once on the VPS Shell Profile"
@@ -1156,9 +1115,9 @@ assert_data_key_once_with_value "$existing_config" "enableMacosAppGroupLauncher"
 assert_data_key_once_with_value "$existing_config" "enableMacosAppGroupMonitoring" "false" "development Preset disables monitoring macOS App Group exactly once in data"
 assert_data_key_once_with_value "$existing_config" "enableMacosAppGroupDevelopmentApps" "false" "development Preset writes development-apps exactly once in data"
 assert_data_key_once_with_value "$existing_config" "enableMacosAppGroupMobileDev" "false" "development Preset writes mobile-dev exactly once in data"
-assert_not_contains "$existing_config" "enableMacosAppGroupAiApps" "explicit config migration removes deprecated ai-apps key"
-assert_not_contains "$existing_config" "enableMacosDesktopApps" "existing update removes the legacy all-in desktop app toggle"
-assert_not_contains "$existing_config" "terrapodPreset" "existing update removes stale dynamic Preset key"
+assert_file_not_contains "$existing_config" "enableMacosAppGroupAiApps" "explicit config migration removes deprecated ai-apps key"
+assert_file_not_contains "$existing_config" "enableMacosDesktopApps" "existing update removes the legacy all-in desktop app toggle"
+assert_file_not_contains "$existing_config" "terrapodPreset" "existing update removes stale dynamic Preset key"
 assert_single_backup_matches "$existing_config" "$tmp_dir/existing-before.toml" "existing update creates one backup before changing managed keys"
 assert_no_shell_startup_backups_under "$existing_home" "existing update does not create shell startup backups"
 
@@ -1180,10 +1139,10 @@ TOML
 
 run_terrapod_configure_yes development "$quoted_table_home" "$quoted_table_xdg" macos-terminal
 
-assert_contains "$quoted_table_config" "[\"data\"]" "quoted data table header is preserved"
-assert_not_contains "$quoted_table_config" "[data]" "quoted data table update does not append a duplicate bare data table"
-assert_contains "$quoted_table_config" "keepQuotedTable = \"preserve\"" "quoted data table update preserves unrelated data values"
-assert_contains "$quoted_table_config" "branch = \"main\"" "quoted data table update preserves later sections"
+assert_file_contains "$quoted_table_config" "[\"data\"]" "quoted data table header is preserved"
+assert_file_not_contains "$quoted_table_config" "[data]" "quoted data table update does not append a duplicate bare data table"
+assert_file_contains "$quoted_table_config" "keepQuotedTable = \"preserve\"" "quoted data table update preserves unrelated data values"
+assert_file_contains "$quoted_table_config" "branch = \"main\"" "quoted data table update preserves later sections"
 assert_data_key_once_with_value "$quoted_table_config" "enableEditorStack" "true" "quoted data table update writes Editor Stack in data"
 assert_data_key_once_with_value "$quoted_table_config" "enableAiCliTools" "true" "quoted data table update writes AI Tool Stack in data"
 assert_data_key_once_with_value "$quoted_table_config" "enableDevelopmentWorkspace" "true" "quoted data table update writes Development Workspace in data"
@@ -1191,8 +1150,8 @@ assert_data_key_once_with_value "$quoted_table_config" "enableMacosAppGroupTermi
 assert_data_key_once_with_value "$quoted_table_config" "enableMacosAppGroupAutomation" "false" "quoted data table update writes automation App Group in data"
 assert_data_key_once_with_value "$quoted_table_config" "enableMacosAppGroupLauncher" "false" "quoted data table update writes launcher App Group in data"
 assert_data_key_once_with_value "$quoted_table_config" "enableMacosAppGroupMonitoring" "false" "quoted data table update writes monitoring App Group in data"
-assert_not_contains "$quoted_table_config" "enableMacosDesktopApps" "quoted data table update removes the legacy all-in desktop app toggle"
-assert_not_contains "$quoted_table_config" "terrapodPreset" "quoted data table update removes stale dynamic Preset key"
+assert_file_not_contains "$quoted_table_config" "enableMacosDesktopApps" "quoted data table update removes the legacy all-in desktop app toggle"
+assert_file_not_contains "$quoted_table_config" "terrapodPreset" "quoted data table update removes stale dynamic Preset key"
 
 spaced_table_home="$tmp_dir/spaced-table-home"
 spaced_table_xdg="$tmp_dir/spaced-table-xdg"
@@ -1212,10 +1171,10 @@ TOML
 
 run_terrapod_configure_yes development "$spaced_table_home" "$spaced_table_xdg" macos-terminal
 
-assert_contains "$spaced_table_config" "[ data ]" "spaced data table header is preserved"
-assert_not_contains "$spaced_table_config" "[data]" "spaced data table update does not append a duplicate bare data table"
-assert_contains "$spaced_table_config" "keepSpacedTable = \"preserve\"" "spaced data table update preserves unrelated data values"
-assert_contains "$spaced_table_config" "branch = \"main\"" "spaced data table update preserves later sections"
+assert_file_contains "$spaced_table_config" "[ data ]" "spaced data table header is preserved"
+assert_file_not_contains "$spaced_table_config" "[data]" "spaced data table update does not append a duplicate bare data table"
+assert_file_contains "$spaced_table_config" "keepSpacedTable = \"preserve\"" "spaced data table update preserves unrelated data values"
+assert_file_contains "$spaced_table_config" "branch = \"main\"" "spaced data table update preserves later sections"
 assert_data_key_once_with_value "$spaced_table_config" "enableEditorStack" "true" "spaced data table update writes Editor Stack in data"
 assert_data_key_once_with_value "$spaced_table_config" "enableAiCliTools" "true" "spaced data table update writes AI Tool Stack in data"
 assert_data_key_once_with_value "$spaced_table_config" "enableDevelopmentWorkspace" "true" "spaced data table update writes Development Workspace in data"
@@ -1223,8 +1182,8 @@ assert_data_key_once_with_value "$spaced_table_config" "enableMacosAppGroupTermi
 assert_data_key_once_with_value "$spaced_table_config" "enableMacosAppGroupAutomation" "false" "spaced data table update writes automation App Group in data"
 assert_data_key_once_with_value "$spaced_table_config" "enableMacosAppGroupLauncher" "false" "spaced data table update writes launcher App Group in data"
 assert_data_key_once_with_value "$spaced_table_config" "enableMacosAppGroupMonitoring" "false" "spaced data table update writes monitoring App Group in data"
-assert_not_contains "$spaced_table_config" "enableMacosDesktopApps" "spaced data table update removes the legacy all-in desktop app toggle"
-assert_not_contains "$spaced_table_config" "terrapodPreset" "spaced data table update removes stale dynamic Preset key"
+assert_file_not_contains "$spaced_table_config" "enableMacosDesktopApps" "spaced data table update removes the legacy all-in desktop app toggle"
+assert_file_not_contains "$spaced_table_config" "terrapodPreset" "spaced data table update removes stale dynamic Preset key"
 
 dotted_home="$tmp_dir/dotted-home"
 dotted_xdg="$tmp_dir/dotted-xdg"
@@ -1245,19 +1204,19 @@ TOML
 
 run_terrapod_configure_yes development "$dotted_home" "$dotted_xdg"
 
-assert_not_contains "$dotted_config" "[data]" "dotted data update does not append a duplicate data table"
-assert_contains "$dotted_config" "data.email = \"minu@example.com\"" "dotted data update preserves unrelated data values"
-assert_contains "$dotted_config" "branch = \"main\"" "dotted data update preserves later sections"
-assert_contains "$dotted_config" "data.profile = \"vps-shell\"" "dotted data update writes profile as a dotted data key"
-assert_contains "$dotted_config" "data.enableEditorStack = true" "dotted data update writes Editor Stack as a dotted data key"
-assert_contains "$dotted_config" "data.enableAiCliTools = false" "dotted data update writes the profile-gated AI Tool Stack as a dotted data key"
-assert_contains "$dotted_config" "data.enableDevelopmentWorkspace = true" "dotted data update writes Development Workspace as a dotted data key"
-assert_contains "$dotted_config" "data.enableMacosAppGroupTerminalApps = false" "dotted data update writes terminal-apps App Group as a dotted data key"
-assert_contains "$dotted_config" "data.enableMacosAppGroupAutomation = false" "dotted data update writes automation App Group as a dotted data key"
-assert_contains "$dotted_config" "data.enableMacosAppGroupLauncher = false" "dotted data update writes launcher App Group as a dotted data key"
-assert_contains "$dotted_config" "data.enableMacosAppGroupMonitoring = false" "dotted data update writes monitoring App Group as a dotted data key"
-assert_not_contains "$dotted_config" "data.enableMacosDesktopApps" "dotted data update removes the legacy all-in desktop app toggle"
-assert_not_contains "$dotted_config" "data.terrapodPreset" "dotted data update removes stale dynamic Preset key"
+assert_file_not_contains "$dotted_config" "[data]" "dotted data update does not append a duplicate data table"
+assert_file_contains "$dotted_config" "data.email = \"minu@example.com\"" "dotted data update preserves unrelated data values"
+assert_file_contains "$dotted_config" "branch = \"main\"" "dotted data update preserves later sections"
+assert_file_contains "$dotted_config" "data.profile = \"vps-shell\"" "dotted data update writes profile as a dotted data key"
+assert_file_contains "$dotted_config" "data.enableEditorStack = true" "dotted data update writes Editor Stack as a dotted data key"
+assert_file_contains "$dotted_config" "data.enableAiCliTools = false" "dotted data update writes the profile-gated AI Tool Stack as a dotted data key"
+assert_file_contains "$dotted_config" "data.enableDevelopmentWorkspace = true" "dotted data update writes Development Workspace as a dotted data key"
+assert_file_contains "$dotted_config" "data.enableMacosAppGroupTerminalApps = false" "dotted data update writes terminal-apps App Group as a dotted data key"
+assert_file_contains "$dotted_config" "data.enableMacosAppGroupAutomation = false" "dotted data update writes automation App Group as a dotted data key"
+assert_file_contains "$dotted_config" "data.enableMacosAppGroupLauncher = false" "dotted data update writes launcher App Group as a dotted data key"
+assert_file_contains "$dotted_config" "data.enableMacosAppGroupMonitoring = false" "dotted data update writes monitoring App Group as a dotted data key"
+assert_file_not_contains "$dotted_config" "data.enableMacosDesktopApps" "dotted data update removes the legacy all-in desktop app toggle"
+assert_file_not_contains "$dotted_config" "data.terrapodPreset" "dotted data update removes stale dynamic Preset key"
 
 if ! HOME="$dotted_home" XDG_CONFIG_HOME="$dotted_xdg" chezmoi --config "$dotted_config" data >"$tmp_dir/dotted-data.out" 2>"$tmp_dir/dotted-data.err"; then
   printf '%s\n' "stderr:" >&2
@@ -1290,16 +1249,16 @@ assert_data_key_once_with_value "$quoted_config" "enableMacosAppGroupTerminalApp
 assert_data_key_once_with_value "$quoted_config" "enableMacosAppGroupAutomation" "false" "quoted managed key update writes one automation App Group value in data"
 assert_data_key_once_with_value "$quoted_config" "enableMacosAppGroupLauncher" "false" "quoted managed key update writes one launcher App Group value in data"
 assert_data_key_once_with_value "$quoted_config" "enableMacosAppGroupMonitoring" "false" "quoted managed key update writes one monitoring App Group value in data"
-assert_not_contains "$quoted_config" "\"enableEditorStack\"" "quoted managed key update removes quoted Editor Stack key"
-assert_not_contains "$quoted_config" "\"enableAiCliTools\"" "quoted managed key update removes quoted AI Tool Stack key"
-assert_not_contains "$quoted_config" "\"enableDevelopmentWorkspace\"" "quoted managed key update removes quoted Development Workspace key"
-assert_not_contains "$quoted_config" "\"enableMacosDesktopApps\"" "quoted managed key update removes quoted macOS desktop-app boundary key"
-assert_not_contains "$quoted_config" "'enableEditorStack'" "quoted managed key update removes literal Editor Stack key"
-assert_not_contains "$quoted_config" "'enableAiCliTools'" "quoted managed key update removes literal AI Tool Stack key"
-assert_not_contains "$quoted_config" "'enableDevelopmentWorkspace'" "quoted managed key update removes literal Development Workspace key"
-assert_not_contains "$quoted_config" "'enableMacosDesktopApps'" "quoted managed key update removes literal macOS desktop-app boundary key"
-assert_not_contains "$quoted_config" "terrapodPreset" "quoted managed key update removes stale dynamic Preset key"
-assert_contains "$quoted_config" "keepLiteral = \"preserve\"" "quoted managed key update preserves unrelated literal data values"
+assert_file_not_contains "$quoted_config" "\"enableEditorStack\"" "quoted managed key update removes quoted Editor Stack key"
+assert_file_not_contains "$quoted_config" "\"enableAiCliTools\"" "quoted managed key update removes quoted AI Tool Stack key"
+assert_file_not_contains "$quoted_config" "\"enableDevelopmentWorkspace\"" "quoted managed key update removes quoted Development Workspace key"
+assert_file_not_contains "$quoted_config" "\"enableMacosDesktopApps\"" "quoted managed key update removes quoted macOS desktop-app boundary key"
+assert_file_not_contains "$quoted_config" "'enableEditorStack'" "quoted managed key update removes literal Editor Stack key"
+assert_file_not_contains "$quoted_config" "'enableAiCliTools'" "quoted managed key update removes literal AI Tool Stack key"
+assert_file_not_contains "$quoted_config" "'enableDevelopmentWorkspace'" "quoted managed key update removes literal Development Workspace key"
+assert_file_not_contains "$quoted_config" "'enableMacosDesktopApps'" "quoted managed key update removes literal macOS desktop-app boundary key"
+assert_file_not_contains "$quoted_config" "terrapodPreset" "quoted managed key update removes stale dynamic Preset key"
+assert_file_contains "$quoted_config" "keepLiteral = \"preserve\"" "quoted managed key update preserves unrelated literal data values"
 
 array_home="$tmp_dir/array-home"
 array_xdg="$tmp_dir/array-xdg"
@@ -1319,7 +1278,7 @@ chmod 600 "$array_config"
 
 run_terrapod_configure_yes development "$array_home" "$array_xdg" macos-terminal
 
-assert_contains "$array_config" "keepMe = \"yes\"" "array-table update preserves unrelated data values"
+assert_file_contains "$array_config" "keepMe = \"yes\"" "array-table update preserves unrelated data values"
 assert_data_key_once_with_value "$array_config" "enableEditorStack" "true" "array-table update writes Editor Stack only in data"
 assert_data_key_once_with_value "$array_config" "enableAiCliTools" "true" "array-table update writes AI Tool Stack only in data"
 assert_data_key_once_with_value "$array_config" "enableDevelopmentWorkspace" "true" "array-table update writes Development Workspace only in data"
@@ -1327,8 +1286,8 @@ assert_data_key_once_with_value "$array_config" "enableMacosAppGroupTerminalApps
 assert_data_key_once_with_value "$array_config" "enableMacosAppGroupAutomation" "false" "array-table update writes automation App Group only in data"
 assert_data_key_once_with_value "$array_config" "enableMacosAppGroupLauncher" "false" "array-table update writes launcher App Group only in data"
 assert_data_key_once_with_value "$array_config" "enableMacosAppGroupMonitoring" "false" "array-table update writes monitoring App Group only in data"
-assert_contains "$array_config" "[[merge.command]]" "array-table update preserves TOML array table"
-assert_contains "$array_config" "enableEditorStack = \"do-not-touch\"" "array-table update preserves same-named external key"
+assert_file_contains "$array_config" "[[merge.command]]" "array-table update preserves TOML array table"
+assert_file_contains "$array_config" "enableEditorStack = \"do-not-touch\"" "array-table update preserves same-named external key"
 assert_lines_after_header_not_contains "$array_config" "[[merge.command]]" "enableAiCliTools = true" "array-table update does not append AI Tool Stack under array table"
 assert_lines_after_header_not_contains "$array_config" "[[merge.command]]" "enableDevelopmentWorkspace = true" "array-table update does not append Development Workspace under array table"
 assert_lines_after_header_not_contains "$array_config" "[[merge.command]]" "enableMacosAppGroupTerminalApps = false" "array-table update does not append terminal-apps App Group under array table"
@@ -1363,8 +1322,8 @@ TOML
 
 run_terrapod_configure_yes development "$custom_array_home" "$custom_array_xdg" macos-terminal
 
-assert_contains "$custom_array_config" "customValues = [" "custom array update preserves array header"
-assert_contains "$custom_array_config" "preserve-me" "custom array update preserves array value"
+assert_file_contains "$custom_array_config" "customValues = [" "custom array update preserves array header"
+assert_file_contains "$custom_array_config" "preserve-me" "custom array update preserves array value"
 assert_data_key_once_with_value "$custom_array_config" "enableEditorStack" "true" "custom array update writes Editor Stack in data"
 assert_data_key_once_with_value "$custom_array_config" "enableAiCliTools" "true" "custom array update writes AI Tool Stack in data"
 assert_data_key_once_with_value "$custom_array_config" "enableDevelopmentWorkspace" "true" "custom array update writes Development Workspace in data"
@@ -1372,7 +1331,7 @@ assert_data_key_once_with_value "$custom_array_config" "enableMacosAppGroupTermi
 assert_data_key_once_with_value "$custom_array_config" "enableMacosAppGroupAutomation" "false" "custom array update writes automation App Group in data"
 assert_data_key_once_with_value "$custom_array_config" "enableMacosAppGroupLauncher" "false" "custom array update writes launcher App Group in data"
 assert_data_key_once_with_value "$custom_array_config" "enableMacosAppGroupMonitoring" "false" "custom array update writes monitoring App Group in data"
-assert_contains "$custom_array_config" "branch = \"main\"" "custom array update preserves later sections"
+assert_file_contains "$custom_array_config" "branch = \"main\"" "custom array update preserves later sections"
 
 multiline_array_home="$tmp_dir/multiline-array-home"
 multiline_array_xdg="$tmp_dir/multiline-array-xdg"
@@ -1399,9 +1358,9 @@ if printf '%s\n' "y" |
 fi
 pass "section-like multiline array config is rejected before rewriting"
 
-assert_contains "$tmp_dir/multiline-array.err" "unsupported multiline array" "section-like multiline array rejection explains unsupported format"
-assert_not_contains "$tmp_dir/multiline-array.err" "Update Terrapod-managed data keys" "section-like multiline array rejection does not prompt before failing"
-assert_not_contains "$tmp_dir/multiline-array.out" "Configured Terrapod Preset" "section-like multiline array rejection does not report success"
+assert_file_contains "$tmp_dir/multiline-array.err" "unsupported multiline array" "section-like multiline array rejection explains unsupported format"
+assert_file_not_contains "$tmp_dir/multiline-array.err" "Update Terrapod-managed data keys" "section-like multiline array rejection does not prompt before failing"
+assert_file_not_contains "$tmp_dir/multiline-array.out" "Configured Terrapod Preset" "section-like multiline array rejection does not report success"
 
 if ! cmp -s "$multiline_array_config" "$tmp_dir/multiline-array-before.toml"; then
   fail "section-like multiline array rejection leaves existing config unchanged"
@@ -1479,9 +1438,9 @@ if printf '%s\n' "y" |
 fi
 pass "inline data table config is rejected instead of rewritten"
 
-assert_contains "$tmp_dir/inline-table.err" "unsupported inline data table" "inline data table rejection explains unsupported format"
-assert_not_contains "$tmp_dir/inline-table.err" "Update Terrapod-managed data keys" "inline data table rejection does not prompt before failing"
-assert_not_contains "$tmp_dir/inline-table.out" "Configured Terrapod Preset" "inline data table rejection does not report success"
+assert_file_contains "$tmp_dir/inline-table.err" "unsupported inline data table" "inline data table rejection explains unsupported format"
+assert_file_not_contains "$tmp_dir/inline-table.err" "Update Terrapod-managed data keys" "inline data table rejection does not prompt before failing"
+assert_file_not_contains "$tmp_dir/inline-table.out" "Configured Terrapod Preset" "inline data table rejection does not report success"
 
 if ! cmp -s "$inline_table_config" "$tmp_dir/inline-table-before.toml"; then
   fail "inline data table rejection leaves existing config unchanged"
@@ -1514,9 +1473,9 @@ if printf '%s\n' "y" |
 fi
 pass "multiline string with data-like content is rejected instead of rewritten"
 
-assert_contains "$tmp_dir/multiline-string.err" "unsupported multiline string" "multiline string rejection explains unsupported format"
-assert_not_contains "$tmp_dir/multiline-string.err" "Update Terrapod-managed data keys" "multiline string rejection does not prompt before failing"
-assert_not_contains "$tmp_dir/multiline-string.out" "Configured Terrapod Preset" "multiline string rejection does not report success"
+assert_file_contains "$tmp_dir/multiline-string.err" "unsupported multiline string" "multiline string rejection explains unsupported format"
+assert_file_not_contains "$tmp_dir/multiline-string.err" "Update Terrapod-managed data keys" "multiline string rejection does not prompt before failing"
+assert_file_not_contains "$tmp_dir/multiline-string.out" "Configured Terrapod Preset" "multiline string rejection does not report success"
 
 if ! cmp -s "$multiline_string_config" "$tmp_dir/multiline-string-before.toml"; then
   fail "multiline string rejection leaves existing config unchanged"
@@ -1547,9 +1506,9 @@ if printf '%s\n' "y" |
 fi
 pass "dotted data update rejects multiline strings before injecting managed keys"
 
-assert_contains "$tmp_dir/dotted-multiline.err" "unsupported multiline string" "dotted multiline rejection explains unsupported format"
-assert_not_contains "$tmp_dir/dotted-multiline.err" "Update Terrapod-managed data keys" "dotted multiline rejection does not prompt before failing"
-assert_not_contains "$tmp_dir/dotted-multiline.out" "Configured Terrapod Preset" "dotted multiline rejection does not report success"
+assert_file_contains "$tmp_dir/dotted-multiline.err" "unsupported multiline string" "dotted multiline rejection explains unsupported format"
+assert_file_not_contains "$tmp_dir/dotted-multiline.err" "Update Terrapod-managed data keys" "dotted multiline rejection does not prompt before failing"
+assert_file_not_contains "$tmp_dir/dotted-multiline.out" "Configured Terrapod Preset" "dotted multiline rejection does not report success"
 
 if ! cmp -s "$dotted_multiline_config" "$tmp_dir/dotted-multiline-before.toml"; then
   fail "dotted multiline rejection leaves existing config unchanged"
@@ -1582,9 +1541,9 @@ if printf '%s\n' "y" |
 fi
 pass "dotted data update rejects multiline strings in arrays before injecting managed keys"
 
-assert_contains "$tmp_dir/dotted-array-multiline.err" "unsupported multiline string" "dotted array multiline rejection explains unsupported format"
-assert_not_contains "$tmp_dir/dotted-array-multiline.err" "Update Terrapod-managed data keys" "dotted array multiline rejection does not prompt before failing"
-assert_not_contains "$tmp_dir/dotted-array-multiline.out" "Configured Terrapod Preset" "dotted array multiline rejection does not report success"
+assert_file_contains "$tmp_dir/dotted-array-multiline.err" "unsupported multiline string" "dotted array multiline rejection explains unsupported format"
+assert_file_not_contains "$tmp_dir/dotted-array-multiline.err" "Update Terrapod-managed data keys" "dotted array multiline rejection does not prompt before failing"
+assert_file_not_contains "$tmp_dir/dotted-array-multiline.out" "Configured Terrapod Preset" "dotted array multiline rejection does not report success"
 
 if ! cmp -s "$dotted_array_multiline_config" "$tmp_dir/dotted-array-multiline-before.toml"; then
   fail "dotted array multiline rejection leaves existing config unchanged"
@@ -1616,8 +1575,8 @@ if ! cmp -s "$decline_config" "$tmp_dir/decline-before.toml"; then
 fi
 pass "declined config update leaves existing config unchanged"
 
-assert_contains "$tmp_dir/decline.out" "Update Terrapod-managed data keys" "existing config update asks before writing"
-assert_contains "$tmp_dir/decline.out" "config update cancelled" "declined config update explains the cancellation"
+assert_file_contains "$tmp_dir/decline.out" "Update Terrapod-managed data keys" "existing config update asks before writing"
+assert_file_contains "$tmp_dir/decline.out" "config update cancelled" "declined config update explains the cancellation"
 assert_backup_count "$decline_config" 0 "declined config update does not create a backup"
 
 accept_home="$tmp_dir/accept-home"
@@ -1633,9 +1592,9 @@ TOML
 
 run_terrapod_configure_in_pty development "y" "$accept_home" "$accept_xdg" >"$tmp_dir/accept.out" 2>&1
 
-assert_contains "$tmp_dir/accept.out" "Update Terrapod-managed data keys" "accepted config update asks before writing"
+assert_file_contains "$tmp_dir/accept.out" "Update Terrapod-managed data keys" "accepted config update asks before writing"
 assert_data_key_once_with_value "$accept_config" "enableEditorStack" "true" "accepted config update writes the Preset settings"
-assert_contains "$accept_config" "keepMe = \"yes\"" "accepted config update preserves unrelated data values"
+assert_file_contains "$accept_config" "keepMe = \"yes\"" "accepted config update preserves unrelated data values"
 
 no_tty_home="$tmp_dir/no-tty-home"
 no_tty_xdg="$tmp_dir/no-tty-xdg"
@@ -1659,10 +1618,10 @@ if ! cmp -s "$no_tty_config" "$tmp_dir/no-tty-before.toml"; then
 fi
 pass "refused config update leaves existing config unchanged"
 
-assert_not_contains "$tmp_dir/no-tty.err" "Update Terrapod-managed data keys" "configure without a terminal does not print an unanswerable prompt"
-assert_contains "$tmp_dir/no-tty.err" "tpod configure --yes" "configure without a terminal names the flag that allows the overwrite"
-assert_contains "$tmp_dir/no-tty.err" "TERRAPOD_ASSUME_YES=1" "configure without a terminal names the environment variable that allows the overwrite"
-assert_not_contains "$tmp_dir/no-tty.out" "Configured Terrapod Preset" "configure without a terminal does not report success"
+assert_file_not_contains "$tmp_dir/no-tty.err" "Update Terrapod-managed data keys" "configure without a terminal does not print an unanswerable prompt"
+assert_file_contains "$tmp_dir/no-tty.err" "tpod configure --yes" "configure without a terminal names the flag that allows the overwrite"
+assert_file_contains "$tmp_dir/no-tty.err" "TERRAPOD_ASSUME_YES=1" "configure without a terminal names the environment variable that allows the overwrite"
+assert_file_not_contains "$tmp_dir/no-tty.out" "Configured Terrapod Preset" "configure without a terminal does not report success"
 assert_backup_count "$no_tty_config" 0 "refused config update does not create a backup"
 assert_no_terrapod_temp_files "$no_tty_config" "refused config update leaves no Terrapod temp files"
 
@@ -1706,10 +1665,10 @@ TERRAPOD_ASSUME_YES=1 TERRAPOD_PROFILE=vps-shell TERRAPOD_CHEZMOI_CONFIG= \
   HOME="$assume_yes_home" XDG_CONFIG_HOME="$assume_yes_xdg" \
   sh "$terrapod" configure development >"$tmp_dir/assume-yes.out" 2>&1 </dev/null
 
-assert_contains "$tmp_dir/assume-yes.out" "Configured Terrapod Preset 'development'" "TERRAPOD_ASSUME_YES=1 lets configure overwrite an existing config"
-assert_not_contains "$tmp_dir/assume-yes.out" "Update Terrapod-managed data keys" "TERRAPOD_ASSUME_YES=1 skips the confirmation prompt"
+assert_file_contains "$tmp_dir/assume-yes.out" "Configured Terrapod Preset 'development'" "TERRAPOD_ASSUME_YES=1 lets configure overwrite an existing config"
+assert_file_not_contains "$tmp_dir/assume-yes.out" "Update Terrapod-managed data keys" "TERRAPOD_ASSUME_YES=1 skips the confirmation prompt"
 assert_data_key_once_with_value "$assume_yes_config" "enableEditorStack" "true" "TERRAPOD_ASSUME_YES=1 writes the Preset settings"
-assert_contains "$assume_yes_config" "keepMe = \"yes\"" "TERRAPOD_ASSUME_YES=1 preserves unrelated data values"
+assert_file_contains "$assume_yes_config" "keepMe = \"yes\"" "TERRAPOD_ASSUME_YES=1 preserves unrelated data values"
 assert_single_backup_matches "$assume_yes_config" "$tmp_dir/assume-yes-before.toml" "TERRAPOD_ASSUME_YES=1 still backs up the config before changing managed keys"
 
 flag_new_home="$tmp_dir/flag-new-home"
@@ -1719,7 +1678,7 @@ mkdir -p "$flag_new_home"
 
 run_terrapod_configure_yes minimal "$flag_new_home" "$flag_new_xdg" >"$tmp_dir/flag-new.out"
 
-assert_contains "$tmp_dir/flag-new.out" "Configured Terrapod Preset 'minimal' in $flag_new_config" "--yes writes a new config the same way as a bare configure"
+assert_file_contains "$tmp_dir/flag-new.out" "Configured Terrapod Preset 'minimal' in $flag_new_config" "--yes writes a new config the same way as a bare configure"
 assert_backup_count "$flag_new_config" 0 "--yes new config creation does not create a backup"
 
 if TERRAPOD_PROFILE=vps-shell TERRAPOD_CHEZMOI_CONFIG= HOME="$tmp_dir/unknown-option-home" XDG_CONFIG_HOME="$tmp_dir/unknown-option-xdg" \
@@ -1728,7 +1687,7 @@ if TERRAPOD_PROFILE=vps-shell TERRAPOD_CHEZMOI_CONFIG= HOME="$tmp_dir/unknown-op
 fi
 pass "configure rejects an unknown option"
 
-assert_contains "$tmp_dir/unknown-option.err" "unknown configure option: --force" "configure names the unknown option it rejected"
+assert_file_contains "$tmp_dir/unknown-option.err" "unknown configure option: --force" "configure names the unknown option it rejected"
 
 if TERRAPOD_PROFILE=vps-shell TERRAPOD_CHEZMOI_CONFIG= HOME="$tmp_dir/flag-only-home" XDG_CONFIG_HOME="$tmp_dir/flag-only-xdg" \
   sh "$terrapod" configure --yes >"$tmp_dir/flag-only.out" 2>"$tmp_dir/flag-only.err" </dev/null; then
@@ -1736,7 +1695,7 @@ if TERRAPOD_PROFILE=vps-shell TERRAPOD_CHEZMOI_CONFIG= HOME="$tmp_dir/flag-only-
 fi
 pass "configure still requires a Preset when only the overwrite flag is given"
 
-assert_contains "$tmp_dir/flag-only.err" "Preset is required" "configure with only the overwrite flag reports the missing Preset"
+assert_file_contains "$tmp_dir/flag-only.err" "Preset is required" "configure with only the overwrite flag reports the missing Preset"
 
 directory_home="$tmp_dir/directory-home"
 directory_xdg="$tmp_dir/directory-xdg"
@@ -1748,8 +1707,8 @@ if TERRAPOD_CHEZMOI_CONFIG="$directory_config" HOME="$directory_home" XDG_CONFIG
 fi
 pass "config path that is a directory fails explicitly"
 
-assert_contains "$tmp_dir/directory.err" "not a regular file" "directory config path explains it is not usable"
-assert_not_contains "$tmp_dir/directory.out" "Configured Terrapod Preset" "directory config path does not report success"
+assert_file_contains "$tmp_dir/directory.err" "not a regular file" "directory config path explains it is not usable"
+assert_file_not_contains "$tmp_dir/directory.out" "Configured Terrapod Preset" "directory config path does not report success"
 assert_no_terrapod_temp_files "$directory_config" "directory config path leaves no Terrapod temp files"
 
 symlink_home="$tmp_dir/symlink-home"
@@ -1773,9 +1732,9 @@ if TERRAPOD_CHEZMOI_CONFIG="$symlink_config" HOME="$symlink_home" XDG_CONFIG_HOM
 fi
 pass "config path that is a symlink to a regular file fails explicitly"
 
-assert_contains "$tmp_dir/symlink.err" "not a regular file" "symlink config path explains it is not usable"
-assert_not_contains "$tmp_dir/symlink.err" "Update Terrapod-managed data keys" "symlink config path does not prompt before failing"
-assert_not_contains "$tmp_dir/symlink.err" "config update cancelled" "symlink config path does not report a declined update"
+assert_file_contains "$tmp_dir/symlink.err" "not a regular file" "symlink config path explains it is not usable"
+assert_file_not_contains "$tmp_dir/symlink.err" "Update Terrapod-managed data keys" "symlink config path does not prompt before failing"
+assert_file_not_contains "$tmp_dir/symlink.err" "config update cancelled" "symlink config path does not report a declined update"
 
 if [ ! -L "$symlink_config" ]; then
   fail "symlink config path remains a symlink after failed update"
@@ -1809,7 +1768,7 @@ if TERRAPOD_CHEZMOI_CONFIG="$dangling_config" HOME="$dangling_home" XDG_CONFIG_H
 fi
 pass "config path that is a dangling symlink fails explicitly"
 
-assert_contains "$tmp_dir/dangling.err" "not a regular file" "dangling symlink config path explains it is not usable"
+assert_file_contains "$tmp_dir/dangling.err" "not a regular file" "dangling symlink config path explains it is not usable"
 
 if [ ! -L "$dangling_config" ]; then
   fail "dangling symlink config path remains a symlink after failed update"
@@ -1846,11 +1805,11 @@ if [ "$empty_preset_status" -ne 64 ]; then
 fi
 pass "empty Preset exits with usage status 64"
 
-assert_contains "$tmp_dir/empty-preset.err" "Preset is required" "empty Preset reports required Preset"
-assert_not_contains "$tmp_dir/empty-preset.err" "unknown Preset" "empty Preset does not report unknown Preset"
-assert_not_contains "$tmp_dir/empty-preset.err" "Update Terrapod-managed data keys" "empty Preset does not prompt before failing"
-assert_not_contains "$tmp_dir/empty-preset.out" "Update Terrapod-managed data keys" "empty Preset does not prompt on stdout before failing"
-assert_not_contains "$tmp_dir/empty-preset.out" "Configured Terrapod Preset" "empty Preset does not report success"
+assert_file_contains "$tmp_dir/empty-preset.err" "Preset is required" "empty Preset reports required Preset"
+assert_file_not_contains "$tmp_dir/empty-preset.err" "unknown Preset" "empty Preset does not report unknown Preset"
+assert_file_not_contains "$tmp_dir/empty-preset.err" "Update Terrapod-managed data keys" "empty Preset does not prompt before failing"
+assert_file_not_contains "$tmp_dir/empty-preset.out" "Update Terrapod-managed data keys" "empty Preset does not prompt on stdout before failing"
+assert_file_not_contains "$tmp_dir/empty-preset.out" "Configured Terrapod Preset" "empty Preset does not report success"
 
 if ! cmp -s "$empty_preset_config" "$tmp_dir/empty-preset-before.toml"; then
   fail "empty Preset leaves existing config unchanged"
@@ -1883,8 +1842,8 @@ if [ "$invalid_status" -ne 64 ]; then
 fi
 pass "invalid Preset exits with usage status 64"
 
-assert_contains "$tmp_dir/invalid.err" "unknown Preset: typo" "invalid Preset names rejected Preset"
-assert_not_contains "$tmp_dir/invalid.err" "Update Terrapod-managed data keys" "invalid Preset does not prompt before failing"
+assert_file_contains "$tmp_dir/invalid.err" "unknown Preset: typo" "invalid Preset names rejected Preset"
+assert_file_not_contains "$tmp_dir/invalid.err" "Update Terrapod-managed data keys" "invalid Preset does not prompt before failing"
 
 if ! cmp -s "$invalid_config" "$tmp_dir/invalid-before.toml"; then
   fail "invalid Preset leaves existing config unchanged"

--- a/tests/terrapod_installer_test.sh
+++ b/tests/terrapod_installer_test.sh
@@ -2,56 +2,19 @@
 set -eu
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+. "$repo_root/tests/lib/harness.sh"
 install_warnings_lib_template="$repo_root/dot_local/lib/terrapod/install-warnings.sh"
 export TERRAPOD_INSTALL_WARNINGS_LIB_TEMPLATE="$install_warnings_lib_template"
 config_toml_lib_template="$repo_root/dot_local/lib/terrapod/config-toml.sh"
 export TERRAPOD_CONFIG_TOML_LIB_TEMPLATE="$config_toml_lib_template"
-tmp_dir="$(mktemp -d)"
+make_tmp_dir
 safe_path_dir="$tmp_dir/safe-bin"
-
-cleanup() {
-  rm -rf "$tmp_dir"
-}
-trap cleanup EXIT INT TERM
-
-fail() {
-  printf '%s\n' "not ok - $1" >&2
-  exit 1
-}
-
-pass() {
-  printf '%s\n' "ok - $1"
-}
 
 mkdir -p "$safe_path_dir"
 for command_name in awk cat chmod cmp cp date df grep ln mkdir mktemp mv readlink rm sed; do
   command_path="$(command -v "$command_name")"
   ln -s "$command_path" "$safe_path_dir/$command_name"
 done
-
-assert_contains() {
-  haystack="$1"
-  needle="$2"
-  message="$3"
-
-  if ! printf '%s\n' "$haystack" | grep -F "$needle" >/dev/null; then
-    fail "$message"
-  fi
-
-  pass "$message"
-}
-
-assert_not_contains() {
-  haystack="$1"
-  needle="$2"
-  message="$3"
-
-  if printf '%s\n' "$haystack" | grep -F -e "$needle" >/dev/null; then
-    fail "$message"
-  fi
-
-  pass "$message"
-}
 
 assert_line() {
   haystack="$1"

--- a/tests/zprofile_orbstack_test.sh
+++ b/tests/zprofile_orbstack_test.sh
@@ -2,21 +2,8 @@
 set -eu
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
-tmp_dir="$(mktemp -d)"
-
-cleanup() {
-  rm -rf "$tmp_dir"
-}
-trap cleanup EXIT INT TERM
-
-fail() {
-  printf '%s\n' "not ok - $1" >&2
-  exit 1
-}
-
-pass() {
-  printf '%s\n' "ok - $1"
-}
+. "$repo_root/tests/lib/harness.sh"
+make_tmp_dir
 
 render_zprofile() {
   data="$1"

--- a/tests/zshenv_local_bin_test.sh
+++ b/tests/zshenv_local_bin_test.sh
@@ -2,39 +2,8 @@
 set -eu
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
-tmp_dir="$(mktemp -d)"
-
-cleanup() {
-  rm -rf "$tmp_dir"
-}
-trap cleanup EXIT INT TERM
-
-fail() {
-  printf '%s\n' "not ok - $1" >&2
-  exit 1
-}
-
-pass() {
-  printf '%s\n' "ok - $1"
-}
-
-assert_contains() {
-  haystack="$1"
-  needle="$2"
-  message="$3"
-  printf '%s\n' "$haystack" | grep -F "$needle" >/dev/null || fail "$message"
-  pass "$message"
-}
-
-assert_not_contains() {
-  haystack="$1"
-  needle="$2"
-  message="$3"
-  if printf '%s\n' "$haystack" | grep -F "$needle" >/dev/null; then
-    fail "$message"
-  fi
-  pass "$message"
-}
+. "$repo_root/tests/lib/harness.sh"
+make_tmp_dir
 
 assert_order() {
   haystack="$1"

--- a/tests/zshrc_clear_test.zsh
+++ b/tests/zshrc_clear_test.zsh
@@ -3,21 +3,8 @@
 set -u
 
 repo_root="${0:A:h:h}"
-tmp_dir="$(mktemp -d)"
-
-cleanup() {
-  rm -rf "$tmp_dir"
-}
-trap cleanup EXIT INT TERM
-
-fail() {
-  print -u2 -- "not ok - $1"
-  exit 1
-}
-
-pass() {
-  print -- "ok - $1"
-}
+. "$repo_root/tests/lib/harness.sh"
+make_tmp_dir
 
 assert_log_contains() {
   local expected="$1"

--- a/tests/zshrc_completions_test.zsh
+++ b/tests/zshrc_completions_test.zsh
@@ -3,21 +3,8 @@
 set -u
 
 repo_root="${0:A:h:h}"
-tmp_dir="$(mktemp -d)"
-
-cleanup() {
-  rm -rf "$tmp_dir"
-}
-trap cleanup EXIT INT TERM
-
-fail() {
-  print -u2 -- "not ok - $1"
-  exit 1
-}
-
-pass() {
-  print -- "ok - $1"
-}
+. "$repo_root/tests/lib/harness.sh"
+make_tmp_dir
 
 render_zshrc() {
   local data="$1"

--- a/tests/zshrc_zoxide_test.zsh
+++ b/tests/zshrc_zoxide_test.zsh
@@ -3,21 +3,8 @@
 set -u
 
 repo_root="${0:A:h:h}"
-tmp_dir="$(mktemp -d)"
-
-cleanup() {
-  rm -rf "$tmp_dir"
-}
-trap cleanup EXIT INT TERM
-
-fail() {
-  print -u2 -- "not ok - $1"
-  exit 1
-}
-
-pass() {
-  print -- "ok - $1"
-}
+. "$repo_root/tests/lib/harness.sh"
+make_tmp_dir
 
 assert_log_contains() {
   local expected="$1"
@@ -25,18 +12,6 @@ assert_log_contains() {
 
   if ! grep -F "$expected" "$ZELLIJ_TEST_LOG" >/dev/null 2>&1; then
     fail "$message; expected log to contain '$expected'"
-  fi
-
-  pass "$message"
-}
-
-assert_file_contains() {
-  local file="$1"
-  local expected="$2"
-  local message="$3"
-
-  if ! grep -F "$expected" "$file" >/dev/null 2>&1; then
-    fail "$message; expected $file to contain '$expected'"
   fi
 
   pass "$message"


### PR DESCRIPTION
Closes #176

First PR in this lane; branched from `main`.

## Problem

`fail`, `pass`, the `mktemp -d` + `trap 'rm -rf' EXIT INT TERM` preamble, and the contains/not-contains assertions were re-declared in almost every test file, and the assertion signatures had drifted apart. Three different shapes were live at once:

| shape | files | calls |
| --- | --- | --- |
| `(haystack, needle, message)` | `bootstrap_ubuntu`, `lazygit_pr_merge`, `shell_integrations`, `terrapod_command`, `terrapod_installer`, `zshenv_local_bin`, plus `executable_selection` and `helper_resolution` matching with a `case` glob instead of `grep` | 696 |
| `(file, needle, message)` | `git_config`, `readme_korean`, `terrapod_config` | 206 |
| `(needle, message)`, reading `$readme` implicitly | `readme_optional_stack_profiles` | 73 |

`chezmoiignore_test.sh` had a fourth variation: canonical behaviour under the names `assert_contains_text` / `assert_not_contains_text` (178 calls).

## Change

`tests/lib/harness.sh` holds one set of definitions, sourced by all 24 test files. It is POSIX shell with no shebang so `sh` and `zsh` files read the same definitions.

```
assert_contains          <haystack> <needle> <message>
assert_not_contains      <haystack> <needle> <message>
assert_file_contains     <file>     <needle> <message>
assert_file_not_contains <file>     <needle> <message>
```

Plus `fail`, `pass`, `skip`, and `make_tmp_dir`.

### Which signature is canonical, and why

**`(haystack, needle, message)`.** Three reasons:

1. It is what 696 of the 975 call sites already pass — moving 206 file-first calls is a smaller and more mechanical change than rewriting 696 into `$(cat "$file")`.
2. Several haystacks are never files. `terrapod_command_test.sh` and `terrapod_installer_test.sh` assert on captured stdout and on stub logs read into variables; forcing those through a file would mean writing temporary files just to assert on them.
3. `$(cat "$file")` strips trailing newlines and would silently rewrite what some assertions mean.

The file form is kept, but under its own name rather than as an overload. That is the actual fix for the footgun the issue names: the ambiguity was never that both forms exist, it was that one name meant both things depending on which file you were in. `assert_file_contains` cannot be handed a string by accident — `grep` fails loudly on a missing path. `zshrc_zoxide_test.zsh` already had an `assert_file_contains` with exactly this signature, so the naming is the repo's own.

Helper variables inside the harness carry a `harness_` prefix so sourcing never shadows a name a test holds. The deliberate exception is `make_tmp_dir`, which fills `$tmp_dir` because that is the name every test already reads.

### A latent false pass this fixed

The canonical assertions pass the needle as `grep -F -e "$needle"`. `lazygit_pr_merge_test.sh:114` asserts a rendered config does **not** contain `- pager:`. Under the old `grep -F "$needle"` that needle was parsed as options, so grep printed a usage error and exited non-zero — and `assert_not_contains` read the non-zero exit as "not found" and passed. It was passing for the wrong reason, and would have kept passing if the string had actually appeared. It passes correctly now; this is the one line that differs between the before and after suite output (see below).

### zsh test files are included

`zshrc_clear_test.zsh`, `zshrc_completions_test.zsh` and `zshrc_zoxide_test.zsh` source the same harness. They had the same duplicated `fail`/`pass`/cleanup preamble, only spelled with `print` instead of `printf`, and nothing in the harness needs a shell feature zsh lacks.

One zsh difference did shape the design: **zsh runs an EXIT trap set inside a function as soon as that function returns**, so a `make_tmp_dir` that armed its own trap would delete the temp directory before the test used it (verified directly). The trap is therefore armed at harness source time against a `$tmp_dir` that starts empty, and `make_tmp_dir` only fills it.

### `tests/run` is unaffected

The globs are `tests/*_test.sh` and `tests/*_test.zsh`. `tests/lib/harness.sh` matches neither, and lives in a subdirectory besides. Confirmed empirically: the runner reports 24 test files before and after. `tests/**` is already in `.chezmoiignore`, so the new file changes no managed path.

### Out of scope

Assertions specific to one test file (`assert_line`, `assert_status`, `assert_json_value`, `assert_order`, `assert_call_args`, …) stay where they are. Only the vocabulary that was duplicated across files moved.

## Tests

The refactor is meant to be output-preserving, so that is what was checked. The full suite was captured before any edit and again after, and the two were diffed with the random `mktemp` paths normalized:

```
$ PATH="$(mise where python)/bin:$PATH" tests/run > before.txt   # on origin/main
$ PATH="$(mise where python)/bin:$PATH" tests/run > after.txt    # on this branch
$ diff <(norm before.txt) <(norm after.txt)
574,578d573
< grep: invalid option --
< usage: grep [-abcdDEFGHhIiJLlMmnOopqRSsUVvwXxZz] [-A num] [-B num] [-C[num]]
...
```

Assertion counts are identical and the only difference is the disappearance of the `grep` usage error described above:

```
before: 2224 ok, 0 skip, 24 test files passed, exit 0
after:  2224 ok, 0 skip, 24 test files passed, exit 0
```

Every `ok - ` line is byte-identical in the same order, which covers all 975 migrated call sites — each one prints its message on the pass path, so a call whose arguments were rewritten wrongly could not still print the same line in the same place.

### A regression caught during the work

A first pass at the migration collapsed runs of blank lines file-wide as cleanup. That corrupted multi-line quoted literals that feed the gum stub its answers — blank lines there mean "accept the default" — and `terrapod_config_test.sh` and `terrapod_installer_test.sh` failed on their interactive-setup cases. The blank-line collapsing was removed and the migration redone; the `\n\n\n` counts in the three files that contain such literals are unchanged from `main`.

## Docs

`AGENTS.md` gains a short paragraph naming the harness and its four signatures, since a contributor adding a test file needs it. No `CONTEXT.md` change (no domain term moved) and no ADR (no architectural decision changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKu7yrNkZj6rtDDuF1kzVF