### PR TITLE
Report mise payloads no declaration can reach

### DIFF
--- a/dot_local/lib/terrapod/executable_executable-selection
+++ b/dot_local/lib/terrapod/executable_executable-selection
@@ -508,6 +508,75 @@ render_advisories() {
   '
 }
 
+# Payloads under the Development Runtime Manager's own install directory that
+# no declaration can reach. ADR 0010 moved the Core Shell Stack to Homebrew and
+# ADR 0012 kept apply non-destructive, so every install made before that
+# migration stays on disk: no config selects it, 'mise which' reports it is not
+# active, and mise keeps generating a shim for it. Those shims used to be
+# (over)reported as one selection advisory per tool; silencing them correctly
+# left the disk they occupy with nothing to report it at all, which is what
+# this count restores.
+#
+# A payload is reachable when a 'mise bin-paths' entry lies beneath it. The
+# comparison respects the path boundary rather than comparing strings: one
+# payload name can extend another -- 'installs/node' and 'installs/node-canary'
+# -- and a prefix test would let either hide the other.
+leftover_payload_count() {
+  command -v mise >/dev/null 2>&1 || return 0
+  leftover_installs="$(normalize_path "${MISE_DATA_DIR:-$HOME/.local/share/mise}/installs")"
+  [ -d "$leftover_installs" ] || return 0
+
+  leftover_bin_paths="$(
+    mise_bin_paths | while IFS= read -r leftover_bin_dir; do
+      [ -n "$leftover_bin_dir" ] || continue
+      normalize_path "$leftover_bin_dir"
+    done
+  )"
+
+  leftover_count=0
+  for leftover_payload in "$leftover_installs"/*; do
+    [ -d "$leftover_payload" ] || continue
+    leftover_payload="$(normalize_path "$leftover_payload")"
+
+    leftover_reachable=0
+    while IFS= read -r leftover_bin_dir; do
+      [ -n "$leftover_bin_dir" ] || continue
+      case "$leftover_bin_dir" in
+        "$leftover_payload"|"$leftover_payload"/*)
+          leftover_reachable=1
+          break
+          ;;
+      esac
+    done <<EOF
+$leftover_bin_paths
+EOF
+
+    [ "$leftover_reachable" -eq 1 ] || leftover_count=$((leftover_count + 1))
+  done
+
+  printf '%s\n' "$leftover_count"
+}
+
+# A separate finding from executable selection, so it prints after that block
+# and carries its own second line instead of sharing the block's guidance
+# sentence. It never sets the issue flag: disk a user chose to keep is not a
+# readiness problem, and Terrapod neither runs 'mise uninstall' nor decides
+# which payloads to remove. The provider is named because the payloads sit in
+# mise's own data directory, which is the case ADR 0020 exempts from ADR 0012's
+# ban on suggesting an uninstall command.
+render_leftover_payloads() {
+  leftover_found="$(leftover_payload_count)"
+  [ -n "$leftover_found" ] || return 0
+  [ "$leftover_found" -gt 0 ] || return 0
+
+  if [ "$leftover_found" -eq 1 ]; then
+    printf '%s\n' "  advisory - 1 mise payload is outside any canonical declaration"
+  else
+    printf '  advisory - %s mise payloads are outside any canonical declaration\n' "$leftover_found"
+  fi
+  printf '%s\n' "             'mise uninstall' reclaims the disk; Terrapod does not remove them."
+}
+
 initialize_mise_bin_paths
 initialize_managed_path
 
@@ -564,6 +633,12 @@ $records
 EOF
 
 render_advisories
+
+# apply and doctor report the finding. status only summarizes readiness, which
+# this advisory deliberately does not affect, so it has nothing to add there.
+case "$mode" in
+  apply|doctor) render_leftover_payloads ;;
+esac
 
 case "$mode" in
   apply)

--- a/tests/executable_selection_test.sh
+++ b/tests/executable_selection_test.sh
@@ -695,3 +695,96 @@ assert_contains "$absent_status_output" "Warning: executable selection helper is
 [ "$absent_status_status" -eq 0 ] ||
   fail "tpod status stays informational when the executable selection helper is missing"
 pass "tpod status stays informational when the executable selection helper is missing"
+
+# Leftover mise payloads: installs the migration to Homebrew left behind, which
+# no declaration can reach and which no other finding reports since the shims
+# they generate stopped being read as selection defects.
+leftover_data_dir="$tmp_dir/mise-data"
+leftover_installs="$leftover_data_dir/installs"
+
+run_leftover_selection() {
+  leftover_mode="$1"
+  leftover_path="${2:-$path_dir}"
+  HOME="$tmp_dir/home" \
+    MISE_DATA_DIR="$leftover_data_dir" \
+    TERRAPOD_EXECUTABLE_SELECTION_INVENTORY_DIR="$inventory" \
+    TERRAPOD_STANDARD_HOMEBREW_PREFIX="$prefix" \
+    TERRAPOD_MISE_SHIMS_DIR="$mise_shims" \
+    TERRAPOD_MANAGED_PATH="$leftover_path:/usr/bin:/bin" \
+    PATH="$leftover_path:/usr/bin:/bin" \
+    "$selection" "$leftover_mode" macos-terminal false false 2>&1 || true
+}
+
+absent_installs_output="$(run_leftover_selection doctor)"
+assert_not_contains "$absent_installs_output" "mise payload" \
+  "an absent mise installs directory says nothing about leftover payloads"
+assert_contains "$absent_installs_output" "Canonical executable selection: ready" \
+  "an absent mise installs directory leaves the selection verdict alone"
+
+mkdir -p "$leftover_installs/aqua-sharkdp-bat" \
+  "$leftover_installs/aqua-junegunn-fzf" \
+  "$leftover_installs/aqua-lsd-rs-lsd"
+leftover_output="$(run_leftover_selection doctor)"
+assert_line "$leftover_output" \
+  "  advisory - 3 mise payloads are outside any canonical declaration" \
+  "payloads no declaration reaches are reported as one counted advisory"
+assert_line "$leftover_output" \
+  "             'mise uninstall' reclaims the disk; Terrapod does not remove them." \
+  "the leftover advisory carries its own guidance line"
+assert_not_contains "$leftover_output" \
+  "Adjust PATH or remove the other installation manually" \
+  "the leftover advisory does not borrow the selection block's guidance sentence"
+assert_contains "$leftover_output" "Canonical executable selection: ready" \
+  "leftover payloads are a separate finding from executable selection"
+
+# Decision guard: disk a user chose to keep is not a readiness problem. Without
+# this assertion nothing stops a later change from setting the issue flag here.
+leftover_status_output="$(run_leftover_selection status)"
+assert_contains "$leftover_status_output" "Executable selection: ready" \
+  "tpod status stays ready on a machine whose only finding is leftover payloads"
+assert_not_contains "$leftover_status_output" "mise payload" \
+  "status leaves the leftover payload advisory to apply and doctor"
+
+leftover_apply_output="$(run_leftover_selection apply)"
+assert_line "$leftover_apply_output" \
+  "  advisory - 3 mise payloads are outside any canonical declaration" \
+  "apply reports leftover payloads"
+
+mkdir -p "$leftover_installs/node/20.0.0/bin"
+printf '%s\n' "$leftover_installs/node/20.0.0/bin" >"$mise_bin_paths_file"
+declared_payload_output="$(run_leftover_selection doctor)"
+assert_line "$declared_payload_output" \
+  "  advisory - 3 mise payloads are outside any canonical declaration" \
+  "a payload holding a reported mise bin directory is not a leftover"
+assert_not_contains "$declared_payload_output" "4 mise payloads" \
+  "the declared payload is excluded from the count rather than added to it"
+
+# One payload name can be a string prefix of another. A comparison that ignores
+# the path boundary lets either name hide the other, in both directions.
+mkdir -p "$leftover_installs/node-canary"
+sibling_payload_output="$(run_leftover_selection doctor)"
+assert_line "$sibling_payload_output" \
+  "  advisory - 4 mise payloads are outside any canonical declaration" \
+  "a payload whose name extends a declared payload's name is still a leftover"
+
+rm -rf "$leftover_installs"
+mkdir -p "$leftover_installs/node" "$leftover_installs/node-canary/2026.1.1/bin"
+printf '%s\n' "$leftover_installs/node-canary/2026.1.1/bin" >"$mise_bin_paths_file"
+sibling_declared_output="$(run_leftover_selection doctor)"
+assert_line "$sibling_declared_output" \
+  "  advisory - 1 mise payload is outside any canonical declaration" \
+  "a declared payload does not cover the sibling whose name it extends"
+
+# The whole check depends on mise to say which directories are declared, so an
+# absent mise skips it rather than calling every payload a leftover.
+mise_absent_path_dir="$tmp_dir/mise-absent-path"
+mkdir -p "$mise_absent_path_dir"
+for path_entry in "$path_dir"/*; do
+  case "${path_entry##*/}" in
+    mise) continue ;;
+  esac
+  ln -s "$path_entry" "$mise_absent_path_dir/${path_entry##*/}"
+done
+mise_absent_output="$(run_leftover_selection doctor "$mise_absent_path_dir")"
+assert_not_contains "$mise_absent_output" "mise payload" \
+  "an absent mise skips the leftover payload check instead of reporting one"


