### PR TITLE
Compute the managed default PATH instead of inheriting it

### DIFF
--- a/dot_local/lib/terrapod/executable_executable-selection
+++ b/dot_local/lib/terrapod/executable_executable-selection
@@ -36,6 +36,73 @@ standard_homebrew_prefix() {
   terrapod_standard_homebrew_prefix_for_profile "$profile"
 }
 
+# The PATH every verdict is computed in. Inheriting the caller's PATH makes the
+# same machine answer differently depending on how tpod was invoked, so the
+# check reconstructs the PATH a login shell builds instead of reading the one
+# it was handed.
+#
+# Two details are load-bearing. PATH is reset to the system default before the
+# probe, because letting the caller's PATH into the probe reproduces the same
+# bug one level down. The Homebrew variables are cleared because
+# dot_zshenv.tmpl skips its 'brew shellenv' probe when the environment already
+# carries a prefix, so a leaked prefix whose bin directory is not on the reset
+# PATH would yield a managed PATH with no Homebrew in it at all.
+#
+# 'zsh -lc' reads .zshenv, /etc/zprofile, and .zprofile but not .zshrc. That is
+# the right boundary: it excludes fastfetch, oh-my-zsh, and compinit, and the
+# only PATH .zshrc contributes is mise activation, which 'mise bin-paths'
+# supplies directly.
+probe_login_path() {
+  probe_zsh="$(command -v zsh 2>/dev/null || true)"
+  [ -n "$probe_zsh" ] || return 1
+
+  PATH=/usr/bin:/bin:/usr/sbin:/sbin \
+    env -u HOMEBREW_PREFIX -u HOMEBREW_CELLAR -u HOMEBREW_REPOSITORY -u MISE_SHELL \
+    "$probe_zsh" -lc 'print -rn -- $PATH' 2>/dev/null
+}
+
+mise_bin_paths() {
+  command -v mise >/dev/null 2>&1 || return 0
+  mise bin-paths 2>/dev/null || true
+}
+
+managed_path_value=""
+managed_path_inherited=0
+
+# Probed once per process; every resolution afterwards reads the variable.
+initialize_managed_path() {
+  if [ -n "${TERRAPOD_MANAGED_PATH:-}" ]; then
+    managed_path_value="$TERRAPOD_MANAGED_PATH"
+    return
+  fi
+
+  login_path="$(probe_login_path || true)"
+  if [ -z "$login_path" ]; then
+    managed_path_value="$PATH"
+    managed_path_inherited=1
+    return
+  fi
+
+  managed_path_value="$(mise_bin_paths | tr '\n' ':')$login_path"
+}
+
+managed_path() {
+  printf '%s\n' "$managed_path_value"
+}
+
+# command -v inside the managed PATH. The subshell keeps the assignment from
+# leaking into the rest of the check, and the hash table is dropped because a
+# command this process already ran -- mise, brew -- would otherwise report
+# where the ambient PATH found it rather than where the managed PATH does.
+resolve_in_path() {
+  (
+    PATH="$managed_path_value"
+    export PATH
+    hash -r 2>/dev/null || true
+    command -v "$1" 2>/dev/null
+  )
+}
+
 core_records() {
   while IFS=' ' read -r package command; do
     printf '%s|%s|%s\n' homebrew-formula "$package" "$command"
@@ -199,6 +266,14 @@ print_advisory() {
   printf '%s\n' "             Adjust PATH or remove the other installation manually, then rerun 'tpod doctor'."
 }
 
+initialize_managed_path
+
+# A verdict that cannot be made invocation-independent still has to be
+# interpretable, so the PATH it was computed from is named.
+if [ "$managed_path_inherited" -eq 1 ]; then
+  printf '  note - executable selection judged against the inherited PATH: %s\n' "$(managed_path)"
+fi
+
 failure_found=0
 issue_found=0
 records="$(active_records)"
@@ -221,7 +296,7 @@ while IFS='|' read -r provider package command; do
     continue
   fi
 
-  actual="$(command -v "$command" 2>/dev/null || true)"
+  actual="$(resolve_in_path "$command" || true)"
   if [ -z "$actual" ]; then
     print_failure "$package is unavailable on PATH (canonical: $expected)"
     failure_found=1

--- a/tests/executable_selection_test.sh
+++ b/tests/executable_selection_test.sh
@@ -95,6 +95,7 @@ run_selection() {
     TERRAPOD_EXECUTABLE_SELECTION_INVENTORY_DIR="$inventory" \
     TERRAPOD_STANDARD_HOMEBREW_PREFIX="$prefix" \
     TERRAPOD_MISE_SHIMS_DIR="$mise_shims" \
+    TERRAPOD_MANAGED_PATH="$path_dir:/usr/bin:/bin" \
     PATH="$path_dir:/usr/bin:/bin" \
     "$selection" "$mode" macos-terminal false false "$@"
 }
@@ -177,6 +178,7 @@ ai_enabled_output="$(
     TERRAPOD_EXECUTABLE_SELECTION_INVENTORY_DIR="$inventory" \
     TERRAPOD_STANDARD_HOMEBREW_PREFIX="$prefix" \
     TERRAPOD_MISE_SHIMS_DIR="$mise_shims" \
+    TERRAPOD_MANAGED_PATH="$path_dir:/usr/bin:/bin" \
     PATH="$path_dir:/usr/bin:/bin" \
     "$selection" doctor macos-terminal true false 2>&1
 )"
