### PR TITLE
Judge executable selection by the effective executable (ADR 0020)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -56,6 +56,14 @@ _Avoid_: mise CLI provider, aqua provider, platform-specific CLI source
 mise, which installs and selects Bun, Node.js, Python, and uv independently from Homebrew-managed user-facing CLI tools.
 _Avoid_: Modern CLI Provider, Homebrew runtime manager, aqua tool provider
 
+**Managed Default PATH**:
+The PATH Terrapod computes for executable selection: a zsh login shell's PATH from a reset environment, with the Development Runtime Manager's active bin directories ahead of it. Terrapod computes it rather than inheriting the caller's PATH.
+_Avoid_: ambient PATH, inherited PATH, current PATH
+
+**Effective Executable**:
+The file that actually executes when a command is typed in the Managed Default PATH, after shim forwarding is followed to its target.
+_Avoid_: primary executable, first match on PATH, resolved path
+
 **macOS Desktop App Stack**:
 The opt-in macOS package set for GUI apps, system-style desktop apps, cask-delivered desktop support tools, and tap-delivered companion CLIs that ship with those apps.
 _Avoid_: Homebrew bootstrap, shared CLI formula, Core Shell Stack
@@ -211,13 +219,17 @@ _Avoid_: separate Korean introduction, independent README, self-labeled translat
 - **Terrapod** applies this repository's declared dotfiles state; it does not act as the package manager for OS packages or mise-managed tool upgrades.
 - **Terrapod** may install declared dependencies needed to reach the target state, but it does not run broad version upgrade commands such as `brew upgrade`, `apt upgrade`, or `mise upgrade`.
 - Active command-bearing declarations include the Core Shell Stack, Development Runtime Stack, enabled Optional AI Tool Stack, and executable-providing enabled macOS App Groups.
-- Terrapod checks only the declared canonical provider, expected executable path, and current primary executable. It does not scan secondary PATH copies or infer alternate installer provenance.
+- Terrapod checks the declared canonical provider, the canonical executable locations, and the **Effective Executable**. It does not scan secondary PATH copies or infer alternate installer provenance.
 - `tpod apply` and `tpod update` install declared state and then print executable selection advisories without removing alternate payloads.
-- `tpod status` remains informational. `tpod doctor` fails when a declared provider package or canonical executable is missing or when an enabled command is unavailable on PATH.
+- `tpod status` remains informational. `tpod doctor` fails when a declared provider package or canonical executable is missing or when an enabled command is unavailable on the **Managed Default PATH**.
 - When the canonical executable exists but another file is primary, `tpod apply`, `tpod status`, and `tpod doctor` report actual and canonical paths as an advisory without changing exit status.
-- Exact path matches and different symlink paths that resolve to the same file both count as canonical selection.
+- Executable selection is judged in the **Managed Default PATH**, which Terrapod computes rather than inherits, so the verdict does not depend on how `tpod` was invoked.
+- A command resolving through a **Development Runtime Manager** shim is judged by what the shim actually executes, including the case where the manager reports the tool is not currently active and the shim falls through.
+- Canonical selection is a set of accepted locations. **Development Runtime Stack** commands are canonical under both `mise activate` and `mise activate --shims`; other providers keep one canonical location.
+- Advisories group by the directory a command resolved through and repeat invariant guidance once per advisory block, while keeping per-package actual and canonical paths.
 - Nonstandard Homebrew prefixes and files under `~/.config/zsh/path.d` remain user-managed and advisory-only.
-- Executable selection checks are read-only, do not persist pending state, and never suggest provider-specific uninstall commands.
+- Executable selection checks are read-only and do not persist pending state. They name a recovery command only when the provider is established by location, such as a payload inside the **Development Runtime Manager**'s own data directory, and never when the provider would have to be inferred.
+- **Development Runtime Manager** payloads that no active declaration can reach are reported as one advisory line, do not affect `tpod status` readiness, and are never removed by Terrapod.
 - After **Terrapod Setup** writes concrete settings, first-run declared-state apply should prioritize installing the **Terrapod** command surface and managed dotfiles so the machine reaches a recoverable state.
 - First-run completion separates **Terrapod** installation from machine profile readiness: installing the command surface and managed dotfiles can succeed while the **Core Shell Stack** or **Development Runtime Stack** remains incomplete.
 - Ubuntu package bootstrap failures can leave the **VPS Shell Profile** shell experience incomplete while **Terrapod** itself is installed; this is a machine profile readiness warning, not a first-run installer hard failure after **Terrapod Setup** succeeds.

