### PR TITLE
Test the Hammerspoon leader modal and Ghostty retry through a stubbed hs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,16 @@ jobs:
           sudo apt-get update
           sudo apt-get install --yes zsh
 
+      # tests/hammerspoon_runtime_test.sh skips without a Lua interpreter.
+      # Both runners get one so the skip never hides a regression in CI.
+      - name: Install Lua
+        if: runner.os == 'Linux'
+        run: sudo apt-get install --yes lua5.4
+
+      - name: Install Lua
+        if: runner.os == 'macOS'
+        run: brew install lua
+
       - name: Install chezmoi
         run: |
           mkdir -p "$HOME/.local/bin"
@@ -41,6 +51,7 @@ jobs:
           zsh --version
           python3 --version
           jq --version
+          if command -v lua5.4 >/dev/null 2>&1; then lua5.4 -v; else lua -v; fi
 
       # Terrapod Setup refuses to run whenever CI is set, and the setup tests
       # drive it through a PTY. That guard is itself product behavior the same

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,12 @@ and exits non-zero when any file fails.
 
 The suite needs `chezmoi`, `zsh`, `python3`, and `jq` on `PATH`.
 
+A Lua interpreter (`lua5.4`, `lua`, or `luajit`, in that order) is optional:
+`tests/hammerspoon_runtime_test.sh` loads `dot_hammerspoon/init.lua` through
+it with `hs` stubbed, and reports a skip instead of running when none is
+found. CI installs one on both runners so the skip never hides a regression
+there.
+
 `python3` has to be a real interpreter, not a mise shim. The tests that
 exercise the Jetendard helpers override `HOME`, and a shim resolving its
 tool versions under that empty `HOME` blocks on a download instead of

