### PR TITLE
Group executable selection advisories by resolved directory

### DIFF
--- a/dot_local/lib/terrapod/executable_executable-selection
+++ b/dot_local/lib/terrapod/executable_executable-selection
@@ -401,13 +401,111 @@ print_failure() {
   esac
 }
 
-print_advisory() {
-  package="$1"
-  actual="$2"
-  expected="$3"
-  printf '  advisory - %s resolves to %s\n' "$package" "$actual"
-  printf '             canonical: %s\n' "$expected"
-  printf '%s\n' "             Adjust PATH or remove the other installation manually, then rerun 'tpod doctor'."
+# Advisories are buffered rather than printed as they are found, so the shape
+# of the block can be decided once every finding is in. The key is the
+# directory the managed PATH resolved to: when several commands resolve
+# through one directory, that directory is the single cause, and the reader
+# has one entry to reorder rather than fifteen findings to read.
+#
+# The record loop reads from a heredoc rather than a pipeline, so appending
+# here reaches the buffer the renderer reads. Filling it from inside a
+# pipeline would fill a subshell and throw it away.
+advisory_records=""
+
+buffer_advisory() {
+  advisory_package="$1"
+  advisory_actual="$2"
+  advisory_expected="$3"
+
+  case "$advisory_actual" in
+    */*) advisory_dir="${advisory_actual%/*}" ;;
+    *) advisory_dir="$advisory_actual" ;;
+  esac
+
+  advisory_records="$advisory_records$advisory_dir|$advisory_package|$advisory_actual|$advisory_expected
+"
+}
+
+# The guidance sentence is invariant, so it prints once as the block's last
+# line instead of once per finding. That is one step further than #237's mock,
+# which repeats it per group; the stated goal is to stop repeating invariant
+# text, and there is only one sentence to give.
+#
+# A group of two or more collapses to a header, a wrapped package list, and
+# the canonical location. Per-package actual and canonical paths still have to
+# be recoverable -- ADR 0012 requires the advisory to carry both -- so a group
+# prints the shared canonical directory only when its canonical paths share
+# one, and falls back to a line per package when they do not.
+render_advisories() {
+  printf '%s' "$advisory_records" | awk \
+    -v guidance="Adjust PATH or remove the other installation manually, then rerun 'tpod doctor'." '
+    BEGIN {
+      FS = "|"
+      indent = "             "
+      width = 76
+    }
+
+    function directory_of(path,   trimmed) {
+      trimmed = path
+      sub(/\/[^\/]*$/, "", trimmed)
+      return trimmed
+    }
+
+    {
+      dir = $1
+      if (!(dir in count)) { order[++groups] = dir }
+      slot = ++count[dir]
+      package[dir, slot] = $2
+      actual[dir, slot] = $3
+      canonical[dir, slot] = $4
+    }
+
+    END {
+      for (g = 1; g <= groups; g++) {
+        dir = order[g]
+        members = count[dir]
+
+        if (members == 1) {
+          printf "  advisory - %s resolves to %s\n", package[dir, 1], actual[dir, 1]
+          printf "%scanonical: %s\n", indent, canonical[dir, 1]
+          continue
+        }
+
+        printf "  advisory - %d commands resolve through %s\n", members, dir
+
+        line = ""
+        for (member = 1; member <= members; member++) {
+          item = package[dir, member] (member < members ? "," : "")
+          candidate = (line == "" ? item : line " " item)
+          if (line != "" && length(candidate) + length(indent) > width) {
+            print indent line
+            line = item
+          } else {
+            line = candidate
+          }
+        }
+        if (line != "") print indent line
+
+        shared = directory_of(canonical[dir, 1])
+        for (member = 2; member <= members; member++) {
+          if (directory_of(canonical[dir, member]) != shared) {
+            shared = ""
+            break
+          }
+        }
+
+        if (shared != "") {
+          printf "%scanonical: %s\n", indent, shared
+        } else {
+          for (member = 1; member <= members; member++) {
+            printf "%scanonical (%s): %s\n", indent, package[dir, member], canonical[dir, member]
+          }
+        }
+      }
+
+      if (groups > 0) { printf "  %s\n", guidance }
+    }
+  '
 }
 
 initialize_mise_bin_paths
@@ -458,12 +556,14 @@ while IFS='|' read -r provider package command; do
   # shared cause.
   effective="$(effective_executable "$command" "$actual")"
   if ! matches_canonical "$effective" "$candidates"; then
-    print_advisory "$package" "$actual" "$representative"
+    buffer_advisory "$package" "$actual" "$representative"
     issue_found=1
   fi
 done <<EOF
 $records
 EOF
+
+render_advisories
 
 case "$mode" in
   apply)

--- a/tests/executable_selection_test.sh
+++ b/tests/executable_selection_test.sh
@@ -420,9 +420,94 @@ assert_contains "$active_rogue_output" "advisory - ripgrep resolves to $mise_shi
 
 rm -f "$mise_shims/rg" "$mise_which_dir/rg"
 
-# The canonical path appears in whichever concern the record raises, so these
-# assertions observe the resolved prefix without depending on what the host
-# machine has actually installed.
+rm -f "$path_dir/bat"
+ln -s "$prefix/bin/bat" "$path_dir/bat"
+
+# The output shape #237 is about. Fifteen commands resolving through one
+# directory share one cause, so they collapse into a single finding with a
+# wrapped package list, the lone genuine finding keeps the two-line form that
+# makes it readable beside them, and the invariant guidance sentence prints
+# once for the whole block instead of once per package.
+#
+# Advisory lines are asserted whole rather than as substrings, because a group
+# line and a per-package line differ only in their tail.
+assert_line() {
+  if ! printf '%s\n' "$1" | grep -F -x -e "$2" >/dev/null; then
+    printf '%s\n' "missing line: $2" >&2
+    printf '%s\n' "$1" | sed 's/^/  /' >&2
+    fail "$3"
+  fi
+  pass "$3"
+}
+
+assert_occurrences() {
+  occurrences="$(printf '%s\n' "$1" | grep -c -F -e "$2" || true)"
+  [ "$occurrences" = "$3" ] || fail "$4 (found $occurrences)"
+  pass "$4"
+}
+
+group_dir="$tmp_dir/group-bin"
+single_dir="$tmp_dir/single-bin"
+mkdir -p "$group_dir" "$single_dir"
+for group_command in bat dust duf fastfetch fd fzf gh delta lazygit lsd nvim rg starship zellij zoxide; do
+  write_executable "$group_dir/$group_command"
+done
+write_executable "$single_dir/git"
+
+run_group_selection() {
+  HOME="$tmp_dir/home" \
+    TERRAPOD_EXECUTABLE_SELECTION_INVENTORY_DIR="$inventory" \
+    TERRAPOD_STANDARD_HOMEBREW_PREFIX="$prefix" \
+    TERRAPOD_MISE_SHIMS_DIR="$mise_shims" \
+    TERRAPOD_MANAGED_PATH="$group_dir:$single_dir:$path_dir:/usr/bin:/bin" \
+    PATH="$group_dir:$single_dir:$path_dir:/usr/bin:/bin" \
+    "$selection" doctor macos-terminal false false 2>&1 || true
+}
+
+group_output="$(run_group_selection)"
+assert_line "$group_output" "  advisory - 15 commands resolve through $group_dir" \
+  "advisories that share a resolved directory collapse into one finding"
+assert_line "$group_output" \
+  "             bat, dust, duf, fastfetch, fd, fzf, gh, git-delta, lazygit," \
+  "the grouped finding wraps its package list instead of running it off the line"
+assert_line "$group_output" "             lsd, neovim, ripgrep, starship, zellij, zoxide" \
+  "the wrapped package list carries every package in the group"
+assert_line "$group_output" "             canonical: $prefix/bin" \
+  "a group whose canonical paths share a directory names that directory once"
+assert_not_contains "$group_output" "advisory - bat resolves to" \
+  "a grouped package does not also print an advisory header of its own"
+assert_line "$group_output" "  advisory - git resolves to $single_dir/git" \
+  "a lone finding keeps the per-package form"
+assert_line "$group_output" "             canonical: $prefix/bin/git" \
+  "a lone finding still names its canonical executable"
+assert_line "$group_output" \
+  "  Adjust PATH or remove the other installation manually, then rerun 'tpod doctor'." \
+  "the guidance sentence closes the advisory block"
+assert_occurrences "$group_output" \
+  "Adjust PATH or remove the other installation manually, then rerun 'tpod doctor'." 1 \
+  "the guidance sentence prints once for the whole block, not once per finding"
+
+# ADR 0012 requires the advisory to carry both paths, so a group collapses to a
+# single canonical directory only when its members actually share one. A
+# Development Runtime declaration resolving through the same directory as the
+# Homebrew ones does not, and the group falls back to a line per package.
+write_executable "$group_dir/node"
+mixed_canonical_output="$(run_group_selection)"
+assert_line "$mixed_canonical_output" "  advisory - 16 commands resolve through $group_dir" \
+  "a Development Runtime declaration joins the group of its resolved directory"
+assert_line "$mixed_canonical_output" "             canonical (bat): $prefix/bin/bat" \
+  "a group with unshared canonical directories names each package's canonical path"
+assert_line "$mixed_canonical_output" "             canonical (node): $mise_shims/node" \
+  "the per-package fallback keeps each provider's own canonical location"
+assert_occurrences "$mixed_canonical_output" "             canonical (" 16 \
+  "the per-package fallback covers every package in the group"
+rm -f "$group_dir/node"
+
+# The canonical location appears in whichever concern the record raises -- a
+# missing-executable failure, a per-package advisory, or a group's shared
+# canonical directory -- so these assertions observe the resolved prefix
+# without depending on what the host machine has actually installed or on
+# which shape the finding takes.
 assert_canonical_prefix() {
   profile="$1"
   arch="$2"
@@ -444,8 +529,8 @@ assert_canonical_prefix() {
   )"
   set -e
 
-  assert_contains "$prefix_output" "$expected_prefix/bin/bat" "$label"
-  assert_not_contains "$prefix_output" "$rejected_prefix/bin/bat" "$label rejects the other prefix"
+  assert_contains "$prefix_output" "$expected_prefix/bin" "$label"
+  assert_not_contains "$prefix_output" "$rejected_prefix/bin" "$label rejects the other prefix"
 }
 
 assert_canonical_prefix macos-terminal x86_64 1 /opt/homebrew /usr/local \


### PR DESCRIPTION
Closes #237

## Problem

Every advisory printed three lines and the third was invariant. A macOS workstation with sixteen findings emitted forty-eight lines with the same sentence repeated sixteen times, and the one genuine misconfiguration was buried in fifteen that shared a single cause.

#233 removed those fifteen at the source. This is the output shape that made sixteen advisories unreadable in the first place, which the issue says stays worth fixing after that lands.

## Change

`print_advisory` becomes a buffer plus a renderer. Findings are collected during the record loop and rendered once it ends, keyed by the directory `resolve_in_path` landed in — not the effective executable the shim forwarding reached, which is somewhere the reader never put anything. The resolved directory is the shared cause and the single PATH entry to reorder.

- A group of two or more prints a header, a wrapped package list, and the canonical location.
- A lone finding keeps the current two-line form.
- The guidance sentence prints once, as the advisory block's last line.

```
  advisory - 15 commands resolve through /Users/minu/.local/share/mise/shims
             bat, dust, duf, fastfetch, fd, fzf, gh, git-delta, lazygit,
             lsd, neovim, ripgrep, starship, zellij, zoxide
             canonical: /opt/homebrew/bin
  advisory - git resolves to /usr/bin/git
             canonical: /opt/homebrew/bin/git
  Adjust PATH or remove the other installation manually, then rerun 'tpod doctor'.
```

The guidance sentence lands once per block rather than once per group as #237's mock shows. That is deliberate and recorded in the approved design: the stated goal is to stop repeating invariant text, end-of-block is strictly better at that goal than per-group, and there is only one sentence to give.

ADR 0012 requires the advisory to carry actual and canonical paths. A group prints a shared canonical directory only when its members actually share one, and falls back to a line per package (`canonical (bat): /opt/homebrew/bin/bat`) when they do not.

`tpod status` still summarizes to a readiness word, `issue_found` keeps its meaning, and no resolution logic is touched.

## Buffering

The buffer is a plain variable and the record loop reads from a heredoc, so appends reach the buffer the renderer reads. Filling it from inside a pipeline would fill a subshell and throw it away — the trap this file already hit once in #234 review.

## Tests

New coverage in `tests/executable_selection_test.sh` reproduces the issue's own shape: fifteen commands shadowed through one directory plus `git` shadowed through another. It asserts the header, both wrapped package-list lines, the shared canonical directory, that a grouped package prints no header of its own, that the lone finding keeps the per-package form, and that the guidance sentence occurs exactly once. A second case adds a Development Runtime declaration to the group and asserts the per-package canonical fallback.

The Homebrew prefix assertions moved from `<prefix>/bin/bat` to `<prefix>/bin`. They exist to observe which prefix was resolved without depending on what the host machine has installed, and that prefix is now visible as a group's shared canonical directory on a machine where the finding takes that shape.

`PATH="$(mise where python)/bin:$PATH" tests/run` — 28 test files passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1vLGxSRHovE2WGeb21AtC