--- a/docs/adr/0012-keep-package-source-migration-advisory-only.md
+++ b/docs/adr/0012-keep-package-source-migration-advisory-only.md
@@ -2,6 +2,8 @@
 
 Terrapod installs active package declarations through their canonical providers but does not remove alternate installations. After installation, Terrapod performs a read-only check of canonical provider presence, the expected executable, and the executable selected first on PATH. If the canonical executable exists but another file is primary, `tpod apply`, `tpod status`, and `tpod doctor` report the actual and canonical paths as an advisory.
 
+ADR 0020 supersedes this decision's definition of the compared executable as the one selected first on the ambient PATH, its singular expected executable, and its rule that only exact path matches and symlinks resolving to the same file count as canonical. It narrows this decision's prohibition on suggesting provider-specific uninstall commands to inferred providers. This decision's non-destructive apply contract, advisory-only treatment of a non-canonical primary executable, and refusal to scan secondary PATH copies remain in force.
+
 This decision supersedes ADR 0011's ownership registry, deep alternate-provider scan, removal plan, confirmation, lock, and migration warning state. It restores ADR 0010's non-destructive apply contract. ADR 0011's `tpod update` handoff to the refreshed `tpod apply` and the first-run installer's use of the installed `tpod apply` remain in force.
 
 ## Considered Options

--- a/docs/adr/0020-judge-executable-selection-by-the-effective-executable.md
+++ b/docs/adr/0020-judge-executable-selection-by-the-effective-executable.md
@@ -1,0 +1,30 @@
+# Judge executable selection by the effective executable
+
+Terrapod judges executable selection by the file that would actually execute in the managed default PATH, not by the path string the ambient PATH happens to return. That file is the effective executable.
+
+Terrapod computes the managed default PATH itself rather than inheriting it. It resets PATH to the system default, clears leaked Homebrew and mise environment state, reads the PATH a zsh login shell builds, and prepends the Development Runtime Manager's active bin directories. When zsh is unavailable or the probe fails, Terrapod falls back to the inherited PATH and reports which PATH the verdict was computed from. Resolution follows shim indirection: when a command resolves into the Development Runtime Manager's shims directory, Terrapod asks the manager for the target, and when the manager reports the tool is not currently active, Terrapod resolves what the shim falls through to.
+
+Canonical selection is a set of accepted locations rather than one path. `mise activate` and `mise activate --shims` are both supported resolution modes, so Development Runtime declarations accept the manager's active target, its bin directories, and the shims path. Other providers keep a single canonical location.
+
+Advisories group by the directory a command resolved through and print invariant guidance once per advisory block instead of once per package. Payloads under the Development Runtime Manager's install directory that no active declaration can reach are reported as one advisory line with a recovery command; Terrapod never runs it.
+
+This decision supersedes ADR 0012's definition of the compared executable as the one selected first on the ambient PATH, its singular expected executable, and its rule that only exact path matches and symlinks resolving to the same file count as canonical. It narrows ADR 0012's prohibition on suggesting provider-specific uninstall commands to cases where the provider is inferred; a payload inside a provider's own data directory establishes that provider by location. ADR 0012's non-destructive apply contract, advisory-only treatment of a non-canonical primary executable, and refusal to scan secondary PATH copies remain in force.
+
+## Considered Options
+
+- Reconstruct the managed default PATH in POSIX shell inside the helper: rejected because the managed shell templates and the helper would carry the same ordering rules in two places and drift on every PATH change.
+- Probe through an interactive login shell: rejected because it runs the full interactive startup, including the greeting and completion initialization, for a value that non-interactive login plus the manager's bin directories already yields.
+- Keep the ambient PATH and only report which PATH was used: rejected because a verdict that still changes with shell interactivity is not usable in CI, over SSH, or in cron, which are the contexts the check exists for.
+- Resolve shim indirection by comparing inodes: rejected because a shim is a symlink to the manager binary and never to the canonical executable, so inode comparison cannot observe the forwarding.
+- Treat the shims path as canonical and require `mise activate --shims`: rejected because it would make Terrapod's own managed zshrc non-canonical.
+
+## Consequences
+
+- `tpod apply`, `tpod status`, and `tpod doctor` produce the same executable selection verdict regardless of how the process was invoked.
+- An unactivated non-interactive shell no longer reports an enabled command as unavailable on PATH.
+- A shim that transparently forwards to the canonical executable is canonical selection and raises no advisory.
+- Development Runtime declarations are canonical under either supported activation mode.
+- The managed default PATH reflects system PATH ordering, so a login-shell ordering defect surfaces as an advisory rather than being hidden.
+- Advisory output carries per-package actual and canonical paths, and repeats invariant guidance once per advisory block.
+- Unreachable Development Runtime payloads are advisory, do not affect `tpod status` readiness, and are never removed by Terrapod.
+- Executable selection remains read-only and does not persist state.