--- a/tests/fixtures/hammerspoon_hs_stub.lua
+++ b/tests/fixtures/hammerspoon_hs_stub.lua
@@ -1,0 +1,362 @@
+-- A recording stand-in for the `hs` global that dot_hammerspoon/init.lua
+-- expects Hammerspoon to provide.
+--
+-- Loading this file defines global `hs` and returns a harness table. Only the
+-- API init.lua actually calls is implemented; anything else is a hard error so
+-- a new hs call in init.lua fails the test instead of passing by accident.
+--
+-- Everything init.lua does through `hs` lands in `harness.trace`, one line per
+-- call, in order. The test driver reads that trace; nothing here asserts.
+--
+-- Timers never fire on their own. `hs.timer.doAfter` queues the callback and
+-- `harness.flushTimers()` runs the queue in delay order, so a scenario decides
+-- exactly when Hammerspoon's clock advances.
+
+local harness = {
+  trace = {},
+  timers = {},
+  hotkeys = {},
+  modals = {},
+  appWatchers = {},
+  windowSubscriptions = {},
+  apps = {},
+  frontmost = nil,
+  currentSourceID = "com.apple.inputmethod.Korean.2SetKorean",
+  -- hs.keycodes.currentSourceID(id) and hs.keycodes.setLayout(name) report
+  -- these results. When one succeeds the current source becomes its target,
+  -- the way the real calls change the input source.
+  setSourceSucceeds = true,
+  setLayoutSucceeds = true,
+}
+
+local function record(line)
+  table.insert(harness.trace, line)
+end
+
+local function formatMods(mods)
+  if #mods == 0 then
+    return "none"
+  end
+
+  local copy = {}
+  for _, mod in ipairs(mods) do
+    table.insert(copy, mod)
+  end
+  table.sort(copy)
+  return table.concat(copy, "+")
+end
+
+local function chordName(mods, key)
+  return formatMods(mods) .. " " .. key
+end
+
+-- hs.hotkey.bind and modal:bind accept an optional message string before the
+-- pressed function. init.lua never passes one, but the stub accepts either
+-- shape so a future edit does not silently bind nothing.
+local function splitHotkeyArgs(...)
+  local first, second = ...
+  if type(first) == "function" then
+    return first, second
+  end
+  return second, (select(3, ...))
+end
+
+-- Application objects --------------------------------------------------------
+
+local appMethods = {}
+appMethods.__index = appMethods
+
+function appMethods:bundleID()
+  return self.id
+end
+
+function appMethods:isHidden()
+  return self.hidden
+end
+
+function appMethods:unhide()
+  record("app.unhide " .. self.id)
+  self.hidden = false
+end
+
+function appMethods:activate()
+  record("app.activate " .. self.id)
+  harness.frontmost = self
+  return true
+end
+
+-- Registers a running application the scenario can return from
+-- hs.application.get and hand to activateApp.
+function harness.addApp(bundleID, options)
+  options = options or {}
+  local app = setmetatable({ id = bundleID, hidden = options.hidden or false }, appMethods)
+  harness.apps[bundleID] = app
+  return app
+end
+
+-- Replays what Hammerspoon does when an app comes to the front: the frontmost
+-- application changes and every hs.application.watcher hears `activated`.
+function harness.activateApp(app)
+  harness.frontmost = app
+  for _, callback in ipairs(harness.appWatchers) do
+    callback(app and app.id or nil, hs.application.watcher.activated, app)
+  end
+end
+
+-- Fires every subscriber init.lua registered for the given window event.
+function harness.focusWindow(event)
+  for _, subscription in ipairs(harness.windowSubscriptions) do
+    if subscription.event == event then
+      subscription.callback()
+    end
+  end
+end
+
+-- Key events ----------------------------------------------------------------
+
+-- An entered modal's binding wins over a global hotkey for the same chord,
+-- which is how Hammerspoon resolves the two while a modal is active.
+function harness.press(key, mods)
+  mods = mods or {}
+  local chord = chordName(mods, key)
+
+  for _, modal in ipairs(harness.modals) do
+    if modal.entered and modal.bindings[chord] then
+      record("press " .. chord .. " (modal)")
+      modal.bindings[chord].pressed()
+      return
+    end
+  end
+
+  local hotkey = harness.hotkeys[chord]
+  if not hotkey then
+    error("no hotkey bound for " .. chord)
+  end
+
+  record("press " .. chord)
+  hotkey.pressed()
+end
+
+function harness.release(key, mods)
+  mods = mods or {}
+  local chord = chordName(mods, key)
+  local hotkey = harness.hotkeys[chord]
+  if not hotkey then
+    error("no hotkey bound for " .. chord)
+  end
+
+  record("release " .. chord)
+  if hotkey.released then
+    hotkey.released()
+  end
+end
+
+-- Timers --------------------------------------------------------------------
+
+local timerMethods = {}
+timerMethods.__index = timerMethods
+
+function timerMethods:stop()
+  if not self.stopped and not self.fired then
+    record(string.format("timer.stop %.2f", self.delay))
+  end
+  self.stopped = true
+end
+
+function harness.pendingTimers()
+  local count = 0
+  for _, timer in ipairs(harness.timers) do
+    if not timer.stopped and not timer.fired then
+      count = count + 1
+    end
+  end
+  return count
+end
+
+-- Runs queued timers in delay order until none are left, including timers a
+-- callback queues while the flush is running. A callback that stops a later
+-- timer keeps that timer from firing, as it would under a real clock. With a
+-- limit, at most that many timers fire so a scenario can act between two.
+function harness.flushTimers(limit)
+  local fired = 0
+  while limit == nil or fired < limit do
+    local due = nil
+    for _, timer in ipairs(harness.timers) do
+      if not timer.stopped and not timer.fired and (due == nil or timer.delay < due.delay) then
+        due = timer
+      end
+    end
+
+    if due == nil then
+      return
+    end
+
+    due.fired = true
+    fired = fired + 1
+    record(string.format("timer.fire %.2f", due.delay))
+    due.callback()
+  end
+end
+
+-- Output --------------------------------------------------------------------
+
+function harness.printTrace()
+  for _, line in ipairs(harness.trace) do
+    print(line)
+  end
+end
+
+-- hs ------------------------------------------------------------------------
+
+local function unsupported(name)
+  return setmetatable({}, {
+    __index = function(_, key)
+      error("hs stub does not implement " .. name .. "." .. tostring(key), 2)
+    end,
+  })
+end
+
+hs = unsupported("hs")
+
+hs.application = unsupported("hs.application")
+
+function hs.application.get(bundleID)
+  return harness.apps[bundleID]
+end
+
+function hs.application.launchOrFocusByBundleID(bundleID)
+  record("application.launchOrFocusByBundleID " .. bundleID)
+  return harness.apps[bundleID] ~= nil
+end
+
+function hs.application.frontmostApplication()
+  return harness.frontmost
+end
+
+hs.application.watcher = unsupported("hs.application.watcher")
+hs.application.watcher.activated = "activated"
+
+function hs.application.watcher.new(callback)
+  local watcher = { callback = callback }
+  function watcher:start()
+    record("application.watcher.start")
+    table.insert(harness.appWatchers, self.callback)
+    return self
+  end
+  return watcher
+end
+
+hs.alert = unsupported("hs.alert")
+
+function hs.alert.show(message)
+  record("alert.show " .. (message:gsub("\n", "\\n")))
+  return "alert-" .. #harness.trace
+end
+
+function hs.alert.closeSpecific(id)
+  record("alert.closeSpecific " .. tostring(id))
+end
+
+hs.keycodes = unsupported("hs.keycodes")
+
+function hs.keycodes.currentSourceID(sourceID)
+  if sourceID == nil then
+    return harness.currentSourceID
+  end
+
+  record("keycodes.currentSourceID set " .. sourceID)
+  if harness.setSourceSucceeds then
+    harness.currentSourceID = sourceID
+  end
+  return harness.setSourceSucceeds
+end
+
+function hs.keycodes.setLayout(name)
+  record("keycodes.setLayout " .. name)
+  if harness.setLayoutSucceeds then
+    harness.currentSourceID = "com.apple.keylayout." .. name
+  end
+  return harness.setLayoutSucceeds
+end
+
+hs.timer = unsupported("hs.timer")
+
+function hs.timer.doAfter(delay, callback)
+  local timer = setmetatable({ delay = delay, callback = callback, stopped = false, fired = false }, timerMethods)
+  record(string.format("timer.doAfter %.2f", delay))
+  table.insert(harness.timers, timer)
+  return timer
+end
+
+hs.hotkey = unsupported("hs.hotkey")
+
+function hs.hotkey.bind(mods, key, ...)
+  local pressed, released = splitHotkeyArgs(...)
+  local chord = chordName(mods, key)
+  record("hotkey.bind " .. chord)
+  harness.hotkeys[chord] = { pressed = pressed, released = released }
+end
+
+hs.hotkey.modal = unsupported("hs.hotkey.modal")
+
+local modalMethods = {}
+modalMethods.__index = modalMethods
+
+function modalMethods:bind(mods, key, ...)
+  local pressed, released = splitHotkeyArgs(...)
+  local chord = chordName(mods, key)
+  record("modal.bind " .. chord)
+  self.bindings[chord] = { pressed = pressed, released = released }
+  return self
+end
+
+function modalMethods:enter()
+  record("modal.enter")
+  self.entered = true
+  return self
+end
+
+function modalMethods:exit()
+  record("modal.exit")
+  self.entered = false
+  return self
+end
+
+function hs.hotkey.modal.new()
+  local modal = setmetatable({ bindings = {}, entered = false }, modalMethods)
+  table.insert(harness.modals, modal)
+  return modal
+end
+
+hs.screen = unsupported("hs.screen")
+
+function hs.screen.mainScreen()
+  return "main-screen"
+end
+
+function hs.reload()
+  record("reload")
+end
+
+hs.window = unsupported("hs.window")
+hs.window.filter = unsupported("hs.window.filter")
+hs.window.filter.windowFocused = "windowFocused"
+
+function hs.window.filter.new()
+  local filter = {}
+
+  function filter:setAppFilter(appName)
+    record("window.filter.setAppFilter " .. appName)
+    return self
+  end
+
+  function filter:subscribe(event, callback)
+    record("window.filter.subscribe " .. event)
+    table.insert(harness.windowSubscriptions, { event = event, callback = callback })
+    return self
+  end
+
+  return filter
+end
+
+return harness