@@ -201,6 +203,7 @@ run_claude_selection() {
     TERRAPOD_EXECUTABLE_SELECTION_INVENTORY_DIR="$inventory" \
     TERRAPOD_STANDARD_HOMEBREW_PREFIX="$prefix" \
     TERRAPOD_MISE_SHIMS_DIR="$mise_shims" \
+    TERRAPOD_MANAGED_PATH="$claude_path_dir:/usr/bin:/bin" \
     PATH="$claude_path_dir:/usr/bin:/bin" \
     "$selection" doctor macos-terminal true false 2>&1 || true
 }
@@ -225,6 +228,36 @@ claude_missing_output="$(run_claude_selection)"
 assert_contains "$claude_missing_output" "failure - claude-code is not installed through the Claude Code installer" \
   "an absent Claude Code install names the vendor installer"
 
+# With no TERRAPOD_MANAGED_PATH and a zsh that refuses to run, the probe cannot
+# produce a managed PATH. The verdict then falls back to the inherited PATH and
+# has to say so, because that is the one case where it depends on the caller.
+failing_probe_dir="$tmp_dir/failing-probe"
+mkdir -p "$failing_probe_dir"
+cat >"$failing_probe_dir/zsh" <<'EOF'
+#!/bin/sh
+exit 1
+EOF
+chmod +x "$failing_probe_dir/zsh"
+
+inherited_path="$failing_probe_dir:$path_dir:/usr/bin:/bin"
+fallback_output="$(
+  HOME="$tmp_dir/home" \
+    TERRAPOD_EXECUTABLE_SELECTION_INVENTORY_DIR="$inventory" \
+    TERRAPOD_STANDARD_HOMEBREW_PREFIX="$prefix" \
+    TERRAPOD_MISE_SHIMS_DIR="$mise_shims" \
+    PATH="$inherited_path" \
+    "$selection" doctor macos-terminal false false 2>&1 || true
+)"
+assert_contains "$fallback_output" \
+  "note - executable selection judged against the inherited PATH: $inherited_path" \
+  "a failed login-shell probe names the PATH the verdict was computed from"
+assert_not_contains "$fallback_output" "failure -" \
+  "the inherited-PATH fallback still resolves the declared commands"
+
+managed_output="$(run_selection doctor)"
+assert_not_contains "$managed_output" "inherited PATH" \
+  "a computed managed PATH says nothing about inheriting one"
+
 status_output="$(run_selection status)"
 assert_contains "$status_output" "Executable selection:" \
   "status exposes executable selection state"
@@ -247,6 +280,7 @@ assert_canonical_prefix() {
       TERRAPOD_MISE_SHIMS_DIR="$mise_shims" \
       TERRAPOD_MACHINE_ARCH="$arch" \
       TERRAPOD_DARWIN_TRANSLATED="$translated" \
+      TERRAPOD_MANAGED_PATH="$path_dir:/usr/bin:/bin" \
       PATH="$path_dir:/usr/bin:/bin" \
       "$selection" doctor "$profile" false false 2>&1
   )"
@@ -272,6 +306,7 @@ missing_lib_output="$(
     TERRAPOD_STANDARD_HOMEBREW_PREFIX="$prefix" \
     TERRAPOD_MISE_SHIMS_DIR="$mise_shims" \
     TERRAPOD_HOMEBREW_PREFIX_LIB="$tmp_dir/absent-homebrew-prefix.sh" \
+    TERRAPOD_MANAGED_PATH="$path_dir:/usr/bin:/bin" \
     PATH="$path_dir:/usr/bin:/bin" \
     "$selection" doctor macos-terminal false false 2>&1
 )"


### PR DESCRIPTION
Executable selection ran `command -v` against whatever PATH the `tpod` process
inherited, so the same machine answered differently depending on how doctor was
invoked: `ssh vps 'tpod doctor'` reported `bun` as a failure while `ssh vps 'zsh
-ic "tpod doctor"'` reported it clean. A verdict that flips on shell
interactivity is unusable in exactly the contexts the check exists for — CI,
SSH, cron.

The helper now computes the PATH it judges in instead of inheriting it.

- `probe_login_path` resets PATH to the system default, clears
  `HOMEBREW_PREFIX`/`HOMEBREW_CELLAR`/`HOMEBREW_REPOSITORY`/`MISE_SHELL`, and
  reads the PATH a `zsh -lc` login shell builds. Resetting PATH matters because
  letting the caller's PATH into the probe reproduces the same bug one level
  down; clearing the Homebrew variables matters because `dot_zshenv.tmpl:11`
  skips its `brew shellenv` probe when the environment already carries a
  prefix, which would otherwise yield a managed PATH with no Homebrew in it at
  all.
- `mise bin-paths` supplies the Development Runtime Manager's active bin
  directories, which is what `.zshrc` would have contributed. `zsh -lc` reads
  `.zshenv`, `/etc/zprofile`, and `.zprofile` but not `.zshrc`, so fastfetch,
  oh-my-zsh, and compinit stay out of the probe.
- `TERRAPOD_MANAGED_PATH` overrides the probe verbatim. The tests use it, so no
  test needs a real login shell.
- When `zsh` is absent or the probe fails, the check falls back to the inherited
  PATH and prints a `note` line naming it. A verdict that cannot be made
  invocation-independent still has to be interpretable.
- The probe runs once per process and is cached in a variable.

`resolve_in_path` replaces the bare `command -v`. It runs in a subshell so the
PATH assignment cannot leak, and drops the hash table first: `mise` and `brew`
have already executed in this process by then, and a hashed path would report
where the ambient PATH found them rather than where the managed PATH does.

Advisory and failure output shapes are untouched; #237 owns those.

Tests: every existing case now injects `TERRAPOD_MANAGED_PATH`, plus a new case
that points `zsh` at a stub which exits 1 and asserts the fallback both resolves
the declared commands and names the inherited PATH it used.

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1vLGxSRHovE2WGeb21AtC
