### PR TITLE
Drop the claude-code cask from ADR 0008's upgrade command

### DIFF
--- a/docs/adr/0008-use-homebrew-for-optional-ai-cli-tools.md
+++ b/docs/adr/0008-use-homebrew-for-optional-ai-cli-tools.md
@@ -30,5 +30,7 @@ Provider for other shared command-line tools and development runtimes.
 - Existing vendor-installed commands are not deleted. `tpod status` and
   `tpod doctor` warn when a command outside the active Homebrew prefix shadows
   a managed cask.
-- Intentional upgrades use
-  `brew upgrade --cask claude-code codex antigravity-cli`.
+- Intentional cask upgrades use `brew upgrade --cask codex antigravity-cli`.
+  Claude Code is not upgraded through Homebrew: ADR 0017 moved it to the
+  **Claude Code Installer** at `https://claude.ai/install.sh`, and its own
+  updater owns version freshness.

--- a/tests/adr_supersession_test.sh
+++ b/tests/adr_supersession_test.sh
@@ -31,3 +31,14 @@ pass "ADR 0006 records the Claude Code vendor installer ADR 0017 restored"
 grep -F "ADR 0006's vendor-installer choice" "$adr_dir/0008-use-homebrew-for-optional-ai-cli-tools.md" >/dev/null ||
   fail "ADR 0008 still records the supersession ADR 0006 points back to"
 pass "ADR 0008 still records the supersession ADR 0006 points back to"
+
+# ADR 0017 moved Claude Code off the cask, so ADR 0008's upgrade guidance must
+# not name `claude-code` while still covering the two casks that remain.
+adr_0008="$adr_dir/0008-use-homebrew-for-optional-ai-cli-tools.md"
+adr_0008_upgrade="$(grep -F 'brew upgrade --cask' "$adr_0008")"
+assert_not_contains "$adr_0008_upgrade" 'claude-code' \
+  "ADR 0008's upgrade command does not name the claude-code cask"
+assert_contains "$adr_0008_upgrade" 'brew upgrade --cask codex antigravity-cli' \
+  "ADR 0008's upgrade command still covers the codex and antigravity-cli casks"
+assert_file_contains "$adr_0008" 'ADR 0017' \
+  "ADR 0008 points Claude Code upgrades at the vendor installer ADR 0017 records"


### PR DESCRIPTION
Closes #223

Branched from `origin/main`; independent of the other lane-B PR (#222), which edits a different paragraph of the same ADR.

## Problem

ADR 0008's Consequences ended with `brew upgrade --cask claude-code codex antigravity-cli`. ADR 0017 moved Claude Code to the **Claude Code Installer** (`https://claude.ai/install.sh`) and dropped the cask from `Brewfile.ai-cli-tools.tmpl`, so the command named a cask Terrapod no longer installs. The other two casks were still right, which made the stale third one easy to miss.

## Change

One bullet in `docs/adr/0008-use-homebrew-for-optional-ai-cli-tools.md`:

> - Intentional cask upgrades use `brew upgrade --cask codex antigravity-cli`.
>   Claude Code is not upgraded through Homebrew: ADR 0017 moved it to the
>   **Claude Code Installer** at `https://claude.ai/install.sh`, and its own
>   updater owns version freshness.

The upgrade command now matches the one ADR 0017's own Consequences give, and the sentence about the installer mirrors ADR 0017's "Claude Code's own updater owns version freshness" so the two records do not drift apart again. The supersession paragraph near the top of ADR 0008 is untouched; #222 owns that.

## Tests

`tests/adr_supersession_test.sh` gains three assertions, all against the line of ADR 0008 that carries `brew upgrade --cask`:

- it does not name `claude-code`;
- it still covers `codex antigravity-cli`;
- ADR 0008 names ADR 0017, so a reader is pointed at the installer path.

Red-checked by running the test with the ADR change temporarily set aside:

```
unexpected: claude-code
    `brew upgrade --cask claude-code codex antigravity-cli`.
not ok - ADR 0008's upgrade command does not name the claude-code cask
```

Green on the branch:

```
$ sh tests/adr_supersession_test.sh
ok - every ADR cross-reference resolves to an existing record
ok - ADR 0006 records that ADR 0008 superseded its package source
ok - ADR 0006 records the Claude Code vendor installer ADR 0017 restored
ok - ADR 0008 still records the supersession ADR 0006 points back to
ok - ADR 0008's upgrade command does not name the claude-code cask
ok - ADR 0008's upgrade command still covers the codex and antigravity-cli casks
ok - ADR 0008 points Claude Code upgrades at the vendor installer ADR 0017 records
```

Full suite:

```
$ PATH="$(mise where python)/bin:$PATH" tests/run
24 test files passed
ok: 2227  not ok: 0  skip: 0
```

`homebrew_ubuntu_smoke.sh` skipped (needs a container).

## Docs

Only the ADR itself. No `CONTEXT.md` change (no domain term moved) and no new ADR (the decision is ADR 0017's; this corrects a stale consequence in ADR 0008).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MChALHnXtiUN3X7ZHhq41Z