--- a/tests/hammerspoon_runtime_test.sh
+++ b/tests/hammerspoon_runtime_test.sh
@@ -1,0 +1,314 @@
+#!/bin/sh
+# Runtime behavior of dot_hammerspoon/init.lua: the leader-key modal and the
+# Ghostty input-source retry loop.
+#
+# tests/hammerspoon_config_test.sh reads the appBindings table as text. This
+# file instead loads the real init.lua into a Lua interpreter with the `hs`
+# global replaced by tests/fixtures/hammerspoon_hs_stub.lua, which records
+# every Hammerspoon call it receives. Each scenario below drives init.lua
+# through that stub (key presses, app activations, timer flushes) and asserts
+# on the recorded trace.
+#
+# The interpreter is optional: without lua5.4, lua or luajit on PATH the whole
+# file reports a single skip so tests/run stays green but says so.
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+. "$repo_root/tests/lib/harness.sh"
+hammerspoon_config="$repo_root/dot_hammerspoon/init.lua"
+hs_stub="$repo_root/tests/fixtures/hammerspoon_hs_stub.lua"
+make_tmp_dir
+
+lua_bin=""
+for candidate in lua5.4 lua luajit; do
+  if command -v "$candidate" >/dev/null 2>&1; then
+    lua_bin="$(command -v "$candidate")"
+    break
+  fi
+done
+
+if [ -z "$lua_bin" ]; then
+  skip "Hammerspoon runtime behavior (needs lua5.4, lua or luajit on PATH)"
+  exit 0
+fi
+
+# Writes stdin to $tmp_dir/<name>.lua, runs it with the stub and init.lua
+# paths as arg[1] and arg[2], and prints its stdout. A Lua error fails the
+# test here so a broken scenario never reads as a missing trace line.
+run_scenario() {
+  scenario_name="$1"
+  scenario_file="$tmp_dir/$scenario_name.lua"
+  cat >"$scenario_file"
+
+  if ! "$lua_bin" "$scenario_file" "$hs_stub" "$hammerspoon_config" >"$tmp_dir/$scenario_name.out" 2>"$tmp_dir/$scenario_name.err"; then
+    printf '%s\n' "scenario $scenario_name failed under $lua_bin:" >&2
+    sed 's/^/  /' "$tmp_dir/$scenario_name.err" >&2
+    fail "Hammerspoon runtime scenario $scenario_name runs to completion"
+  fi
+
+  cat "$tmp_dir/$scenario_name.out"
+}
+
+count_lines() {
+  printf '%s\n' "$1" | grep -F -c -e "$2" || true
+}
+
+assert_count() {
+  haystack="$1"
+  needle="$2"
+  expected="$3"
+  message="$4"
+  actual="$(count_lines "$haystack" "$needle")"
+
+  if [ "$actual" -ne "$expected" ]; then
+    printf 'expected %s occurrences of %s, found %s in:\n' "$expected" "$needle" "$actual" >&2
+    printf '%s\n' "$haystack" | sed 's/^/  /' >&2
+    fail "$message"
+  fi
+
+  pass "$message"
+}
+
+# Every scenario starts the same way: load the stub, load init.lua on top of
+# it, then discard the load-time trace so assertions see only what the
+# scenario itself triggers.
+scenario_preamble='
+local harness = dofile(arg[1])
+dofile(arg[2])
+local loadTrace = harness.trace
+harness.trace = {}
+'
+
+# --- Load-time side effects ---------------------------------------------------
+
+load_trace="$(run_scenario load <<EOF
+$scenario_preamble
+for _, line in ipairs(loadTrace) do
+  print(line)
+end
+EOF
+)"
+
+assert_contains "$load_trace" "hotkey.bind none f18" "init.lua binds the leader key on load"
+assert_contains "$load_trace" "hotkey.bind alt+cmd+ctrl+shift t" "init.lua binds the hyper chord for Ghostty on load"
+assert_contains "$load_trace" "modal.bind none t" "init.lua binds the Ghostty key inside the leader modal on load"
+assert_contains "$load_trace" "application.watcher.start" "init.lua starts the application watcher on load"
+assert_contains "$load_trace" "window.filter.subscribe windowFocused" "init.lua subscribes to Ghostty window focus on load"
+assert_not_contains "$load_trace" "modal.enter" "loading init.lua does not enter the leader modal"
+assert_not_contains "$load_trace" "timer.doAfter" "loading init.lua does not schedule an input-source retry"
+
+# --- Leader-key modal -----------------------------------------------------------
+
+modal_trace="$(run_scenario modal_launch <<EOF
+$scenario_preamble
+harness.addApp("com.mitchellh.ghostty")
+harness.press("f18")
+harness.press("t")
+harness.release("f18")
+harness.printTrace()
+EOF
+)"
+
+cat >"$tmp_dir/modal_launch.expected" <<'TRACE'
+press none f18
+modal.enter
+press none t (modal)
+app.activate com.mitchellh.ghostty
+modal.exit
+release none f18
+TRACE
+
+if ! diff -u "$tmp_dir/modal_launch.expected" "$tmp_dir/modal_launch.out" >"$tmp_dir/modal_launch.diff"; then
+  cat "$tmp_dir/modal_launch.diff" >&2
+  fail "holding the leader and pressing an app key enters the modal, focuses the app and exits the modal"
+fi
+pass "holding the leader and pressing an app key enters the modal, focuses the app and exits the modal"
+
+assert_count "$modal_trace" "modal.exit" 1 "releasing the leader after an app key does not exit the modal a second time"
+
+modal_release_trace="$(run_scenario modal_release <<EOF
+$scenario_preamble
+harness.press("f18")
+harness.press("f18")
+harness.release("f18")
+harness.release("f18")
+harness.printTrace()
+EOF
+)"
+
+assert_count "$modal_release_trace" "modal.enter" 1 "pressing the leader while the modal is active does not enter it again"
+assert_count "$modal_release_trace" "modal.exit" 1 "releasing the leader without an app key exits the modal once"
+
+modal_launch_missing_trace="$(run_scenario modal_launch_missing <<EOF
+$scenario_preamble
+harness.press("f18")
+harness.press("s")
+harness.printTrace()
+EOF
+)"
+
+assert_contains "$modal_launch_missing_trace" "application.launchOrFocusByBundleID com.tinyspeck.slackmacgap" "an app key for an app that is not running launches it by bundle ID"
+assert_contains "$modal_launch_missing_trace" "alert.show Could not launch Slack" "a failed launch shows an alert naming the app"
+assert_contains "$modal_launch_missing_trace" "modal.exit" "the modal exits after a failed launch"
+
+modal_hidden_trace="$(run_scenario modal_hidden <<EOF
+$scenario_preamble
+harness.addApp("notion.id", { hidden = true })
+harness.press("f18")
+harness.press("n")
+harness.printTrace()
+EOF
+)"
+
+assert_contains "$modal_hidden_trace" "app.unhide notion.id" "an app key for a hidden app unhides it"
+assert_contains "$modal_hidden_trace" "app.activate notion.id" "an app key for a hidden app activates it"
+
+modal_inert_trace="$(run_scenario modal_inert <<EOF
+$scenario_preamble
+local bound, err = pcall(harness.press, "t")
+print(bound and "bound" or "unbound: " .. tostring(err))
+harness.printTrace()
+EOF
+)"
+
+assert_contains "$modal_inert_trace" "unbound: " "an app key without the leader held is not bound"
+assert_not_contains "$modal_inert_trace" "app.activate" "an app key without the leader held launches nothing"
+
+hyper_trace="$(run_scenario hyper <<EOF
+$scenario_preamble
+harness.addApp("com.mitchellh.ghostty")
+harness.press("t", { "ctrl", "alt", "cmd", "shift" })
+harness.printTrace()
+EOF
+)"
+
+assert_contains "$hyper_trace" "app.activate com.mitchellh.ghostty" "the hyper chord focuses the app without the leader"
+assert_not_contains "$hyper_trace" "modal.enter" "the hyper chord does not enter the leader modal"
+
+# --- Ghostty input-source retry -------------------------------------------------
+
+# The stub's input source starts on a Korean layout, so every retry scenario
+# begins with a switch pending. Both switch calls are made to fail here.
+retry_failing_trace="$(run_scenario retry_failing <<EOF
+$scenario_preamble
+harness.setSourceSucceeds = false
+harness.setLayoutSucceeds = false
+local ghostty = harness.addApp("com.mitchellh.ghostty")
+harness.activateApp(ghostty)
+harness.flushTimers()
+print("pending timers: " .. harness.pendingTimers())
+harness.printTrace()
+EOF
+)"
+
+cat >"$tmp_dir/retry_failing.expected" <<'TRACE'
+timer.doAfter 0.00
+timer.doAfter 0.08
+timer.doAfter 0.18
+timer.doAfter 0.35
+TRACE
+
+grep '^timer.doAfter' "$tmp_dir/retry_failing.out" >"$tmp_dir/retry_failing.timers" || true
+if ! diff -u "$tmp_dir/retry_failing.expected" "$tmp_dir/retry_failing.timers" >"$tmp_dir/retry_failing.diff"; then
+  cat "$tmp_dir/retry_failing.diff" >&2
+  fail "activating Ghostty schedules one retry per configured delay and nothing more"
+fi
+pass "activating Ghostty schedules one retry per configured delay and nothing more"
+
+assert_count "$retry_failing_trace" "keycodes.currentSourceID set com.apple.keylayout.ABC" 4 "a switch that keeps failing is requested once per retry"
+assert_count "$retry_failing_trace" "keycodes.setLayout ABC" 4 "a failed source switch falls back to the ABC layout on every retry"
+assert_contains "$retry_failing_trace" "pending timers: 0" "a switch that keeps failing stops after the last retry"
+
+retry_success_trace="$(run_scenario retry_success <<EOF
+$scenario_preamble
+local ghostty = harness.addApp("com.mitchellh.ghostty")
+harness.activateApp(ghostty)
+harness.flushTimers()
+print("pending timers: " .. harness.pendingTimers())
+harness.printTrace()
+EOF
+)"
+
+assert_count "$retry_success_trace" "keycodes.currentSourceID set com.apple.keylayout.ABC" 1 "a switch that succeeds is requested once"
+assert_not_contains "$retry_success_trace" "keycodes.setLayout" "a successful source switch does not fall back to the ABC layout"
+assert_count "$retry_success_trace" "timer.fire" 4 "later retries still fire after a successful switch"
+assert_contains "$retry_success_trace" "pending timers: 0" "no retry is left pending after a successful switch"
+
+retry_fallback_trace="$(run_scenario retry_fallback <<EOF
+$scenario_preamble
+harness.setSourceSucceeds = false
+local ghostty = harness.addApp("com.mitchellh.ghostty")
+harness.activateApp(ghostty)
+harness.flushTimers()
+harness.printTrace()
+EOF
+)"
+
+assert_count "$retry_fallback_trace" "keycodes.currentSourceID set com.apple.keylayout.ABC" 1 "a switch whose fallback succeeds is requested once"
+assert_count "$retry_fallback_trace" "keycodes.setLayout ABC" 1 "the ABC layout fallback is requested once when it succeeds"
+
+retry_already_english_trace="$(run_scenario retry_already_english <<EOF
+$scenario_preamble
+harness.currentSourceID = "com.apple.keylayout.ABC"
+local ghostty = harness.addApp("com.mitchellh.ghostty")
+harness.activateApp(ghostty)
+harness.flushTimers()
+harness.printTrace()
+EOF
+)"
+
+assert_not_contains "$retry_already_english_trace" "keycodes.currentSourceID set" "no switch is requested when Ghostty is already on ABC"
+assert_not_contains "$retry_already_english_trace" "keycodes.setLayout" "no fallback is requested when Ghostty is already on ABC"
+
+retry_other_app_trace="$(run_scenario retry_other_app <<EOF
+$scenario_preamble
+harness.setSourceSucceeds = false
+harness.setLayoutSucceeds = false
+local ghostty = harness.addApp("com.mitchellh.ghostty")
+local slack = harness.addApp("com.tinyspeck.slackmacgap")
+harness.activateApp(ghostty)
+harness.activateApp(slack)
+harness.flushTimers()
+print("pending timers: " .. harness.pendingTimers())
+harness.printTrace()
+EOF
+)"
+
+assert_count "$retry_other_app_trace" "timer.stop" 4 "activating another app cancels every pending Ghostty retry"
+assert_not_contains "$retry_other_app_trace" "keycodes.currentSourceID set" "no switch is requested once another app is activated"
+assert_contains "$retry_other_app_trace" "pending timers: 0" "no retry is left pending once another app is activated"
+
+retry_focus_lost_trace="$(run_scenario retry_focus_lost <<EOF
+$scenario_preamble
+harness.setSourceSucceeds = false
+harness.setLayoutSucceeds = false
+local ghostty = harness.addApp("com.mitchellh.ghostty")
+local slack = harness.addApp("com.tinyspeck.slackmacgap")
+harness.activateApp(ghostty)
+harness.flushTimers(1)
+harness.frontmost = slack
+harness.flushTimers()
+print("pending timers: " .. harness.pendingTimers())
+harness.printTrace()
+EOF
+)"
+
+assert_count "$retry_focus_lost_trace" "keycodes.currentSourceID set com.apple.keylayout.ABC" 1 "a retry that finds Ghostty no longer frontmost requests no switch"
+assert_count "$retry_focus_lost_trace" "timer.stop" 2 "a retry that finds Ghostty no longer frontmost cancels the remaining retries"
+assert_contains "$retry_focus_lost_trace" "pending timers: 0" "no retry is left pending once Ghostty loses focus mid-way"
+
+retry_refocus_trace="$(run_scenario retry_refocus <<EOF
+$scenario_preamble
+harness.setSourceSucceeds = false
+harness.setLayoutSucceeds = false
+local ghostty = harness.addApp("com.mitchellh.ghostty")
+harness.activateApp(ghostty)
+harness.focusWindow("windowFocused")
+harness.flushTimers()
+harness.printTrace()
+EOF
+)"
+
+assert_count "$retry_refocus_trace" "timer.doAfter" 8 "a Ghostty window focus after activation schedules a fresh set of retries"
+assert_count "$retry_refocus_trace" "timer.stop" 4 "a Ghostty window focus after activation cancels the earlier retries"
+assert_count "$retry_refocus_trace" "keycodes.currentSourceID set com.apple.keylayout.ABC" 4 "overlapping Ghostty focus events never double the retry count"