--- a/docs/superpowers/specs/2026-09-04-executable-selection-resolution-design.md
+++ b/docs/superpowers/specs/2026-09-04-executable-selection-resolution-design.md
@@ -1,0 +1,256 @@
+# Executable selection resolution design
+
+Design for issues #233-#238. Covers the resolution model that `tpod doctor`,
+`tpod status`, and `tpod apply` use to judge executable selection, the advisory
+output shape, a new leftover-payload finding, and the macOS login-shell PATH
+bug that the resolution model exposes.
+
+## Problem
+
+`dot_local/lib/terrapod/executable_executable-selection` answers "does the path
+string `command -v` returned equal the path string we computed?" That question
+is wrong in three separate ways, and the three ways are the first three issues.
+
+- **#236 — which PATH.** The check runs against whatever PATH the `tpod` process
+  inherited. `ssh vps 'tpod doctor'` reports `bun` as a failure; `ssh vps 'zsh
+  -ic "tpod doctor"'` reports it clean. A verdict that flips on shell
+  interactivity is unusable in CI, over SSH, and in cron.
+- **#233 — what that PATH resolves to.** A mise shim forwards transparently to
+  the next PATH match, so a command already running the Homebrew build is
+  reported as a different installation. `files_are_same` cannot catch it either:
+  `-ef` compares inodes, and the shim is a symlink to the `mise` binary, never
+  to the canonical executable. 15 false advisories on a macOS workstation.
+- **#234 — what counts as canonical.** `expected_executable` hardcodes
+  `$MISE_DATA_DIR/shims/<command>` for every mise declaration, but
+  `dot_zshrc.tmpl:7` activates mise with `eval "$(mise activate zsh)"`, which
+  puts resolved install directories at the front of PATH instead. The two
+  disagree permanently, so all four Development Runtime declarations report an
+  advisory on a correctly configured machine.
+
+Two further issues sit on top of the checker rather than inside it.
+
+- **#237 — output shape.** Every advisory prints three lines and the third is
+  invariant, so 16 advisories produce 48 lines with one sentence repeated 16
+  times. The one real finding is buried in the repetition.
+- **#238 — a finding with no home.** 15 pre-ADR-0010 aqua payloads remain under
+  `~/.local/share/mise/installs/`. They are in no mise config, can never be
+  selected, and still generate shims. Today they are visible only as the false
+  advisories #233 removes; after that fix they become invisible entirely.
+
+One issue is independent of the checker.
+
+- **#235 — a real PATH misconfiguration.** `dot_zshenv.tmpl` states that
+  "declared Homebrew tools win by default", but on macOS `/etc/zprofile` runs
+  `/usr/libexec/path_helper` after `.zshenv` and re-prepends `/etc/paths`.
+  `/opt/homebrew/bin` and `$HOME/.local/bin` end up behind `/usr/bin`. The
+  visible symptom is `git` resolving to Apple Git 2.50.1 instead of the declared
+  Homebrew 2.55.0; any future overlap between `/usr/bin` and a declared formula
+  regresses the same way, silently.
+
+## Model
+
+Replace string equality with one question: **in the managed default PATH, does
+typing `<command>` actually execute a canonical binary?** The file that would
+actually execute is the **effective executable**.
+
+Four functions carry the model inside `executable-selection`.
+
+    managed_path()                     # the PATH every verdict is computed in
+    resolve_in_path <command>          # command -v within that PATH
+    effective_executable <command> <resolved>
+    canonical_candidates <provider> <command>
+
+### managed_path (#236)
+
+The managed default PATH is what a login shell builds, plus mise's active bin
+directories.
+
+    base=$(PATH=/usr/bin:/bin:/usr/sbin:/sbin \
+           env -u HOMEBREW_PREFIX -u HOMEBREW_CELLAR -u HOMEBREW_REPOSITORY \
+               -u MISE_SHELL \
+           zsh -lc 'print -rn -- $PATH')
+    bins=$(mise bin-paths 2>/dev/null | tr '\n' ':')
+    managed="$bins$base"
+
+Two details are load-bearing.
+
+PATH is reset to the system default before the probe. Inheriting the caller's
+PATH is exactly the bug #236 describes; letting it leak into the probe would
+reproduce it one level down.
+
+`HOMEBREW_PREFIX` and its siblings are unset. `dot_zshenv.tmpl:11` short-circuits
+the `brew shellenv` probe when the environment already carries a prefix, so a
+leaked variable whose `bin` directory is not on the reset PATH would yield a
+managed PATH with no Homebrew prefix in it at all.
+
+`zsh -lc` reads `.zshenv`, `/etc/zprofile`, and `.zprofile`, but not `.zshrc`.
+That is the correct boundary: it excludes fastfetch, oh-my-zsh, and compinit,
+and mise activation is supplied by `mise bin-paths` instead. `dot_zshrc.tmpl`
+mutates PATH only through `mise activate`, so nothing else is lost.
+
+Fallbacks and overrides:
+
+- `TERRAPOD_MANAGED_PATH`, when set, is used verbatim. Tests use this.
+- When `zsh` is absent or the probe fails, fall back to the inherited PATH and
+  print which PATH the verdict was computed from. The verdict stays
+  interpretable even when it cannot be made invocation-independent.
+- The probe runs once per process; the result is cached in a variable.
+
+Because `zsh -lc` reads `/etc/zprofile`, the managed PATH reflects path_helper's
+reordering on macOS. Doctor therefore keeps reporting the `git` advisory
+honestly until #235 lands, and the advisory disappears on its own once it does.
+
+### effective_executable (#233)
+
+Given the path `resolve_in_path` returned:
+
+1. If it is not under the mise shims directory, it is the effective executable.
+2. If it is, ask `mise which <command>`. On success that target is the effective
+   executable.
+3. When mise reports the tool is not currently active, the shim falls through.
+   Resolve the command again against the managed PATH with the shims directory
+   removed; that result is the effective executable.
+4. Normalize the result before comparing.
+
+Step 3 is the case that produces the 15 false advisories: `rg` executes 15.2.0
+from Homebrew while mise's own payload sits at 15.1.0, unreachable.
+
+### canonical_candidates (#234)
+
+Canonical becomes a set, not a single path.
+
+| provider | candidates |
+| --- | --- |
+| `homebrew-formula`, `homebrew-cask` | `<prefix>/bin/<command>` |
+| `claude-installer` | `$HOME/.local/bin/<command>` |
+| `mise` | `mise which <command>`, plus `<dir>/<command>` for each `mise bin-paths` directory, plus `<shims>/<command>` |
+
+Both `mise activate` and `mise activate --shims` are supported resolution modes.
+Keeping the shims path in the set preserves `--shims` without making it the only
+answer. Selection is canonical when the effective executable equals, or is `-ef`
+to, any candidate.
+
+Only the `mise` provider gains a set; the others keep a single candidate and the
+same behavior they have today.
+
+### Advisory output (#237)
+
+Advisories are buffered rather than printed inside the loop, keyed by the
+directory the original `resolve_in_path` landed in — that directory is the shared
+cause.
+
+    resolved_dir|package|actual|canonical
+
+After the loop, groups of two or more print as one block; singletons keep the
+current two-line form.
+
+      advisory - 15 commands resolve through ~/.local/share/mise/shims
+                 bat, dust, duf, fastfetch, fd, fzf, gh, git-delta, lazygit,
+                 lsd, neovim, ripgrep, starship, zellij, zoxide
+                 canonical: /opt/homebrew/bin
+      advisory - git resolves to /usr/bin/git
+                 canonical: /opt/homebrew/bin/git
+      Adjust PATH or remove the other installation manually, then rerun 'tpod doctor'.
+
+The guidance sentence prints **once per advisory block**, as its last line,
+rather than once per group as #237's mock shows. #237's stated goal is to stop
+repeating invariant text per row; end-of-block is strictly better than per-group
+at that goal, and there is only one guidance sentence to give. Per-package actual
+and canonical paths remain available, as ADR 0012 requires: a group prints the
+shared resolved directory and the shared canonical directory, and falls back to
+per-package lines when the group's canonical paths do not share a directory.
+
+### Leftover mise payloads (#238)
+
+Enumerate the top-level directories under
+`${MISE_DATA_DIR:-$HOME/.local/share/mise}/installs`. A directory is a leftover
+when no `mise bin-paths` entry lies beneath it. Report the count as a single
+advisory line.
+
+      advisory - 15 mise payloads are outside any canonical declaration
+                 'mise uninstall' reclaims the disk; Terrapod does not remove them.
+
+This is advisory, never a failure, and the whole check is skipped when mise is
+absent or the installs directory does not exist. Terrapod does not run
+`mise uninstall` and does not choose which payloads to remove.
+
+ADR 0012 and `CONTEXT.md` currently forbid suggesting provider-specific uninstall
+commands. That rule exists to stop Terrapod from *inferring* an alternate
+installer. Here the provider is not inferred: the payloads are inside mise's own
+data directory, so mise is the provider by construction. ADR 0020 narrows the
+rule to match that reasoning — no uninstall command is named unless the provider
+is established by location rather than guessed.
+
+### macOS login-shell PATH (#235)
+
+`dot_zprofile.tmpl` gains a macOS branch that runs after `/etc/zprofile` has
+already run `path_helper`: re-evaluate `brew shellenv` and re-prepend
+`$HOME/.local/bin`. This is Homebrew's own documented answer to path_helper.
+The Ubuntu path is unaffected and keeps its single-place initialization.
+
+The comment in `dot_zprofile.tmpl` that says "Login-shell PATH is initialized by
+the managed .zshenv for both profiles" is the assumption path_helper breaks; it
+is corrected rather than left in place.
+
+This is an ordering repair, not a new PATH source. `.zshenv` keeps building the
+PATH; `.zprofile` restores the intended order after the system reshuffles it.
+
+## Testing
+
+Existing coverage lives in `tests/executable_selection_test.sh`, which builds a
+fixture tree of fake executables and drives the helper with
+`TERRAPOD_EXECUTABLE_SELECTION_INVENTORY_DIR`. Extend that harness rather than
+adding a parallel one.
+
+- `TERRAPOD_MANAGED_PATH` makes the resolution PATH injectable, so no test needs
+  a real login shell. One test covers the fallback: with the probe forced to
+  fail, the helper uses the inherited PATH and says so in its output.
+- Shim pass-through needs a fake `mise` on PATH that reports `not currently
+  active` for a command, a shim that is a symlink to that fake `mise`, and a
+  canonical Homebrew executable later in `TERRAPOD_MANAGED_PATH`. The assertion
+  is that no advisory is printed.
+- Canonical sets need a fake `mise bin-paths` emitting a directory that holds the
+  runtime executable; the assertion is that resolving there is canonical while
+  the shims path is still accepted.
+- Grouping asserts one header line, the package list, and exactly one occurrence
+  of the guidance sentence in output carrying several advisories.
+- Leftover payloads assert the count line against a fixture installs directory,
+  and assert silence when the directory is absent.
+- #235 renders `dot_zprofile.tmpl` with the pattern in
+  `tests/zprofile_orbstack_test.sh`, sources it from a login zsh, and asserts the
+  Homebrew prefix index is lower than `/usr/bin`'s. It skips on Linux, where
+  path_helper does not exist.
+
+## Documentation
+
+ADR 0020 records the resolution model. It supersedes three clauses of ADR 0012 —
+"the executable selected first on PATH", the singular "the expected executable",
+and "Exact path matches and symlinks resolving to the same file are canonical" —
+and narrows 0012's uninstall-command rule as described above. Per the repo
+convention established in #230, the supersession is recorded on ADR 0012's side
+as well.
+
+`CONTEXT.md` lines 214-220 restate the superseded rules and are updated with
+ADR 0020.
+
+## Delivery
+
+Six issues, one shared file, one independent file pair. Lanes are cut by file
+overlap.
+
+| lane | issues | files | start |
+| --- | --- | --- | --- |
+| — | ADR 0020, `CONTEXT.md` | `docs/adr/`, `CONTEXT.md` | coordinator, before dispatch |
+| A | #235 | `dot_zprofile.tmpl`, `dot_zshenv.tmpl`, new test | immediately |
+| B | #236, #234, #233 | `executable-selection` core, its test | immediately, parallel with A |
+| C | #237, #238 | `executable-selection` output, its test | after lane B merges |
+
+Lane B's three issues are one refactor delivered as three ordered PRs, one per
+issue. The order is fixed: #236 defines the PATH that #233's fall-through
+resolution searches, and #234 defines the candidate set that #233 compares
+against.
+
+Lane C edits the middle of the same file lane B is rewriting, so it waits for
+lane B rather than rebasing through three merges.
+
+Every branch is cut from `origin/main`. No stacked PRs.

