### PR TITLE
Refuse a shimmed python3 in tests/run instead of hanging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,10 @@ The suite needs `chezmoi`, `zsh`, `python3`, and `jq` on `PATH`.
 `python3` has to be a real interpreter, not a mise shim. The tests that
 exercise the Jetendard helpers override `HOME`, and a shim resolving its
 tool versions under that empty `HOME` blocks on a download instead of
-running. Put the resolved interpreter's directory ahead of the shims for
-the run: `PATH="$(mise where python)/bin:$PATH" tests/run`.
+running. `tests/run` checks for this before running anything and exits
+with status 2 when `python3` resolves into the mise shim directory. Put
+the resolved interpreter's directory ahead of the shims for the run:
+`PATH="$(mise where python)/bin:$PATH" tests/run`.
 
 `tests/homebrew_ubuntu_smoke.sh` is not part of `tests/run` — it builds an
 Ubuntu container image and has to be invoked directly with Docker available.

--- a/tests/run
+++ b/tests/run
@@ -6,6 +6,24 @@
 set -u
 
 repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+
+# A mise shim for python3 does not run once a test overrides HOME: the shim
+# re-resolves its tool versions under that empty HOME and blocks on a
+# download, so the suite looks hung and an unrelated test reports the
+# failure. Refuse up front instead. The shim directory is resolved the same
+# way the executable-selection library resolves it; where mise is absent the
+# directory does not exist and the check passes without a word.
+python3_bin="$(command -v python3 2>/dev/null || true)"
+mise_shims_dir="${TERRAPOD_MISE_SHIMS_DIR:-${MISE_DATA_DIR:-${HOME:-}/.local/share/mise}/shims}"
+case "$python3_bin" in
+  "$mise_shims_dir"/*)
+    printf 'tests/run: python3 resolves to the mise shim %s\n' "$python3_bin" >&2
+    printf 'The tests override HOME, and a shim blocks on a download there instead of running.\n' >&2
+    printf 'Put the real interpreter ahead of the shims: PATH="$(mise where python)/bin:$PATH" tests/run\n' >&2
+    exit 2
+    ;;
+esac
+
 work_dir="$(mktemp -d)"
 
 cleanup() {

--- a/tests/run_shim_guard_test.sh
+++ b/tests/run_shim_guard_test.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+. "$repo_root/tests/lib/harness.sh"
+make_tmp_dir
+
+# tests/run globs test files relative to its own location, so a copy under an
+# empty tests/ directory exercises the runner's startup checks without running
+# this suite again inside itself.
+fake_repo="$tmp_dir/repo"
+mkdir -p "$fake_repo/tests"
+cp "$repo_root/tests/run" "$fake_repo/tests/run"
+
+# Stand-ins for a real interpreter and for a mise shim. Neither is a python;
+# both record being executed, which the guarded run must never do.
+real_bin="$tmp_dir/real-bin"
+shim_home="$tmp_dir/home"
+default_shims="$shim_home/.local/share/mise/shims"
+custom_data_dir="$tmp_dir/mise-data"
+custom_shims="$custom_data_dir/shims"
+executed_log="$tmp_dir/executed.log"
+: >"$executed_log"
+
+write_python3_stub() {
+  mkdir -p "$1"
+  cat >"$1/python3" <<STUB
+#!/bin/sh
+printf '%s\\n' "$1/python3" >>"$executed_log"
+STUB
+  chmod +x "$1/python3"
+}
+
+write_python3_stub "$real_bin"
+write_python3_stub "$default_shims"
+write_python3_stub "$custom_shims"
+
+# The runner needs the usual utilities; only the python3 lookup is under test.
+run_runner() {
+  set +e
+  env -u MISE_DATA_DIR -u TERRAPOD_MISE_SHIMS_DIR HOME="$shim_home" "$@" \
+    sh "$fake_repo/tests/run" >"$tmp_dir/stdout" 2>"$tmp_dir/stderr"
+  runner_status=$?
+  set -e
+}
+
+guidance='PATH="$(mise where python)/bin:$PATH" tests/run'
+
+run_runner PATH="$default_shims:$PATH"
+if [ "$runner_status" != 2 ]; then
+  fail "tests/run refuses a python3 under the default mise shim directory (exit $runner_status)"
+fi
+pass "tests/run refuses a python3 under the default mise shim directory"
+assert_file_contains "$tmp_dir/stderr" "$default_shims/python3" \
+  "the refusal names the shim python3 resolved to"
+assert_file_contains "$tmp_dir/stderr" "$guidance" \
+  "the refusal carries the PATH prefix AGENTS.md documents"
+assert_file_not_contains "$tmp_dir/stdout" "test files passed" \
+  "a refused run reaches no test file"
+
+run_runner PATH="$custom_shims:$PATH" MISE_DATA_DIR="$custom_data_dir"
+if [ "$runner_status" != 2 ]; then
+  fail "tests/run honours MISE_DATA_DIR when locating the shim directory (exit $runner_status)"
+fi
+pass "tests/run honours MISE_DATA_DIR when locating the shim directory"
+
+run_runner PATH="$custom_shims:$PATH" TERRAPOD_MISE_SHIMS_DIR="$custom_shims"
+if [ "$runner_status" != 2 ]; then
+  fail "tests/run honours TERRAPOD_MISE_SHIMS_DIR like the executable-selection library (exit $runner_status)"
+fi
+pass "tests/run honours TERRAPOD_MISE_SHIMS_DIR like the executable-selection library"
+
+if [ -s "$executed_log" ]; then
+  fail "a refused run never executes the shim; ran: $(cat "$executed_log")"
+fi
+pass "a refused run never executes the shim"
+
+# A shim directory that exists but sits behind a real interpreter on PATH is
+# fine, and so is a machine without mise at all; both start the suite quietly.
+run_runner PATH="$real_bin:$default_shims:$PATH"
+if [ "$runner_status" != 0 ]; then
+  fail "tests/run starts when a real python3 is ahead of the shims (exit $runner_status): $(cat "$tmp_dir/stderr")"
+fi
+pass "tests/run starts when a real python3 is ahead of the shims"
+assert_file_contains "$tmp_dir/stdout" "0 test files passed" \
+  "a run that passes the guard proceeds to the test files"
+assert_file_not_contains "$tmp_dir/stderr" "mise shim" \
+  "a run that passes the guard says nothing about shims"
+
+rm -rf "$shim_home/.local"
+run_runner PATH="$real_bin:$PATH"
+if [ "$runner_status" != 0 ]; then
+  fail "tests/run starts on a machine without mise (exit $runner_status): $(cat "$tmp_dir/stderr")"
+fi
+pass "tests/run starts on a machine without mise"
+assert_not_contains "$(cat "$tmp_dir/stderr")" "mise" \
+  "a machine without mise sees no shim guidance"


### PR DESCRIPTION
Closes #221

Branched from `main`; not stacked.

## Problem

On a Terrapod-managed machine `dot_config/mise/config.toml` pins `python = "3.13"`, so `python3` resolves to a mise shim. The Jetendard test files override `HOME`; the shim then re-resolves its tool versions under the now-empty `HOME` and blocks trying to fetch an interpreter. The suite looks hung for 90+ seconds and `terrapod_command_test.sh` fails on an unrelated-looking assertion. `AGENTS.md` documents the cause and the `PATH="$(mise where python)/bin:$PATH"` prefix that avoids it, but a contributor only finds that after waiting out the hang.

## Change

`tests/run` checks before running anything. When `command -v python3` lands inside the mise shim directory it prints the guidance `AGENTS.md` already carries to stderr and exits 2:

```
tests/run: python3 resolves to the mise shim /Users/minu/.local/share/mise/shims/python3
The tests override HOME, and a shim blocks on a download there instead of running.
Put the real interpreter ahead of the shims: PATH="$(mise where python)/bin:$PATH" tests/run
```

The shim directory is resolved with the expression `dot_local/lib/terrapod/executable_executable-selection` already uses for the same purpose, `${TERRAPOD_MISE_SHIMS_DIR:-${MISE_DATA_DIR:-$HOME/.local/share/mise}/shims}`, so the runner and the installer agree on where a shim lives. Where mise is absent that directory does not exist, nothing on PATH can sit under it, and the check passes without a word. Where `python3` is absent altogether the check also passes, and the suite fails on the missing interpreter as before.

Exit status 2 rather than 1 so a refused start is distinguishable from a failed suite.

`AGENTS.md`'s paragraph on the shim now says the runner enforces this instead of leaving it as advice.

## Tests

New `tests/run_shim_guard_test.sh` (12 assertions). Nothing in the repo invoked `tests/run` from a test, and calling it directly would run the suite inside itself, so the test copies the runner under an empty `tests/` directory: the runner globs test files relative to its own location, finds none, and reports `0 test files passed`. Against that copy it checks:

- a stub `python3` under `$HOME/.local/share/mise/shims` is refused with exit 2, the message names the resolved shim path and carries the `PATH="$(mise where python)/bin:$PATH" tests/run` prefix, and no test file is reached;
- the same with the shim directory relocated through `MISE_DATA_DIR`, and through `TERRAPOD_MISE_SHIMS_DIR`;
- the stub is never executed on a refused run (each stub logs its own invocation);
- a real interpreter ahead of an existing shim directory starts the runner with exit 0 and no mention of shims;
- with no mise directory at all the runner starts with exit 0 and stderr never mentions mise.

Red-check: with `tests/run` reverted to `main` the first case fails with `not ok - tests/run refuses a python3 under the default mise shim directory (exit 0)`.

On this machine, where `python3` is the shim, an unprefixed `tests/run` now exits 2 in well under a second with the message above, instead of hanging. In a stock `ubuntu:24.04` container with no mise and no python3 the copied runner starts silently and reports `0 test files passed`, exit 0.

Full suite on this branch:

```
$ PATH="$(mise where python)/bin:$PATH" tests/run
=== summary ===
25 test files passed
ok: 2236, skip: 0, exit 0
```

## Docs

`AGENTS.md`: the `python3` paragraph now states that `tests/run` refuses a shimmed interpreter with status 2, keeping the PATH prefix as the remedy. No `CONTEXT.md` change (no domain term moved) and no ADR (no architectural decision changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MChALHnXtiUN3X7ZHhq41Z