### PR DESCRIPTION
Closes #238

## Problem

ADR 0010 moved the Core Shell Stack from mise/aqua to Homebrew and ADR
0012 kept apply non-destructive, so every install made before that
migration stays on disk indefinitely. A migrated macOS workstation still
carries fifteen aqua installs: no config selects them, `mise which bat`
says the tool is not currently active, and mise keeps generating a shim
for each one.

Those shims used to surface as fifteen false selection advisories. #233
correctly silenced them, and the disk they hold lost the only thing that
reported it. This restores that information as a finding of its own
rather than as a side effect of a wrong verdict.

## Change

`leftover_payload_count` walks the top-level directories under
`${MISE_DATA_DIR:-$HOME/.local/share/mise}/installs` and counts the ones
no `mise bin-paths` entry lies beneath. `render_leftover_payloads`
prints the count as one advisory, after the selection advisory block:

```
  advisory - 15 mise payloads are outside any canonical declaration
             'mise uninstall' reclaims the disk; Terrapod does not remove them.
```

The comparison respects the path boundary instead of testing string
prefixes. `installs/node` and `installs/node-canary` are separate
payloads although one name extends the other, and a prefix test lets
either hide the other depending on which one is declared.

This is a separate finding from executable selection, so it carries its
own second line rather than sharing the selection block's trailing
guidance sentence, and it does not set `issue_found`: disk a user chose
to keep is not a readiness problem, and `tpod status` stays `ready` on a
machine whose only finding is leftover payloads. `apply` and `doctor`
print it; `status` summarizes readiness and has nothing to add.