--- a/docs/superpowers/specs/2026-09-04-executable-selection-resolution-design.md
+++ b/docs/superpowers/specs/2026-09-04-executable-selection-resolution-design.md
@@ -174,6 +174,13 @@ This is advisory, never a failure, and the whole check is skipped when mise is
 absent or the installs directory does not exist. Terrapod does not run
 `mise uninstall` and does not choose which payloads to remove.
 
+The leftover advisory is a separate finding from executable selection, so it
+prints after the selection advisory block and carries its own second line rather
+than sharing that block's trailing guidance sentence. It does not set the
+issue flag: `tpod status` stays `ready` on a machine whose only finding is
+leftover payloads, because disk a user chose to keep is not a readiness problem.
+`tpod apply` and `tpod doctor` print it.
+
 ADR 0012 and `CONTEXT.md` currently forbid suggesting provider-specific uninstall
 commands. That rule exists to stop Terrapod from *inferring* an alternate
 installer. Here the provider is not inferred: the payloads are inside mise's own


### PR DESCRIPTION
Records the resolution model that #233–#238 implement, so every lane starts from the same vocabulary instead of inventing one per PR.

## What changed

- **ADR 0020** — executable selection is judged by the *effective executable* (the file that actually runs) in the *managed default PATH* (which Terrapod computes rather than inherits). Shim forwarding is followed to its target; canonical becomes a set of accepted locations; advisories group and repeat invariant guidance once.
- **ADR 0012** — records the supersession on its own side, per the convention from #230. Three clauses go: "the executable selected first on PATH", the singular "the expected executable", and "exact path matches and symlinks resolving to the same file". Its uninstall-command prohibition narrows to *inferred* providers.
- **CONTEXT.md** — glossary entries for **Managed Default PATH** and **Effective Executable**, and the selection rules in Relationships updated to match.
- **Design spec** — `docs/superpowers/specs/2026-09-04-executable-selection-resolution-design.md`, with the per-issue design, testing approach, and lane split.

## Why the uninstall rule narrows

ADR 0012 forbade suggesting provider-specific uninstall commands so Terrapod would not *guess* which installer to blame. #238's leftover payloads sit inside mise's own data directory, so the provider is established by location, not inferred. ADR 0020 narrows the rule to match the reasoning it was written for; removal stays the user's decision either way.

## Verification

`./tests/adr_supersession_test.sh` — 20 assertions pass, including the new `ADR 0020 names ADR 0012 back` / `ADR 0012 names ADR 0020 back` pair.

Docs only; no behavior change. Implementation follows in the per-issue PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1vLGxSRHovE2WGeb21AtC