### PR DESCRIPTION
Closes #225

Branched from `main`; not stacked on anything.

## Problem

`tests/hammerspoon_config_test.sh` reads the `appBindings` table out of `dot_hammerspoon/init.lua` as text. That covers the ten bindings, duplicate keys and the reserved `/` and `r` keys, but the two behaviours #177 named — the leader-key modal and the Ghostty input-source retry loop — are runtime behaviour, not table shape, so nothing asserted on them.

## Change

The approach the issue asked to decide on is the first one: drive the real `init.lua` through a Lua interpreter with `hs` faked. Both behaviours are plain Lua once `hs` is a table.

### `tests/fixtures/hammerspoon_hs_stub.lua`

A recording stand-in for the `hs` global. Loading it defines `hs` and returns a harness table. Only the API `init.lua` calls is implemented (`hs.hotkey.bind`, `hs.hotkey.modal`, `hs.application` and its `watcher`, `hs.keycodes`, `hs.timer.doAfter`, `hs.alert`, `hs.screen`, `hs.window.filter`, `hs.reload`); every other field is a metatable `__index` that raises, so a new `hs` call in `init.lua` fails the test instead of being silently absorbed (red-checked below).

Every call lands in `harness.trace` as one line. Load-time side effects (hotkey binds, watcher start, the "config loaded" alert) are recorded and nothing else. The harness then offers what a scenario needs to drive the config:

