### PR TITLE
Spell git config the way the supported Ubuntu git accepts

### DIFF
--- a/tests/git_config_test.sh
+++ b/tests/git_config_test.sh
@@ -52,23 +52,25 @@ cp "$managed_config" "$tmp_dir/shared-config-before"
 
 HOME="$test_home" XDG_CONFIG_HOME="$test_xdg" \
   chezmoi --source "$repo_root" --destination "$test_home" apply "$test_home/.gitconfig"
+# Spelled the pre-2.46 way on purpose: `git config set` / `git config get`
+# are usage errors on the git 2.43 that Ubuntu 24.04 ships.
 HOME="$test_home" XDG_CONFIG_HOME="$test_xdg" \
-  git config set --global user.name "Test User"
+  git config --global user.name "Test User"
 HOME="$test_home" XDG_CONFIG_HOME="$test_xdg" \
-  git config set --global user.email "test@example.com"
+  git config --global user.email "test@example.com"
 
 if ! cmp -s "$tmp_dir/shared-config-before" "$test_xdg/git/config"; then
   fail "setting user-level Git identity leaves shared Terrapod config unchanged"
 fi
 pass "setting user-level Git identity leaves shared Terrapod config unchanged"
 
-if [ "$(HOME="$test_home" XDG_CONFIG_HOME="$test_xdg" git config get user.name)" != "Test User" ] ||
-   [ "$(HOME="$test_home" XDG_CONFIG_HOME="$test_xdg" git config get user.email)" != "test@example.com" ]; then
+if [ "$(HOME="$test_home" XDG_CONFIG_HOME="$test_xdg" git config --get user.name)" != "Test User" ] ||
+   [ "$(HOME="$test_home" XDG_CONFIG_HOME="$test_xdg" git config --get user.email)" != "test@example.com" ]; then
   fail "user-level Git identity overrides shared Terrapod settings"
 fi
 pass "user-level Git identity overrides shared Terrapod settings"
 
-if [ "$(HOME="$test_home" XDG_CONFIG_HOME="$test_xdg" git config get merge.ff)" != "false" ]; then
+if [ "$(HOME="$test_home" XDG_CONFIG_HOME="$test_xdg" git config --get merge.ff)" != "false" ]; then
   fail "setting user-level Git identity preserves shared Terrapod settings"
 fi
 pass "setting user-level Git identity preserves shared Terrapod settings"
@@ -80,6 +82,16 @@ if ! cmp -s "$tmp_dir/user-config-before" "$test_home/.gitconfig"; then
   fail "Terrapod preserves user changes in ~/.gitconfig on later applies"
 fi
 pass "Terrapod preserves user changes in ~/.gitconfig on later applies"
+
+# The README's `git config set` guidance is fine: it runs after Terrapod has
+# installed Homebrew's git. The tests themselves have no such guarantee, so no
+# test file may drive git config through the 2.46-only subcommands.
+for test_file in "$repo_root"/tests/*_test.sh "$repo_root"/tests/*_test.zsh; do
+  if grep -E '[[:space:]]git config (set|get) ' "$test_file" >/dev/null; then
+    fail "${test_file##*/} drives git config with a subcommand git 2.43 rejects"
+  fi
+done
+pass "test files spell git config the way the supported Ubuntu git accepts"
 
 assert_file_contains "$readme" 'git config set --global user.name "Your Name"' \
   "README documents user-level Git name setup"


### PR DESCRIPTION
Closes #219

Branched from `main`; not stacked.

## Problem

`tests/git_config_test.sh` drove git through `git config set --global …` and `git config get …`, subcommands added in git 2.46. Ubuntu 24.04 LTS, the only Linux release the VPS Shell Profile targets, ships git 2.43, where both forms exit with a usage error. The suite passed only because GitHub's `ubuntu-latest` image carries a current git and a Terrapod-provisioned machine has Homebrew's `git` ahead of the system one on PATH. In a stock `ubuntu:24.04` container the file fails, and CI is one runner-image change away from the same.

## Change

The issue offered two directions (portable spellings, or a version check that skips). This takes the first: the test now uses the spellings every supported git accepts, so nothing is skipped anywhere.

| before | after |
| --- | --- |
| `git config set --global user.name "Test User"` | `git config --global user.name "Test User"` |
| `git config get user.name` | `git config --get user.name` |

Both pairs read and write the same files. The `get` calls stay scope-less on purpose: the assertions they feed check that `~/.gitconfig` overrides the shared `XDG_CONFIG_HOME/git/config` while `merge.ff` from the shared file still shows through, which is a merged read.

A guard assertion in the same file greps every `tests/*_test.sh` and `tests/*_test.zsh` for a `git config set` / `git config get` invocation and fails the file naming the offender, so the 2.46-only spelling cannot come back. The pattern requires whitespace before `git config`, which leaves the README needle strings (quoted, `'git config set …'`) alone.

`README.md:417-426` and `README.ko.md` keep their `git config set` guidance, as the issue says: that runs after Terrapod has installed Homebrew's git.

## Tests

Verified on the git the issue is about, in a stock `ubuntu:24.04` container with `apt`'s git 2.43 and the repo's shared config copied to `XDG_CONFIG_HOME/git/config`:

```
--- old spelling:
git config set --global user.name "Test User"   → exit=129 (usage)
git config get user.name                        → exit=128
--- new spelling:
git config --global user.name / user.email      → set exit=0
name=Test User email=test@example.com merge.ff=false
```

Red-check of the guard: reintroducing one `git config set --global` line gives

```
not ok - git_config_test.sh drives git config with a subcommand git 2.43 rejects
```

Full suite on this branch (macOS, git 2.50):

```
$ PATH="$(mise where python)/bin:$PATH" tests/run
=== summary ===
24 test files passed
ok: 2225, skip: 0, exit 0
```

## Docs

None. No domain term moved (no `CONTEXT.md` change) and no architectural decision changed (no ADR). `AGENTS.md` says nothing about git versions, and the constraint is now enforced by the test rather than documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MChALHnXtiUN3X7ZHhq41Z