### PR TITLE
Record every ADR supersession on the superseded side too

### DIFF
--- a/docs/adr/0001-use-mise-for-modern-cli-tools.md
+++ b/docs/adr/0001-use-mise-for-modern-cli-tools.md
@@ -2,6 +2,8 @@
 
 The macOS Terminal Profile and VPS Shell Profile should share one Core Shell Stack, but Homebrew on macOS, APT on Ubuntu, standalone aqua, and manual GitHub release installers each create different package names, versions, and upgrade paths. We will use OS package managers only to bootstrap each machine and install GUI or platform-specific packages, then use mise with its aqua backend for modern CLI tools and mise runtimes for language tools. This keeps macOS and Ubuntu aligned without introducing Homebrew on Linux or a second standalone aqua configuration.
 
+ADR 0008 supersedes this decision's blanket rejection of Homebrew on Linux, for the Optional AI Tool Stack only. ADR 0010 then supersedes its assignment of modern CLI tools to mise/aqua and its rejection of Linuxbrew: Homebrew is the Modern CLI Provider for the Core Shell Stack on both profiles, so CLI upgrades no longer move to `mise upgrade`. mise remains the Development Runtime Manager for language runtimes, and OS package managers still only bootstrap each machine and install GUI or platform-specific packages.
+
 ## Considered Options
 
 - Homebrew for macOS and APT for Ubuntu: rejected because Ubuntu 24.04 has missing, older, or renamed packages for several Core Shell Stack tools.

--- a/docs/adr/0003-use-terrapod-as-the-dotfiles-management-tool.md
+++ b/docs/adr/0003-use-terrapod-as-the-dotfiles-management-tool.md
@@ -2,6 +2,8 @@
 
 This repository will present Terrapod as the user-facing installer and management command for personal dotfiles while keeping chezmoi as the internal apply engine. This avoids requiring users to install or remember chezmoi directly, lets first-run setup collect Preset and macOS App Group choices before applying dotfiles, and gives routine commands such as status, diff, apply, and update room to add profile, installer, and validation context around chezmoi behavior.
 
+ADR 0007 supersedes this decision's consequence that the first-run installer stops whenever the default chezmoi source directory already exists: the installer now resumes from an existing checked-out Terrapod Source Repository, force-applies only the recovery core, then runs the full declared-state apply. Terrapod as the user-facing command over chezmoi, and the rest of this decision, remain in force.
+
 ## Considered Options
 
 - Keep chezmoi as the documented entry point: rejected because the first setup flow would still require users to install chezmoi first and manually discover local configuration flags.

--- a/docs/adr/0008-use-homebrew-for-optional-ai-cli-tools.md
+++ b/docs/adr/0008-use-homebrew-for-optional-ai-cli-tools.md
@@ -10,6 +10,18 @@ ADR 0006's vendor-installer choice only for the Optional AI Tool Stack. APT
 remains Ubuntu's Bootstrap Package Manager, and mise remains the Modern CLI
 Provider for other shared command-line tools and development runtimes.
 
+ADR 0010 supersedes this decision's restriction of Linuxbrew to the Optional AI
+Tool Stack: standard-prefix Homebrew is the **Modern CLI Provider** for the Core
+Shell Stack on both profiles, so the stack no longer governs whether Ubuntu
+bootstraps Homebrew. ADR 0015 supersedes the claim that the stack installs from
+the same casks on both profiles and the consequence that Ubuntu bootstraps
+Homebrew only when the stack is enabled; the stack is scoped to the **macOS
+Terminal Profile**. ADR 0017 supersedes the package source for Claude Code alone,
+which the **Claude Code Installer** now installs while `antigravity-cli` and
+`codex` stay Homebrew casks. This decision's choice of Homebrew over vendor
+installers stays in force on macOS for those two casks, as does
+`Brewfile.ai-cli-tools.tmpl` as their canonical declaration.
+
 ## Considered Options
 
 - Keep vendor installers on both profiles: rejected because installation,