- `press` / `release` deliver a chord; an entered modal's binding wins over a global hotkey for the same chord, as in Hammerspoon.
- `addApp` registers a running app for `hs.application.get`; `activateApp` replays an app activation through every `hs.application.watcher`; `focusWindow` fires the window-filter subscribers.
- `hs.timer.doAfter` queues instead of firing. `flushTimers([limit])` runs the queue in delay order, honouring `stop()` calls made by earlier callbacks, so a scenario decides when the clock advances and can act between two retries.
- `setSourceSucceeds` / `setLayoutSucceeds` make `hs.keycodes.currentSourceID(id)` and `hs.keycodes.setLayout` fail or succeed; on success the stub's current source changes, the way the real calls do.

### `tests/hammerspoon_runtime_test.sh`

Loads the stub and then the real `init.lua` per scenario, discards the load-time trace, and asserts on what the scenario triggers. 41 assertions:

- **Load:** leader, hyper and modal bindings are registered; the watcher starts and the window filter subscribes; nothing enters the modal or schedules a retry.
- **Leader modal:** press F18 → `modal.enter`; press `t` → `app.activate com.mitchellh.ghostty` → `modal.exit`, compared as an exact trace with `diff`. Releasing F18 afterwards does not exit twice; pressing F18 while active does not enter twice; releasing F18 without an app key exits once. A key for an app that is not running goes through `launchOrFocusByBundleID` and, on failure, shows the "Could not launch Slack" alert before exiting. A hidden app is unhidden then activated. A modal key without the leader held is not bound at all. The hyper chord focuses the app without touching the modal.
- **Ghostty retry:** activating Ghostty schedules exactly the four configured delays (`0.00 0.08 0.18 0.35`, compared with `diff`) and nothing more. With both switch calls failing, the switch and the `ABC` fallback are each requested four times and no timer is left pending. With the switch succeeding it is requested once and the fallback never; the later timers still fire but request nothing. With only the fallback succeeding, each is requested once. Already on ABC, nothing is requested. Activating another app cancels all four timers before any fires. Ghostty losing focus after the first retry cancels the remaining two. A window-focus event landing after the activation cancels the first four timers and schedules four fresh ones, so overlapping focus events never double the request count.

