### PR TITLE
Accept a set of canonical locations for mise declarations

### DIFF
--- a/dot_local/lib/terrapod/executable_executable-selection
+++ b/dot_local/lib/terrapod/executable_executable-selection
@@ -61,9 +61,34 @@ probe_login_path() {
     "$probe_zsh" -lc 'print -rn -- $PATH' 2>/dev/null
 }
 
+# Asked once per process. The directory set now answers both the managed PATH
+# and every Development Runtime candidate set, and 'mise bin-paths' is not a
+# cheap command to run once per declaration.
+mise_bin_paths_value=""
+mise_bin_paths_loaded=0
+
 mise_bin_paths() {
+  if [ "$mise_bin_paths_loaded" -eq 0 ]; then
+    mise_bin_paths_loaded=1
+    if command -v mise >/dev/null 2>&1; then
+      mise_bin_paths_value="$(mise bin-paths 2>/dev/null || true)"
+    fi
+  fi
+
+  [ -n "$mise_bin_paths_value" ] || return 0
+  printf '%s\n' "$mise_bin_paths_value"
+}
+
+mise_shims_dir() {
+  printf '%s\n' "${TERRAPOD_MISE_SHIMS_DIR:-${MISE_DATA_DIR:-$HOME/.local/share/mise}/shims}"
+}
+
+# The file mise currently selects for a command, or nothing. Failing is not an
+# error here: a tool mise knows about but no active config selects is exactly
+# the case this check exists to describe.
+mise_which() {
   command -v mise >/dev/null 2>&1 || return 0
-  mise bin-paths 2>/dev/null || true
+  mise which "$1" 2>/dev/null || true
 }
 
 managed_path_value=""
@@ -224,7 +249,18 @@ provider_label() {
   esac
 }
 