Nothing about resolution or the shape of `render_advisories` changes.

ADR 0012 forbids suggesting a provider-specific uninstall command. ADR
0020 narrowed that rule to inferred providers, and these payloads sit
inside mise's own data directory, so mise is the provider by location
rather than by guess. Terrapod still never runs `mise uninstall` and
never chooses which payloads to remove.

The whole check is skipped when mise is absent or the installs directory
does not exist. It is never a failure.

A count of one prints `1 mise payload is outside any canonical
declaration`, since a machine down to its last leftover is reachable and
the plural form reads as a defect there.

## Tests

`tests/executable_selection_test.sh` gains a section built on #234's
fake mise harness. It asserts the counted advisory and its guidance
line, that the line does not borrow the selection block's guidance
sentence, that a payload holding a reported bin directory is excluded
from the count, both directions of the prefix trap (`installs/node`
declared with `installs/node-canary` left over, and the reverse), that
an absent installs directory and an absent mise both say nothing, and
that `apply` prints the advisory while `status` does not.

`tpod status` staying `ready` is asserted explicitly. It is the
regression guard for the decision not to set the issue flag, which
nothing else in the file would catch.

`PATH="$(mise where python)/bin:$PATH" tests/run` — 28 test files
passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1vLGxSRHovE2WGeb21AtC