### Where the code differs from the lane brief

The brief asked to check that Escape also exits the modal. `init.lua` binds no Escape key: the modal exits on the leader key's release callback, or after any modal binding runs. The test asserts the release path instead. Adding an Escape binding would be a behaviour change and is out of scope for a test-only issue; it can be its own issue if wanted.

No refactor of `init.lua` was needed; the file is untouched.

### Interpreter and CI

The interpreter is looked up as `lua5.4`, `lua`, then `luajit`. Without one the file prints a single `skip - …` line and exits 0, which `tests/run` reports in its summary. `.github/workflows/tests.yml` installs `lua5.4` on Ubuntu and `lua` on macOS and prints the version in the dependency report, so both runners execute the file rather than skip it. `AGENTS.md` lists Lua as an optional test dependency.

`tests/**` is already in `.chezmoiignore`, and `chezmoiignore_test.sh` asserts that no `tests/` path is managed, so the new fixture changes no managed path (green in the suite run below).

## Tests

Locally with `luajit` (the only interpreter on this Mac):

```
$ sh tests/hammerspoon_runtime_test.sh
ok - init.lua binds the leader key on load
…
ok - overlapping Ghostty focus events never double the retry count
exit=0        (41 ok)

$ PATH=/usr/bin:/bin sh tests/hammerspoon_runtime_test.sh
skip - Hammerspoon runtime behavior (needs lua5.4, lua or luajit on PATH)
exit=0
```