-expected_executable() {
+# The locations a command is allowed to resolve to, newline separated. The
+# Development Runtime Manager is the only provider with more than one: 'mise
+# activate' puts the active install directories on PATH and 'mise activate
+# --shims' puts the shims directory there, both are supported activation
+# modes, and pinning either one as the single answer makes the other mode
+# permanently non-canonical. Every other provider installs to one place.
+#
+# The first line is the representative, the path a failure message names when
+# it has to print a single canonical location. For mise that is the active
+# target, and the shims path when nothing is active, because those are the two
+# locations that exist independently of which runtimes happen to be installed.
+canonical_candidates() {
   provider="$1"
   command="$2"
 
@@ -237,16 +273,52 @@ expected_executable() {
       printf '%s/.local/bin/%s\n' "$HOME" "$command"
       ;;
     mise)
-      mise_shims_dir="${TERRAPOD_MISE_SHIMS_DIR:-${MISE_DATA_DIR:-$HOME/.local/share/mise}/shims}"
-      printf '%s/%s\n' "$mise_shims_dir" "$command"
+      mise_which "$command"
+      printf '%s/%s\n' "$(mise_shims_dir)" "$command"
+      mise_bin_paths | while IFS= read -r bin_dir; do
+        [ -n "$bin_dir" ] || continue
+        printf '%s/%s\n' "$bin_dir" "$command"
+      done
       ;;
   esac
 }
 
-files_are_same() {
-  first="$1"
-  second="$2"
-  [ "$first" = "$second" ] || [ "$first" -ef "$second" ]
+first_candidate() {
+  printf '%s\n' "$1" | awk 'NF { print; exit }'
+}
+
+# A declaration is installed when any accepted location holds an executable.
+# Requiring all of them would fail every machine, because the shims path and
+# the active install directory are alternatives, not companions.
+any_candidate_installed() {
+  printf '%s\n' "$1" | {
+    while IFS= read -r candidate; do
+      [ -n "$candidate" ] || continue
+      if [ -x "$candidate" ]; then
+        exit 0
+      fi
+    done
+    exit 1
+  }
+}
+
+# Whether the executable that runs is one of the canonical candidates. Path
+# equality and -ef are both needed: -ef alone misses a candidate that names a
+# file this machine does not have, and equality alone misses the ordinary case
+# of one file reached through two paths.
+matches_canonical() {
+  matches_actual="$1"
+  matches_list="$2"
+
+  printf '%s\n' "$matches_list" | {
+    while IFS= read -r candidate; do
+      [ -n "$candidate" ] || continue
+      if [ "$matches_actual" = "$candidate" ] || [ "$matches_actual" -ef "$candidate" ]; then
+        exit 0
+      fi
+    done
+    exit 1
+  }
 }
 
 print_failure() {
@@ -280,7 +352,8 @@ records="$(active_records)"
 
 while IFS='|' read -r provider package command; do
   [ -n "$provider" ] || continue
-  expected="$(expected_executable "$provider" "$command" 2>/dev/null || true)"
+  candidates="$(canonical_candidates "$provider" "$command" 2>/dev/null || true)"
+  representative="$(first_candidate "$candidates")"
 
   if ! provider_has_package "$provider" "$package"; then
     print_failure "$package is not installed through $(provider_label "$provider")"
@@ -289,8 +362,8 @@ while IFS='|' read -r provider package command; do
     continue
   fi
 
-  if [ -z "$expected" ] || [ ! -x "$expected" ]; then
-    print_failure "$package canonical executable is missing: ${expected:-unknown}"
+  if ! any_candidate_installed "$candidates"; then
+    print_failure "$package canonical executable is missing: ${representative:-unknown}"
     failure_found=1
     issue_found=1
     continue
@@ -298,14 +371,14 @@ while IFS='|' read -r provider package command; do
 
   actual="$(resolve_in_path "$command" || true)"
   if [ -z "$actual" ]; then
-    print_failure "$package is unavailable on PATH (canonical: $expected)"
+    print_failure "$package is unavailable on PATH (canonical: $representative)"
     failure_found=1
     issue_found=1
     continue
   fi
 
-  if ! files_are_same "$actual" "$expected"; then
-    print_advisory "$package" "$actual" "$expected"
+  if ! matches_canonical "$actual" "$candidates"; then
+    print_advisory "$package" "$actual" "$representative"
     issue_found=1
   fi
 done <<EOF

--- a/dot_local/lib/terrapod/executable_executable-selection
+++ b/dot_local/lib/terrapod/executable_executable-selection
@@ -61,20 +61,20 @@ probe_login_path() {
     "$probe_zsh" -lc 'print -rn -- $PATH' 2>/dev/null
 }
 
-# Asked once per process. The directory set now answers both the managed PATH
-# and every Development Runtime candidate set, and 'mise bin-paths' is not a
-# cheap command to run once per declaration.
 mise_bin_paths_value=""
-mise_bin_paths_loaded=0
+
+# Probed once per process, the same shape initialize_managed_path uses and for
+# the same reason: every read of this value happens inside a pipeline or a
+# command substitution, so a cache filled on first read would be filled in a
+# subshell and thrown away. The directory set answers both the managed PATH and
+# every Development Runtime candidate set, and 'mise bin-paths' is not a cheap
+# command to run once per declaration.
+initialize_mise_bin_paths() {
+  command -v mise >/dev/null 2>&1 || return 0
+  mise_bin_paths_value="$(mise bin-paths 2>/dev/null || true)"
+}
 
 mise_bin_paths() {
-  if [ "$mise_bin_paths_loaded" -eq 0 ]; then
-    mise_bin_paths_loaded=1
-    if command -v mise >/dev/null 2>&1; then
-      mise_bin_paths_value="$(mise bin-paths 2>/dev/null || true)"
-    fi
-  fi
-
   [ -n "$mise_bin_paths_value" ] || return 0
   printf '%s\n' "$mise_bin_paths_value"
 }
@@ -338,6 +338,7 @@ print_advisory() {
   printf '%s\n' "             Adjust PATH or remove the other installation manually, then rerun 'tpod doctor'."
 }
 
+initialize_mise_bin_paths
 initialize_managed_path
 
 # A verdict that cannot be made invocation-independent still has to be

--- a/tests/executable_selection_test.sh
+++ b/tests/executable_selection_test.sh
@@ -88,6 +88,34 @@ python python3
 uv uv
 EOF
 
+# The stand-in for mise answers from fixture files so a test can describe an
+# activation mode without installing a runtime. Both files start empty, which
+# is the machine where mise has no active declaration for anything: 'bin-paths'
+# says nothing and 'which' reports the tool is not currently active.
+mise_bin_paths_file="$tmp_dir/mise-bin-paths"
+mise_which_dir="$tmp_dir/mise-which"
+mkdir -p "$mise_which_dir"
+: >"$mise_bin_paths_file"
+
+cat >"$prefix/bin/mise" <<EOF
+#!/bin/sh
+case "\${1:-}" in
+  bin-paths)
+    cat "$mise_bin_paths_file"
+    ;;
+  which)
+    if [ -f "$mise_which_dir/\${2:-}" ]; then
+      cat "$mise_which_dir/\${2:-}"
+    else
+      printf '%s is a mise bin however it is not currently active\n' "\${2:-}" >&2
+      exit 1
+    fi
+    ;;
+esac
+exit 0
+EOF
+chmod +x "$prefix/bin/mise"
+
 run_selection() {
   mode="$1"
   shift
@@ -261,6 +289,75 @@ assert_not_contains "$managed_output" "inherited PATH" \
 status_output="$(run_selection status)"
 assert_contains "$status_output" "Executable selection:" \
   "status exposes executable selection state"
+
+# Canonical selection for a Development Runtime declaration is a set: the
+# manager's active target, the directories it reports as its bin paths, and the
+# shims path. The same machine has to stay canonical whether it runs
+# 'mise activate' or 'mise activate --shims'.
+mise_bin_dir="$tmp_dir/mise-installs/bin"
+mise_active_dir="$tmp_dir/mise-active/bin"
+mise_path_dir="$tmp_dir/mise-path"
+mkdir -p "$mise_path_dir"
+for runtime_command in bun node python3 uv; do
+  write_executable "$mise_bin_dir/$runtime_command"
+  write_executable "$mise_active_dir/$runtime_command"
+done
+printf '%s\n' "$mise_bin_dir" >"$mise_bin_paths_file"
+
+run_mise_selection() {
+  HOME="$tmp_dir/home" \
+    TERRAPOD_EXECUTABLE_SELECTION_INVENTORY_DIR="$inventory" \
+    TERRAPOD_STANDARD_HOMEBREW_PREFIX="$prefix" \
+    TERRAPOD_MISE_SHIMS_DIR="$mise_shims" \
+    TERRAPOD_MANAGED_PATH="$mise_path_dir:$path_dir:/usr/bin:/bin" \
+    PATH="$mise_path_dir:$path_dir:/usr/bin:/bin" \
+    "$selection" doctor macos-terminal false false 2>&1 || true
+}
+
+# Puts the runtime commands ahead of everything else, resolving to the given
+# directory, so each accepted location can be judged on its own.
+select_runtimes_from() {
+  for runtime_command in bun node python3 uv; do
+    rm -f "$mise_path_dir/$runtime_command"
+    ln -s "$1/$runtime_command" "$mise_path_dir/$runtime_command"
+  done
+}
+
+select_runtimes_from "$mise_bin_dir"
+bin_paths_output="$(run_mise_selection)"
+assert_not_contains "$bin_paths_output" "advisory - node" \
+  "a runtime resolving through a reported mise bin directory is canonical"
+
+select_runtimes_from "$mise_shims"
+shims_mode_output="$(run_mise_selection)"
+assert_not_contains "$shims_mode_output" "advisory - node" \
+  "the shims path stays canonical once the bin directories are accepted"
+
+for runtime_command in bun node python3 uv; do
+  printf '%s\n' "$mise_active_dir/$runtime_command" >"$mise_which_dir/$runtime_command"
+done
+select_runtimes_from "$mise_active_dir"
+active_target_output="$(run_mise_selection)"
+assert_not_contains "$active_target_output" "advisory - node" \
+  "the target mise reports as active is canonical"
+
+mise_rogue_dir="$tmp_dir/mise-rogue"
+write_executable "$mise_rogue_dir/node"
+rm -f "$mise_path_dir/node"
+ln -s "$mise_rogue_dir/node" "$mise_path_dir/node"
+rogue_runtime_output="$(run_mise_selection)"
+assert_contains "$rogue_runtime_output" "advisory - node resolves to $mise_path_dir/node" \
+  "a runtime outside every accepted location stays an advisory"
+assert_contains "$rogue_runtime_output" "canonical: $mise_active_dir/node" \
+  "the advisory names the active target as the single canonical location"
+
+rm -f "$mise_which_dir/node"
+inactive_runtime_output="$(run_mise_selection)"
+assert_contains "$inactive_runtime_output" "canonical: $mise_shims/node" \
+  "the advisory names the shims path when mise reports nothing active"
+
+: >"$mise_bin_paths_file"
+rm -f "$mise_which_dir"/*
 
 # The canonical path appears in whichever concern the record raises, so these
 # assertions observe the resolved prefix without depending on what the host

--- a/tests/executable_selection_test.sh
+++ b/tests/executable_selection_test.sh
@@ -93,14 +93,17 @@ EOF
 # is the machine where mise has no active declaration for anything: 'bin-paths'
 # says nothing and 'which' reports the tool is not currently active.
 mise_bin_paths_file="$tmp_dir/mise-bin-paths"
+mise_bin_paths_log="$tmp_dir/mise-bin-paths.log"
 mise_which_dir="$tmp_dir/mise-which"
 mkdir -p "$mise_which_dir"
 : >"$mise_bin_paths_file"
+: >"$mise_bin_paths_log"
 
 cat >"$prefix/bin/mise" <<EOF
 #!/bin/sh
 case "\${1:-}" in
   bin-paths)
+    printf '%s\n' bin-paths >>"$mise_bin_paths_log"
     cat "$mise_bin_paths_file"
     ;;
   which)
@@ -324,9 +327,18 @@ select_runtimes_from() {
 }
 
 select_runtimes_from "$mise_bin_dir"
+: >"$mise_bin_paths_log"
 bin_paths_output="$(run_mise_selection)"
 assert_not_contains "$bin_paths_output" "advisory - node" \
   "a runtime resolving through a reported mise bin directory is canonical"
+
+# One process, one probe. The directory set feeds four Development Runtime
+# declarations, and every read of it happens inside a pipeline, so a cache that
+# fills itself on first read fills a subshell instead.
+bin_paths_calls="$(grep -c . "$mise_bin_paths_log")"
+[ "$bin_paths_calls" = 1 ] ||
+  fail "the check asks mise for its bin paths once per process (asked $bin_paths_calls times)"
+pass "the check asks mise for its bin paths once per process"
 
 select_runtimes_from "$mise_shims"
 shims_mode_output="$(run_mise_selection)"


### PR DESCRIPTION
`expected_executable` pinned every Development Runtime declaration to `$MISE_DATA_DIR/shims/<command>`, but `dot_zshrc.tmpl:7` activates mise with `eval "$(mise activate zsh)"`, and that mode puts the resolved install directories at the front of PATH rather than the shims. The two disagree permanently, so all four runtime declarations report an advisory on a machine where nothing is wrong:

```
advisory - bun resolves to ~/.local/share/mise/installs/bun/latest/bin/bun
           canonical: ~/.local/share/mise/shims/bun
```

Both `mise activate` and `mise activate --shims` are supported resolution modes. Naming either one as the single canonical location makes the other mode permanently non-canonical, and the one Terrapod's own zshrc configures is the one that was losing.

## What changed

Canonical selection becomes a set. `canonical_candidates` returns a newline-separated list, and `matches_canonical` accepts a resolution that equals any candidate or names the same file as one.

- mise contributes three kinds of location: the target `mise which <command>` reports as active, the shims path, and `<dir>/<command>` for each directory `mise bin-paths` lists. Keeping the shims path in the set preserves the `--shims` mode without making it the only answer.
- Every other provider keeps its single location, so `homebrew-formula`, `homebrew-cask`, and `claude-installer` behave exactly as before.
- A declaration counts as installed when any accepted location holds an executable. Requiring all of them would fail every machine, because the shims path and the active install directory are alternatives, not companions.
- Where a message has to name one canonical path, it names the first candidate: for mise the active target, and the shims path when mise reports nothing active.
- `mise bin-paths` is now asked once per process instead of once per declaration; it already answered the managed PATH and is not a cheap command.

## Tests

The test file's stand-in for mise answers `bin-paths` and `which` from fixture files, so a test can describe an activation mode without installing a runtime. Both files start empty, which is the machine mise has no active declaration for, and that is what every pre-existing assertion still runs against.

New assertions cover each accepted location on its own — a bin directory mise reports, the shims path, and the active target — plus a runtime outside all of them staying an advisory, and both representative paths a message can name.

`PATH="$(mise where python)/bin:$PATH" tests/run` passes: 27 test files, exit 0.

Closes #234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1vLGxSRHovE2WGeb21AtC