--- a/docs/adr/0010-use-homebrew-for-shared-cli-tools.md
+++ b/docs/adr/0010-use-homebrew-for-shared-cli-tools.md
@@ -4,6 +4,8 @@ The macOS Terminal Profile and VPS Shell Profile use Homebrew as the Modern CLI 
 
 This decision supersedes ADR 0001's assignment of modern CLI tools to mise/aqua and its rejection of Linuxbrew, and ADR 0008's restriction of Linuxbrew to the Optional AI Tool Stack. It does not change the macOS Desktop App Stack, the Jetendard release installer, optional-stack semantics, or Terrapod's non-destructive apply contract.
 
+ADR 0011 supersedes this decision's non-destructive apply consequence and its choice to leave all legacy payloads unmanaged. ADR 0012 then restores the non-destructive apply contract and keeps package source migration advisory-only. This decision's canonical Homebrew and mise ownership assignments and its `brew bundle --no-upgrade` contract remain in force.
+
 ## Considered Options
 
 - Keep mise/aqua for shared CLI tools: rejected because GUI apps, AI CLIs, and ordinary CLIs would retain separate installation and recovery owners.

--- a/docs/adr/0011-reconcile-managed-package-sources.md
+++ b/docs/adr/0011-reconcile-managed-package-sources.md
@@ -8,6 +8,8 @@ Every active effective Terrapod package declaration is a Managed Package. Terrap
 
 This decision supersedes ADR 0010's non-destructive apply consequence and its choice to leave all legacy payloads unmanaged. It also supersedes the source-only `tpod update` decision recorded in the domain context. ADR 0010's canonical Homebrew and mise ownership assignments and its `brew bundle --no-upgrade` contract remain in force.
 
+ADR 0012 supersedes this decision's ownership registry, deep alternate-provider scan, removal plan, confirmation, lock, and migration warning state. It restores ADR 0010's non-destructive apply contract. This decision's `tpod update` handoff to the refreshed `tpod apply` and the first-run installer's use of the installed `tpod apply` remain in force.
+
 ## Considered Options
 
 - Keep warning-only legacy detection: rejected because canonical installation alone does not resolve secondary duplicates or safely converge package ownership.

--- a/tests/adr_supersession_test.sh
+++ b/tests/adr_supersession_test.sh
@@ -17,20 +17,54 @@ for adr in "$adr_dir"/*.md; do
 done
 pass "every ADR cross-reference resolves to an existing record"
 
-# ADR 0008 has always recorded that it supersedes ADR 0006; this is the reverse
-# direction, so a reader landing on 0006 is not left believing it is current.
-adr_0006="$adr_dir/0006-use-official-installers-for-ai-cli-tools.md"
-grep -F 'ADR 0008 supersedes this decision' "$adr_0006" >/dev/null ||
-  fail "ADR 0006 records that ADR 0008 superseded its package source"
-pass "ADR 0006 records that ADR 0008 superseded its package source"
+# Supersession is recorded in prose on both sides: the superseding ADR says
+# "This decision supersedes ADR NNNN's ..." and the superseded one answers
+# "ADR MMMM supersedes this decision's ...". Every sentence that speaks of
+# supersession therefore has to be matched by a mention of this ADR in each
+# other ADR that sentence names, whichever side of the link it sits on.
+#
+# Sentences are cut at ". " after the file is flattened to one line, so a
+# claim wrapped over several lines is still read as one sentence.
+supersession_links() {
+  tr '\n' ' ' <"$1" | awk '
+    {
+      count = split($0, sentences, /\. /)
+      for (i = 1; i <= count; i++) {
+        sentence = sentences[i]
+        if (sentence !~ /supersed/) continue
+        while (match(sentence, /ADR [0-9][0-9][0-9][0-9]/)) {
+          print substr(sentence, RSTART + 4, 4)
+          sentence = substr(sentence, RSTART + RLENGTH)
+        }
+      }
+    }'
+}
 
-grep -F 'ADR 0017' "$adr_0006" >/dev/null ||
-  fail "ADR 0006 records the Claude Code vendor installer ADR 0017 restored"
-pass "ADR 0006 records the Claude Code vendor installer ADR 0017 restored"
+link_count=0
+for adr in "$adr_dir"/*.md; do
+  adr_name="${adr##*/}"
+  adr_number="${adr_name%%-*}"
 