Four red checks against a temporarily edited `init.lua`, each restored afterwards:

```
# drop exitLeader() from the modal app-key handler
-modal.exit            (expected before `release none f18`)
+modal.exit            (now only after the release)
not ok - holding the leader and pressing an app key enters the modal, focuses the app and exits the modal

# add a fifth delay 0.60 to ghosttyEnglishRetryDelays
+timer.doAfter 0.60
not ok - activating Ghostty schedules one retry per configured delay and nothing more

# remove the isGhosttyFrontmost() guard from the retry callback
not ok - a retry that finds Ghostty no longer frontmost requests no switch

# append hs.pasteboard.getContents() to init.lua
init.lua:193: hs stub does not implement hs.pasteboard
not ok - Hammerspoon runtime scenario load runs to completion
```

Full suite:

```
$ PATH="$(mise where python)/bin:$PATH" tests/run </dev/null
=== hammerspoon_runtime_test.sh ===
ok - init.lua binds the leader key on load
…                                              (41 ok)
=== summary ===
25 test files passed
exit 0

2265 ok lines across 25 files (24 on main + this one), 0 skip, 0 not ok.
```

`</dev/null` is needed in the session this ran in: the two setup tests drive Terrapod through `script`, which fails with `tcgetattr/ioctl: Operation not supported on socket` when stdin is a socket rather than a terminal or `/dev/null`. That is unrelated to this change and reproduces on `main`.

## Docs

`AGENTS.md` only. No domain term moved, so no `CONTEXT.md` change, and no architectural decision changed, so no ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MChALHnXtiUN3X7ZHhq41Z
