### PR TITLE
Judge shim resolution by the file the shim actually runs

### DIFF
--- a/dot_local/lib/terrapod/executable_executable-selection
+++ b/dot_local/lib/terrapod/executable_executable-selection
@@ -115,17 +115,89 @@ managed_path() {
   printf '%s\n' "$managed_path_value"
 }
 
-# command -v inside the managed PATH. The subshell keeps the assignment from
+# command -v inside a given PATH. The subshell keeps the assignment from
 # leaking into the rest of the check, and the hash table is dropped because a
 # command this process already ran -- mise, brew -- would otherwise report
-# where the ambient PATH found it rather than where the managed PATH does.
-resolve_in_path() {
+# where the ambient PATH found it rather than where the given PATH does.
+resolve_in() {
   (
-    PATH="$managed_path_value"
+    PATH="$1"
     export PATH
     hash -r 2>/dev/null || true
-    command -v "$1" 2>/dev/null
+    command -v "$2" 2>/dev/null
   )
+}
+
+resolve_in_path() {
+  resolve_in "$managed_path_value" "$1"
+}
+
+# The managed PATH with one directory dropped. Used to ask what a shim forwards
+# to: removing the shims directory and resolving again is the only way to
+# observe the next match, because the shim itself answers every other probe.
+managed_path_without() {
+  printf '%s' "$managed_path_value" | awk -v drop="$1" '
+    BEGIN { RS = ":" }
+    {
+      entry = $0
+      sub(/\/+$/, "", entry)
+      if (entry == drop) next
+      out = out (kept++ ? ":" : "") $0
+    }
+    END { printf "%s", out }
+  '
+}
+
+# Trailing and repeated slashes name the same file but not the same string, and
+# the three sources an effective executable can come from -- command -v, 'mise
+# which', and a second resolution -- do not agree on them.
+normalize_path() {
+  printf '%s\n' "$1" | sed -e 's|//*|/|g' -e 's|\(.\)/*$|\1|'
+}
+
+# The file that actually runs when the command is typed, which is not always
+# the file the managed PATH resolves to. A Development Runtime Manager shim is
+# a symlink to the manager binary, so it neither equals nor is -ef to the
+# executable it ends up running; both comparisons the check makes are blind to
+# it and the forwarding has to be followed by asking.
+#
+# A shim for a tool no active config selects does not execute the manager's own
+# payload at all: the manager refuses to resolve it and the shim forwards to
+# the next PATH match. That is the case that produced 15 false advisories on a
+# macOS workstation for commands already running the Homebrew build, so the
+# fall-through is resolved rather than assumed unreachable.
+#
+# When neither question answers -- the manager is gone, or nothing else on PATH
+# provides the command -- the shim itself is the honest answer, because that is
+# the file the managed PATH would hand the caller.
+effective_executable() {
+  effective_command="$1"
+  effective_resolved="$2"
+  effective_shims="$(normalize_path "$(mise_shims_dir)")"
+
+  case "$(normalize_path "$effective_resolved")" in
+    "$effective_shims"/*) ;;
+    *)
+      normalize_path "$effective_resolved"
+      return
+      ;;
+  esac
+
+  effective_active="$(mise_which "$effective_command")"
+  if [ -n "$effective_active" ]; then
+    normalize_path "$effective_active"
+    return
+  fi
+
+  effective_fallthrough="$(
+    resolve_in "$(managed_path_without "$effective_shims")" "$effective_command"
+  )"
+  if [ -n "$effective_fallthrough" ]; then
+    normalize_path "$effective_fallthrough"
+    return
+  fi
+
+  normalize_path "$effective_resolved"
 }
 
 core_records() {
@@ -302,7 +374,7 @@ any_candidate_installed() {
   }
 }
 
-# Whether the executable that runs is one of the canonical candidates. Path
+# Whether the effective executable is one of the canonical candidates. Path
 # equality and -ef are both needed: -ef alone misses a candidate that names a
 # file this machine does not have, and equality alone misses the ordinary case
 # of one file reached through two paths.
@@ -378,7 +450,14 @@ while IFS='|' read -r provider package command; do
     continue
   fi
 
-  if ! matches_canonical "$actual" "$candidates"; then
+  # The verdict is made on the effective executable, but the advisory names the
+  # path the managed PATH resolved to. That path is what the reader has to act
+  # on -- it is the entry to reorder or the file to remove -- while the file the
+  # forwarding reached is somewhere the reader never put anything. It is also
+  # the directory advisories group by, since a shared resolved directory is the
+  # shared cause.
+  effective="$(effective_executable "$command" "$actual")"
+  if ! matches_canonical "$effective" "$candidates"; then
     print_advisory "$package" "$actual" "$representative"
     issue_found=1
   fi

--- a/tests/executable_selection_test.sh
+++ b/tests/executable_selection_test.sh
@@ -371,6 +371,55 @@ assert_contains "$inactive_runtime_output" "canonical: $mise_shims/node" \
 : >"$mise_bin_paths_file"
 rm -f "$mise_which_dir"/*
 
+# A shim is a symlink to the mise binary, never to the executable it ends up
+# running, so neither string equality nor -ef can see through it. These four
+# cases are the whole of that indirection: the shim forwards because mise has
+# nothing active, or it forwards to what mise does have active, and either
+# destination can be canonical or not.
+ln -s "$prefix/bin/mise" "$mise_shims/rg"
+shim_path="$mise_shims:$path_dir:/usr/bin:/bin"
+
+run_shim_selection() {
+  HOME="$tmp_dir/home" \
+    TERRAPOD_EXECUTABLE_SELECTION_INVENTORY_DIR="$inventory" \
+    TERRAPOD_STANDARD_HOMEBREW_PREFIX="$prefix" \
+    TERRAPOD_MISE_SHIMS_DIR="$mise_shims" \
+    TERRAPOD_MANAGED_PATH="$shim_path" \
+    PATH="$shim_path" \
+    "$selection" doctor macos-terminal false false 2>&1 || true
+}
+
+passthrough_output="$(run_shim_selection)"
+assert_not_contains "$passthrough_output" "advisory - ripgrep" \
+  "a shim mise cannot activate is judged by the canonical file it forwards to"
+
+# The same fall-through, landing somewhere else. Without this the fix would
+# also swallow the findings the check exists for.
+rogue_shim_dir="$tmp_dir/rogue-shim-target"
+write_executable "$rogue_shim_dir/rg"
+rm -f "$path_dir/rg"
+ln -s "$rogue_shim_dir/rg" "$path_dir/rg"
+rogue_passthrough_output="$(run_shim_selection)"
+assert_contains "$rogue_passthrough_output" "advisory - ripgrep resolves to $mise_shims/rg" \
+  "a shim forwarding to a non-canonical file stays an advisory"
+assert_contains "$rogue_passthrough_output" "canonical: $prefix/bin/rg" \
+  "the shim advisory names the path the reader has to act on and the canonical one"
+
+rm -f "$path_dir/rg"
+ln -s "$prefix/bin/rg" "$path_dir/rg"
+
+printf '%s\n' "$prefix/bin/rg" >"$mise_which_dir/rg"
+active_canonical_output="$(run_shim_selection)"
+assert_not_contains "$active_canonical_output" "advisory - ripgrep" \
+  "a shim mise activates onto the canonical file raises no advisory"
+
+printf '%s\n' "$rogue_shim_dir/rg" >"$mise_which_dir/rg"
+active_rogue_output="$(run_shim_selection)"
+assert_contains "$active_rogue_output" "advisory - ripgrep resolves to $mise_shims/rg" \
+  "a shim mise activates onto its own payload is an advisory when Homebrew is canonical"
+
+rm -f "$mise_shims/rg" "$mise_which_dir/rg"
+
 # The canonical path appears in whichever concern the record raises, so these
 # assertions observe the resolved prefix without depending on what the host
 # machine has actually installed.


### PR DESCRIPTION
## Problem

`dot_local/lib/terrapod/executable_executable-selection` compared the path
`resolve_in_path` returned against the canonical candidates. A mise shim is a
symlink to the `mise` binary, never to the executable it ends up running, so
neither string equality nor `-ef` can observe what typing the command actually
executes.

When no active config selects a tool, mise refuses to resolve it and the shim
forwards transparently to the next PATH match. On a macOS workstation that is
the Homebrew build the declaration asks for, so 15 commands already running the
canonical file — `bat`, `dust`, `duf`, `fastfetch`, `fd`, `fzf`, `gh`,
`git-delta`, `lazygit`, `lsd`, `neovim`, `ripgrep`, `starship`, `zellij`,
`zoxide` — were reported as a different installation.

## Change

`effective_executable <command> <resolved>` returns the file that would actually
run, following the four steps in the approved design:

1. A resolved path outside the shims directory is the effective executable.
2. Inside it, `mise which <command>` names the target.
3. When mise reports nothing active, the shims directory is dropped from the
   managed PATH and the command is resolved again; that is what the shim falls
   through to.
4. The result is normalized before comparison.

`matches_canonical` now receives the effective executable instead of the
resolved path. `resolve_in_path` is factored into `resolve_in <path> <command>`
so step 3 can resolve against a modified PATH without duplicating the subshell
and `hash -r` handling.

## The `actual` path in the advisory

The advisory keeps naming the path the managed PATH **resolved to**, not the
effective executable. Two reasons, recorded in a comment at the call site:

- The resolved path is what the reader has to act on. It is the PATH entry to
  reorder or the file to remove; the file the forwarding reached is somewhere
  the reader never put anything and cannot usefully change.
- It is the grouping key #237 uses. The design keys advisory groups on "the
  directory the original `resolve_in_path` landed in — that directory is the
  shared cause", and the mock reads `15 commands resolve through
  ~/.local/share/mise/shims`.

## Tests

`tests/executable_selection_test.sh` gains four cases covering the whole of the
shim indirection, built on the fake-mise harness from #234. Each uses a shim
that is a **symlink to the fake mise binary** — the `-ef` trap — with the shims
directory ahead of the canonical Homebrew directory in `TERRAPOD_MANAGED_PATH`:

- mise reports nothing active, fall-through lands on the canonical file → no
  advisory (the 15-false-advisory case).
- mise reports nothing active, fall-through lands elsewhere → advisory, naming
  the shim path and the canonical path. Without this the fix would swallow real
  findings.
- mise reports an active target that is the canonical file → no advisory.
- mise reports an active target that is its own payload → advisory.

The first case fails against `origin/main`, confirming it observes the fix.
Every existing assertion is unchanged.

`PATH="$(mise where python)/bin:$PATH" tests/run` — 28 test files passed.

## Scope

`print_advisory`'s output shape is untouched (#237). ADR 0020 and `CONTEXT.md`
are already on `main` and are unmodified; this implementation matches both.

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1vLGxSRHovE2WGeb21AtC