-grep -F "ADR 0006's vendor-installer choice" "$adr_dir/0008-use-homebrew-for-optional-ai-cli-tools.md" >/dev/null ||
-  fail "ADR 0008 still records the supersession ADR 0006 points back to"
-pass "ADR 0008 still records the supersession ADR 0006 points back to"
+  for other in $(supersession_links "$adr" | sort -u); do
+    [ "$other" != "$adr_number" ] || continue
+    link_count=$((link_count + 1))
+    other_adr="$(find "$adr_dir" -name "$other-*.md")"
+
+    grep -F "ADR $adr_number" "$other_adr" >/dev/null ||
+      fail "ADR $other names ADR $adr_number back ($adr_name links them in a supersession sentence)"
+    pass "ADR $other names ADR $adr_number back"
+  done
+done
+
+[ "$link_count" -gt 0 ] ||
+  fail "at least one supersession sentence was found (the sentence scan is not silently empty)"
+pass "at least one supersession sentence was found"
+
+# ADR 0017 supersedes ADR 0008, not ADR 0006, so the invariant above does not
+# reach this: a reader of 0006 still has to learn that a vendor installer came
+# back for Claude Code.
+assert_file_contains "$adr_dir/0006-use-official-installers-for-ai-cli-tools.md" 'ADR 0017' \
+  "ADR 0006 records the Claude Code vendor installer ADR 0017 restored"
 
 # ADR 0017 moved Claude Code off the cask, so ADR 0008's upgrade guidance must
 # not name `claude-code` while still covering the two casks that remain.


### PR DESCRIPTION
Closes #222

Rebased onto `origin/main` after #228 (#223) merged. Both touched `docs/adr/0008-*.md` and `tests/adr_supersession_test.sh`; the ADR merged cleanly (different paragraphs) and the test conflict was resolved by keeping #228's three upgrade-command assertions after the invariant.

## Problem

Seven ADRs state that they supersede an earlier one (0007→0003, 0008→0001·0006, 0010→0001·0008, 0011→0010, 0012→0011, 0015→0008, 0017→0008). #215 gave ADR 0006 the matching back-reference, but 0001, 0003, 0008, 0010, and 0011 still said nothing. A reader of ADR 0001 was told CLI upgrades move to `mise upgrade`, which ADR 0010 reversed; a reader of ADR 0003 was told the installer stops on an existing source directory, which ADR 0007 reversed. `tests/adr_supersession_test.sh` only checked the 0006↔0008 pair, so nothing stopped the next gap.

## Change

### Five back-reference paragraphs

Each superseded ADR gets one paragraph directly after its decision, before Considered Options, in the same voice as the one ADR 0006 received in #215: which ADR supersedes it, what was replaced, and what remains in force. The wording is lifted from the superseding ADR rather than re-derived, so the two sides agree:

- **0001** ← 0008 (blanket rejection of Homebrew on Linux, for the Optional AI Tool Stack only), then ← 0010 (mise/aqua for modern CLI tools and the rejection of Linuxbrew). mise as the Development Runtime Manager and OS package managers as bootstrap only remain.
- **0003** ← 0007 (the installer stopping when the default chezmoi source directory exists). Terrapod as the command over chezmoi remains.
- **0008** ← 0010 (Linuxbrew restricted to the stack), ← 0015 (same casks on both profiles; Ubuntu bootstrapping Homebrew only for the stack), ← 0017 (package source for Claude Code alone). Homebrew for `antigravity-cli` and `codex` on macOS, and `Brewfile.ai-cli-tools.tmpl` as their declaration, remain.
- **0010** ← 0011 (non-destructive apply consequence; leaving legacy payloads unmanaged), with a sentence noting ADR 0012 restored the non-destructive contract. Ownership assignments and `brew bundle --no-upgrade` remain.
- **0011** ← 0012 (ownership registry, deep scan, removal plan, confirmation, lock, migration warning state). The `tpod update` handoff and the installer's use of `tpod apply` remain.

Each file keeps its own line-wrapping style (0008 wraps at 80 columns, the others do not).

### The invariant

`tests/adr_supersession_test.sh` drops the two 0006↔0008 pair assertions and replaces them with one rule over every file in `docs/adr`:

