### PR TITLE
Drop bare and prunable entries from the wcd worktree picker

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -166,12 +166,31 @@ function wcd() {
     return 1
   fi
 
+  # One porcelain record per worktree, blank-line separated. Bare records have
+  # no checkout and prunable records point at a directory that is already
+  # gone, so neither is offered: cd would fail on both. The display column is
+  # built here rather than pasted from `git worktree list` so the two never
+  # drift out of step when records are dropped.
   local selected
   selected="$(
-    paste \
-      <(git worktree list --porcelain | awk '/^worktree / { print substr($0, 10) }') \
-      <(git worktree list) |
-      fzf --delimiter=$'\t' --with-nth=2.. --height=40% --reverse --ansi
+    git worktree list --porcelain | awk '
+      /^worktree / { path = substr($0, 10); head = ""; ref = ""; locked = ""; skip = 0; next }
+      /^HEAD /     { head = substr($0, 6, 7); next }
+      /^branch /   { ref = substr($0, 8); sub(/^refs\/heads\//, "", ref); ref = "[" ref "]"; next }
+      /^detached$/ { ref = "(detached HEAD)"; next }
+      /^locked/    { locked = " locked"; next }
+      /^bare$/ || /^prunable/ { skip = 1; next }
+      /^$/ {
+        if (path != "" && !skip) {
+          n++; paths[n] = path; rows[n] = head " " ref locked
+          if (length(path) > width) width = length(path)
+        }
+        path = ""
+      }
+      END {
+        for (i = 1; i <= n; i++) printf "%s\t%-" width "s  %s\n", paths[i], paths[i], rows[i]
+      }
+    ' | fzf --delimiter=$'\t' --with-nth=2.. --height=40% --reverse --ansi
   )"
 
   [ -n "$selected" ] || return 0

--- a/tests/zshrc_zoxide_test.zsh
+++ b/tests/zshrc_zoxide_test.zsh
@@ -51,7 +51,7 @@ mkdir -p \
   "$tmp_dir/selected" \
   "$tmp_dir/recent" \
   "$tmp_dir/git-project/.git" \
-  "$tmp_dir/worktree-main" \
+  "$tmp_dir/worktree-seed" \
   "$tmp_dir/plain"
 
 cat >"$tmp_dir/home/.local/share/zinit/zinit.git/zinit.zsh" <<'STUB'
@@ -264,41 +264,59 @@ fi
 PATH="$old_path"
 assert_file_contains "$tmp_dir/wcd-missing-fzf.out" "fzf가 설치되어 있지 않습니다." "wcd explains missing fzf"
 
-git -C "$tmp_dir/worktree-main" init -b main >/dev/null
-git -C "$tmp_dir/worktree-main" config user.email "test@example.com"
-git -C "$tmp_dir/worktree-main" config user.name "Test User"
-: >"$tmp_dir/worktree-main/file.txt"
-git -C "$tmp_dir/worktree-main" add file.txt
-git -C "$tmp_dir/worktree-main" commit -m "initial commit" >/dev/null
-git -C "$tmp_dir/worktree-main" branch feature/worktree
-git -C "$tmp_dir/worktree-main" branch feature/third
-git -C "$tmp_dir/worktree-main" worktree add "$tmp_dir/worktree selected" feature/worktree >/dev/null 2>&1
-git -C "$tmp_dir/worktree-main" worktree add "$tmp_dir/worktree third" feature/third >/dev/null 2>&1
+# `git worktree list` only emits a `bare` record for a bare main repository, so
+# the fixture's main is a bare clone and every checkout is a linked worktree.
+# The seed repository exists only to give that clone a commit; it is a separate
+# repository and never appears in the worktree list.
+git -C "$tmp_dir/worktree-seed" init -b main >/dev/null
+git -C "$tmp_dir/worktree-seed" config user.email "test@example.com"
+git -C "$tmp_dir/worktree-seed" config user.name "Test User"
+: >"$tmp_dir/worktree-seed/file.txt"
+git -C "$tmp_dir/worktree-seed" add file.txt
+git -C "$tmp_dir/worktree-seed" commit -m "initial commit" >/dev/null
+git clone --bare "$tmp_dir/worktree-seed" "$tmp_dir/worktree-bare.git" >/dev/null 2>&1
+git -C "$tmp_dir/worktree-bare.git" worktree add "$tmp_dir/worktree-main" main >/dev/null 2>&1
+git -C "$tmp_dir/worktree-bare.git" worktree add "$tmp_dir/worktree selected" -b feature/worktree >/dev/null 2>&1
+git -C "$tmp_dir/worktree-bare.git" worktree add "$tmp_dir/worktree third" -b feature/third >/dev/null 2>&1
+# A worktree whose directory has been removed is what git reports as prunable.
+git -C "$tmp_dir/worktree-bare.git" worktree add "$tmp_dir/worktree pruned" -b feature/pruned >/dev/null 2>&1
+rm -rf "$tmp_dir/worktree pruned"
 
-cd "$tmp_dir/worktree-main" || fail "could not enter worktree main directory"
-worktree_display="$(git -C "$tmp_dir/worktree-main" worktree list | command grep -F "$tmp_dir/worktree selected")"
-export FZF_TEST_SELECTION="$tmp_dir/worktree selected"$'\t'"$worktree_display"
-wcd
-assert_pwd "$tmp_dir/worktree selected" "wcd should jump to the selected worktree path"
-pass "wcd changes directory to a selected worktree path containing spaces"
+# Guard the fixture itself: if git stopped reporting either record, the
+# exclusion assertions below would pass without testing anything.
+typeset -a fixture_porcelain_lines
+fixture_porcelain_lines=("${(@f)$(git -C "$tmp_dir/worktree-main" worktree list --porcelain)}")
+if (( ! ${fixture_porcelain_lines[(I)bare]} )); then
+  fail "fixture should contain a bare worktree record"
+fi
+if (( ! ${fixture_porcelain_lines[(I)prunable *]} )); then
+  fail "fixture should contain a prunable worktree record"
+fi
+pass "worktree fixture reports one bare and one prunable record"
 
 # The fzf stub answers with FZF_TEST_SELECTION no matter what it is fed, so
-# nothing above this point can see the paste/awk half of wcd's pipeline. These
+# nothing above this point can see the awk half of wcd's pipeline. These
 # assertions read what wcd actually wrote to fzf's stdin.
-cd "$tmp_dir/worktree-main" || fail "could not reset to worktree main directory"
+cd "$tmp_dir/worktree-main" || fail "could not enter worktree main directory"
 export FZF_TEST_STDIN_LOG="$tmp_dir/wcd-fzf-stdin.log"
-export FZF_TEST_SELECTION="$tmp_dir/worktree selected"$'\t'"$worktree_display"
+export FZF_TEST_SELECTION=""
 wcd
 cd "$tmp_dir/worktree-main" || fail "could not reset to worktree main directory"
+unset FZF_TEST_STDIN_LOG
 
 typeset -a pipeline_lines
 # .zshrc aliases cat to bat, which is not on the stub PATH.
 pipeline_lines=("${(@f)$(command cat "$tmp_dir/wcd-fzf-stdin.log")}")
 
 if (( ${#pipeline_lines} != 3 )); then
-  fail "wcd should offer one row per worktree; got ${#pipeline_lines} for 3 worktrees"
+  fail "wcd should offer one row per ordinary worktree; got ${#pipeline_lines} for 3 ordinary, 1 bare and 1 prunable"
 fi
-pass "wcd offers one row per worktree"
+pass "wcd offers one row per ordinary worktree"
+
+# git reports resolved paths, and mktemp -d hands out a symlinked one on macOS.
+bare_path="${tmp_dir:A}/worktree-bare.git"
+pruned_path="${tmp_dir:A}/worktree pruned"
+selected_row=""
 
 typeset -a offered_paths
 offered_paths=()
@@ -306,30 +324,56 @@ for pipeline_line in "${pipeline_lines[@]}"; do
   worktree_path="${pipeline_line%%$'\t'*}"
   worktree_row="${pipeline_line#*$'\t'}"
 
+  if [[ "$worktree_path" == "$bare_path" ]]; then
+    fail "wcd should not offer the bare repository; got '$worktree_path'"
+  fi
+
+  if [[ "$worktree_path" == "$pruned_path" ]]; then
+    fail "wcd should not offer a prunable worktree; got '$worktree_path'"
+  fi
+
   if [[ ! -d "$worktree_path" ]]; then
     fail "wcd's first field should be a worktree directory; got '$worktree_path'"
   fi
 
-  # git worktree list prints the path first, so a row whose display half does
-  # not start with the porcelain half means paste mispaired its two inputs.
+  # The display half is built from the same porcelain record as the path, so
+  # it starts with that path just as `git worktree list` rows do.
   if [[ "$worktree_row" != "$worktree_path"* ]]; then
-    fail "wcd should pair each porcelain path with its own listing row; '$worktree_path' got '$worktree_row'"
+    fail "wcd should pair each path with its own display row; '$worktree_path' got '$worktree_row'"
+  fi
+
+  if [[ "$worktree_path" == "${tmp_dir:A}/worktree selected" ]]; then
+    selected_row="$pipeline_line"
   fi
 
   offered_paths+=("$worktree_path")
 done
+pass "wcd does not offer the bare repository"
+pass "wcd does not offer a prunable worktree"
 pass "wcd's first field is the worktree directory cd receives"
-pass "wcd pairs each porcelain path with its own listing row"
+pass "wcd pairs each path with its own display row"
 
-# git reports resolved paths, and mktemp -d hands out a symlinked one on macOS.
+# git lists worktrees in its own order, so both sides are sorted before the
+# comparison. Without the @, a nested ${(o)array} collapses to one unsorted word.
 typeset -a expected_paths
 expected_paths=("${tmp_dir:A}/worktree-main" "${tmp_dir:A}/worktree selected" "${tmp_dir:A}/worktree third")
-if [[ "${(j:\n:)${(o)offered_paths}}" != "${(j:\n:)${(o)expected_paths}}" ]]; then
-  fail "wcd should offer every worktree path verbatim; got ${(j:, :)offered_paths}"
+if [[ "${(j:\n:)${(@o)offered_paths}}" != "${(j:\n:)${(@o)expected_paths}}" ]]; then
+  fail "wcd should offer every ordinary worktree path verbatim; got ${(j:, :)offered_paths}"
 fi
-pass "wcd offers every worktree path verbatim, spaces included"
+pass "wcd offers every ordinary worktree path verbatim, spaces included"
 
-unset FZF_TEST_STDIN_LOG
+if [[ -z "$selected_row" ]]; then
+  fail "wcd should offer the worktree the selection test picks"
+fi
+assert_contains "${selected_row#*$'\t'}" "[feature/worktree]" "wcd's display row names the worktree's branch"
+
+# Selecting a row the pipeline really produced proves the field cd splits on
+# is the one wcd wrote, not one the test made up.
+cd "$tmp_dir/worktree-main" || fail "could not reset to worktree main directory"
+export FZF_TEST_SELECTION="$selected_row"
+wcd
+assert_pwd "$tmp_dir/worktree selected" "wcd should jump to the selected worktree path"
+pass "wcd changes directory to a selected worktree path containing spaces"
 
 cd "$tmp_dir/worktree-main" || fail "could not reset to worktree main directory"
 export FZF_TEST_SELECTION=""


### PR DESCRIPTION
Closes #224

Branched from `origin/main`; not stacked on anything.

## Problem

`wcd` pasted the path column of `git worktree list --porcelain` against the human `git worktree list` rows and handed every pair to fzf. Two kinds of entry made the final `cd` fail:

- **bare** — the main repository of a bare clone. Its porcelain record is a `worktree` line followed by `bare`; there is no checkout to enter.
- **prunable** — a worktree whose directory has been removed. Its record carries a `prunable gitdir file points to non-existent location` line; the path no longer exists.

The fixture in `tests/zshrc_zoxide_test.zsh` had three ordinary checkouts and neither shape, so the `cd "${selected%%$'\t'*}"` split was never exercised against them (the issue's point).

The coordinator's decision for this issue: **exclude both bare and prunable records from the candidate list.**

## Change

`dot_zshrc.tmpl` `wcd` now reads the porcelain output alone, one blank-line-separated record at a time, and skips any record containing a `bare` or `prunable` line. The display column is built from the same record — path, 7-char HEAD, `[branch]` or `(detached HEAD)`, and a trailing `locked` when present — padded to the widest path, which is the same shape `git worktree list` prints. Building both halves from one source removes the assumption the `paste` relied on: that the porcelain and human listings stay in the same order with the same count once records are dropped.

Verified `git worktree list --porcelain` output shapes directly (git 2.50) before writing the parser:

```
worktree /…/repo.git
bare

worktree /…/wt gone
HEAD 3a206cd…
branch refs/heads/feature/gone
prunable gitdir file points to non-existent location

worktree /…/wt one
HEAD 3a206cd…
branch refs/heads/feature/one
```

### Where the code differed from the issue

Nothing material. The issue is agnostic about whether a prunable entry should be offered; the coordinator's decision settled it as "no". One detail worth stating: a `bare` record can only ever be the *main* worktree (git sets that flag from the main repository's `core.bare`), so a fixture with a bare entry needs a bare main repository — a linked worktree cannot be made bare. That is why the fixture changed shape rather than just gaining two `worktree add` calls.

## Tests

`tests/zshrc_zoxide_test.zsh` fixture is now a bare clone with linked worktrees:

- a seed repository provides the initial commit and is cloned with `git clone --bare` to `worktree-bare.git`
- `worktree-main`, `worktree selected`, `worktree third` are added from the bare repository with `git worktree add`
- `worktree pruned` is added and then `rm -rf`'d, which is what git reports as prunable

New assertions (the fixture is guarded first so the exclusions cannot pass vacuously):

- the fixture's porcelain output really contains a `bare` line and a `prunable` line
- fzf receives exactly 3 rows
- no offered path equals the bare repository path or the pruned path
- the set of offered paths equals the 3 ordinary paths (spaces included)
- the display row for `worktree selected` contains `[feature/worktree]`
- selecting the row the pipeline actually emitted for `worktree selected` (taken from the stdin log rather than composed by the test) lands `cd` in that directory
- cancelling still leaves the directory unchanged

### A latent false pass fixed on the way

The path-set comparison was `"${(j:\n:)${(o)offered_paths}}" != "${(j:\n:)${(o)expected_paths}}"`. In zsh a nested `${(o)array}` without `@` collapses to one space-joined word *before* sorting applies, so both sides were unsorted strings and the assertion passed on `main` only because the array was built in the same order as the expected list. With the bare fixture git lists paths in its own order and the comparison failed despite equal sets. Both sides now use `${(@o)…}`.

### Results

The new test fails against the old `wcd` (checked by restoring `origin/main`'s `dot_zshrc.tmpl` and re-running):

```
not ok - wcd should offer one row per ordinary worktree; got 5 for 3 ordinary, 1 bare and 1 prunable
```

With the fix:

```
$ zsh tests/zshrc_zoxide_test.zsh
ok - worktree fixture reports one bare and one prunable record
ok - wcd offers one row per ordinary worktree
ok - wcd does not offer the bare repository
ok - wcd does not offer a prunable worktree
ok - wcd's first field is the worktree directory cd receives
ok - wcd pairs each path with its own display row
ok - wcd offers every ordinary worktree path verbatim, spaces included
ok - wcd's display row names the worktree's branch
ok - wcd changes directory to a selected worktree path containing spaces
ok - cancelled wcd keeps the current directory

$ PATH="$(mise where python)/bin:$PATH" tests/run
=== summary ===
24 test files passed          (2228 ok, 0 not ok; main had 2224 ok, +4 assertions here)
```

## Docs

None. `wcd` is not described in the README or `CONTEXT.md`, no domain term changed, and no architectural decision changed, so no ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MChALHnXtiUN3X7ZHhq41Z