> In every sentence that contains `supersed`, every other `ADR NNNN` the sentence names must mention this ADR's number somewhere.

The file is flattened to one line and cut at `. `, so a claim wrapped over several lines is still one sentence. Reading "every ADR named in the sentence" rather than only "the number after `supersedes`" makes the rule symmetric: a forward claim (`This decision supersedes ADR 0010's …`) requires 0010 to name the claimant, and a back-reference (`ADR 0012 supersedes this decision's …`) requires 0012 to name the file it sits in. Deleting either side fails. A guard asserts the scan found at least one sentence, so a regex slip cannot turn the whole check into a silent pass.

The sentence scan on the current tree finds exactly the seven claims from the issue plus 0006's back-reference and nothing else:

```
0006 -> 0008
0007 -> 0003
0008 -> 0001 0006
0010 -> 0001 0008
0011 -> 0010
0012 -> 0011
0015 -> 0008
0017 -> 0008
```

Kept as a specific assertion: ADR 0006 names ADR 0017. 0017 supersedes 0008, not 0006, so the invariant cannot derive it, and it is the one thing that stops a 0006 reader concluding no AI CLI uses a vendor installer.

One deliberate wording choice: the 0011 paragraph says "It restores ADR 0010's non-destructive apply contract" as its own sentence (mirroring 0012's text) rather than joining it to the `supersedes` sentence, so the invariant does not read it as a 0011↔0010 supersession claim.

## Tests

Red on the current tree, before any ADR edit, as the issue predicts:

```
ok - every ADR cross-reference resolves to an existing record
ok - ADR 0008 names ADR 0006 back
not ok - ADR 0003 names ADR 0007 back (0007-make-first-run-installation-recoverable.md links them in a supersession sentence)
```

Both directions red-checked after the edits:

```
$ # delete the new paragraph from ADR 0010
not ok - ADR 0010 names ADR 0011 back (0011-reconcile-managed-package-sources.md links them in a supersession sentence)

$ # append "This decision supersedes ADR 0002." to ADR 0013
not ok - ADR 0002 names ADR 0013 back (0013-scope-the-mobile-dev-app-group.md links them in a supersession sentence)
```

Green on the branch: 18 link assertions (one per direction of each of the nine pairs), the non-empty guard, the 0006→0017 check, and the three upgrade-command assertions from #228.

```
$ sh tests/adr_supersession_test.sh
ok - every ADR cross-reference resolves to an existing record
ok - ADR 0008 names ADR 0001 back
ok - ADR 0010 names ADR 0001 back
ok - ADR 0007 names ADR 0003 back
ok - ADR 0008 names ADR 0006 back
ok - ADR 0003 names ADR 0007 back
ok - ADR 0001 names ADR 0008 back
ok - ADR 0006 names ADR 0008 back
ok - ADR 0010 names ADR 0008 back
ok - ADR 0015 names ADR 0008 back
ok - ADR 0017 names ADR 0008 back
ok - ADR 0001 names ADR 0010 back
ok - ADR 0008 names ADR 0010 back
ok - ADR 0011 names ADR 0010 back
ok - ADR 0010 names ADR 0011 back
ok - ADR 0012 names ADR 0011 back
ok - ADR 0011 names ADR 0012 back
ok - ADR 0008 names ADR 0015 back
ok - ADR 0008 names ADR 0017 back
ok - at least one supersession sentence was found
ok - ADR 0006 records the Claude Code vendor installer ADR 0017 restored
ok - ADR 0008's upgrade command does not name the claude-code cask
ok - ADR 0008's upgrade command still covers the codex and antigravity-cli casks
ok - ADR 0008 points Claude Code upgrades at the vendor installer ADR 0017 records
```

Full suite:

```
$ PATH="$(mise where python)/bin:$PATH" tests/run
25 test files passed
ok: 2261  not ok: 0  skip: 0
```

`homebrew_ubuntu_smoke.sh` skipped (needs a container).

## Docs

Only the five ADRs. No `CONTEXT.md` change (no domain term moved) and no new ADR (no decision changed; the existing ones are now recorded from both sides).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MChALHnXtiUN3X7ZHhq41Z
